### PR TITLE
CAD-508: analysis updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
 bin/
 .stack-work/
+dist-newstyle/
+dist/
 stack.yaml.lock
 
+.ghc.environment.*
+
+*~
+\#*
+\.#*
+*.swp
+.dir-locals.el
+
+tags
+
+latest-genesis

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+MODE ?= stack
+
+all: help
+
+###
+###
+###
+help:
+	@echo
+	@echo "Available targets:"
+	@echo
+	@echo "  build build-* run run-* clean clean-*"
+	@echo
+	@echo "Build targets:"
+	@echo
+	@echo "  build-stack"
+	@echo
+	@echo "Run targets:"
+	@echo
+	@echo "  run-cluster3nodes"
+	@echo
+	@echo "Clean targets:"
+	@echo
+	@echo "  clean-all"
+	@echo "  clean-stack"
+	@echo "  clean-runtime"
+	@echo
+
+###
+###
+###
+build: build-${MODE}
+
+build-stack:
+	stack --nix build --copy-bins
+
+###
+###
+###
+run: run-cluster3nodes
+
+run-cluster3nodes:
+	cd benchmarks/cluster3nodes && ./start.sh
+
+###
+###
+###
+clean: clean-all
+
+clean-all: clean-stack clean-runtime
+
+clean-stack:
+	stack clean
+
+clean-runtime:
+	rm -rf db db-* logs

--- a/scripts/README.txt
+++ b/scripts/README.txt
@@ -1,0 +1,13 @@
+
+the 'analyse.sh' script is to be run in the extracted directory from a benchmark run.
+
+it will:
+
+1.) extract transaction ids with timestamp from the generator log
+2.) extract timestamps and tx ids from blocks received on cardano-node on the explorer node
+
+this gives us the "time-to-block" distribution over all transactions.
+
+
+other scripts are included to extract specific information from log files like CPU usage, block forge times, etc.
+

--- a/scripts/analyse.sh
+++ b/scripts/analyse.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -ex
+
+BP=$(dirname $0)
+
+# extract txs from generator
+${BP}/xtx.sh generator/tx-gen-*.json > txs
+sort -k 1 -t ';' txs > txs1
+
+# extract txs in blocks received
+rm -f bks
+for L in node-on-explorer/node-*.json; do
+  ${BP}/xbk.sh $L >> bks
+done
+
+sort -k 2 -t ';' bks > bks1
+
+# number blocks
+BC=1
+{ for B in `cat bks | cut -d ';' -f 2 | sort | uniq`; do
+    echo "$B;$BC"
+    BC=$((BC+1))
+  done
+} > bknum
+
+# join on txid; adds block number
+join -1 2 -2 1 -t ";" bks1 bknum > bks2
+sort -k 2 -t ';' bks2 > bks3
+
+# join on txid; adds block time
+join -1 1 -2 2 -t ";" txs1 bks3 > timetoblock1.lst
+sort -k 2 -t ';' timetoblock1.lst > timetoblock.lst
+
+# clean timestamps
+sed -e 's/\([.0-9]\+\)Z/\1/g;s/\([0-9]\+\)T\([0-9]\+:\)/\1 \2/g;' timetoblock.lst > timetoblock.csv
+

--- a/scripts/xbk.sh
+++ b/scripts/xbk.sh
@@ -1,24 +1,20 @@
 #!/bin/sh
 
-# [2019-12-03 16:15:58.59 UTC]
+# Given a JSON log from a node with configuration, where:
+#
+#   minSeverity: Debug
+#   TracingVerbosity: MaximalVerbosity
+#   TraceBlockFetchClient: True
+#
+# ..extract the list of incoming transactions,
+# as soon as we see them coming in a via BlockFetch protocol.
 
-#sed -ne '/ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock/{s/ \[[0-9]\+-[0-9]\+-[0-9]\+ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9] UTC\]/\n&/;s/Tx [^ ]\+ with inputs /\n&/g;p;}' $1  | sed -ne '
-#  s/^ \[\([0-9]\+-[0-9]\+-[0-9]\+\) \([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9]\) UTC\].*$/\1T\2Z/
-# jq --slurp 'map (select (.data.event.kind == "TraceCopyToImmDBEvent.CopiedBlockToImmDB")) | .[0] | "\(.at);\(.data.tip | sub (".*@(?<slot>.*)$"; "\(.slot)"))"' $LOGFILE_JSON | xargs echo | sed 's/\([0-9]\)T\([0-9]\)/\1 \2/; s/\(20[0-9][0-9]\)/"\1/; s/Z/"/'
-
-sed -ne '/ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock/{s/"at":"/\n&/;s/Tx [^ ]\+ with inputs /\n&/g;p;}' $1  | sed -ne ' 
-  s/^"at":"\([^"]\+\).*$/\1/
-  t keep 
-  b cont 
-  : keep 
-  h; n
-  : cont 
-  s/^Tx \([a-f0-9]\+\) with inputs.*$/\1/
-  t good 
-  d
-  :good
-  G
-  s/\n/;/g
-  p
-  '
-
+jq '
+  select (.data.msg.kind == "MsgBlock")
+| .at as $at        # bind timestamp
+| .data.msg.txids   # narrow to the txid list
+| map ( .[11:]         # cut the "txid: txid: " prefix
+      | "\(.);\($at)") # produce the resulting string
+| .[]               # merge string lists over all messages
+' $1 |
+tr -d '"'

--- a/scripts/xbk.sh
+++ b/scripts/xbk.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# [2019-12-03 16:15:58.59 UTC]
+
+#sed -ne '/ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock/{s/ \[[0-9]\+-[0-9]\+-[0-9]\+ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9] UTC\]/\n&/;s/Tx [^ ]\+ with inputs /\n&/g;p;}' $1  | sed -ne '
+#  s/^ \[\([0-9]\+-[0-9]\+-[0-9]\+\) \([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9]\) UTC\].*$/\1T\2Z/
+# jq --slurp 'map (select (.data.event.kind == "TraceCopyToImmDBEvent.CopiedBlockToImmDB")) | .[0] | "\(.at);\(.data.tip | sub (".*@(?<slot>.*)$"; "\(.slot)"))"' $LOGFILE_JSON | xargs echo | sed 's/\([0-9]\)T\([0-9]\)/\1 \2/; s/\(20[0-9][0-9]\)/"\1/; s/Z/"/'
+
+sed -ne '/ChainSyncServerEvent.TraceChainSyncServerReadBlocked.AddBlock/{s/"at":"/\n&/;s/Tx [^ ]\+ with inputs /\n&/g;p;}' $1  | sed -ne ' 
+  s/^"at":"\([^"]\+\).*$/\1/
+  t keep 
+  b cont 
+  : keep 
+  h; n
+  : cont 
+  s/^Tx \([a-f0-9]\+\) with inputs.*$/\1/
+  t good 
+  d
+  :good
+  G
+  s/\n/;/g
+  p
+  '
+

--- a/scripts/xtx.sh
+++ b/scripts/xtx.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+sed -ne '/"cardano","cli","generate-txs","submit"],.*,"msg":"Send ConnectionId/{s/"at":"/\n&/;s/tx:/\n&/g;p;}' $*  | sed -ne ' 
+  s/^"at":"\([^"]\+\).*$/\1/
+  t keep 
+  b cont 
+  : keep 
+  h; n
+  : cont 
+  s/^tx: Tx \([a-f0-9]\+\).*$/\1/
+  t good 
+  d
+  :good
+  G
+  s/\n/;/g
+  p
+  '
+

--- a/scripts/xtx.sh
+++ b/scripts/xtx.sh
@@ -7,7 +7,7 @@ sed -ne '/"cardano","cli","generate-txs","submit"],.*,"msg":"Send ConnectionId/{
   : keep 
   h; n
   : cont 
-  s/^tx: Tx \([a-f0-9]\+\).*$/\1/
+  s/^tx: Tx \([a-f0-9]\{8\}\)[a-f0-9]*.*$/\1/
   t good 
   d
   :good


### PR DESCRIPTION
1. Import legacy Tx throughput analysis scripts
1. update `xbk.sh` to use the new `BlockFetch` trace -- both in content and format/structure
1. some basic amenities:  `Makefile` and some git ignores
1. update `xtx.sh` to structured logging & use shorter `GenTxIds`

Tested on a slightly-tweaked `cluster3nodes`.

# TODO

- [ ] depends on https://github.com/input-output-hk/cardano-node/pull/668
- [ ] Test in real deployment.