### PR TITLE
CAD-671: TPS as a float number.

### DIFF
--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
@@ -136,7 +136,7 @@ parseFeePerTx :: String -> String -> Parser FeePerTx
 parseFeePerTx opt desc = FeePerTx <$> parseIntegral opt desc
 
 parseTPSRate :: String -> String -> Parser TPSRate
-parseTPSRate opt desc = TPSRate <$> parseIntegral opt desc
+parseTPSRate opt desc = TPSRate <$> parseFloat opt desc
 
 parseTxAdditionalSize :: String -> String -> Parser TxAdditionalSize
 parseTxAdditionalSize opt desc = TxAdditionalSize <$> parseIntegral opt desc
@@ -155,6 +155,10 @@ parseSigningKeysFiles opt desc = some $ SigningKeyFile <$> parseFilePath opt des
 parseIntegral :: Integral a => String -> String -> Parser a
 parseIntegral optname desc = option (fromInteger <$> auto)
   $ long optname <> metavar "INT" <> help desc
+
+parseFloat :: String -> String -> Parser Float
+parseFloat optname desc = option (auto)
+  $ long optname <> metavar "FLOAT" <> help desc
 
 parseUrl :: String -> String -> Parser String
 parseUrl optname desc =

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -11,6 +11,8 @@ data TxGenError =
   -- ^ Error occurred while creating the target node address.
   | NeedMinimumThreeSigningKeyFiles ![FilePath]
   -- ^ Need at least 3 signing key files.
+  | TooSmallTPSRate !Float
+  -- ^ TPS is less than lower limit.
   | SecretKeyDeserialiseError !Text
   | SecretKeyReadError !Text
   deriving Show


### PR DESCRIPTION
Now `--tps` can be defined as a float number.

There's a lower limit for it: 1/20 (minimum one tx per block).