### PR TITLE
CAD-665: Peers info.

### DIFF
--- a/cardano-rt-view/cardano-rt-view.cabal
+++ b/cardano-rt-view/cardano-rt-view.cabal
@@ -48,6 +48,7 @@ library
                      , text
                      , time
                      , threepenny-gui
+                     , unordered-containers
 
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -37,6 +37,7 @@ data ElementName
   | ElChainDensity
   | ElTxsProcessed
   | ElPeersNumber
+  | ElPeersList
   | ElTraceAcceptorHost
   | ElTraceAcceptorPort
   | ElMempoolTxsNumber

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -166,20 +166,29 @@ mkNodeWidget = do
              ]
          ]
 
+  -- List of items corresponding to each peer, it will be changed dynamically!
+  elPeersList <- UI.div #. "" #+ []
+
   peersTabContent
     <- UI.div #. "tab-container" # hideIt #+
          [ UI.div #. "w3-row" #+
-             [ UI.div #. "w3-half w3-theme" #+
-                 [ UI.div #. "" #+
-                     [ UI.div #. "" #+ [string "Peers number:"]
+             [ UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "node-info-values" #+
+                     [ UI.div #. "" #+ [string "Endpoint"]
                      ]
                  ]
-             , UI.div #. "w3-half w3-theme" #+
+             , UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "node-info-values" #+
-                     [ UI.div #. "" #+ [element elPeersNumber]
+                     [ UI.div #. "" #+ [string "Slot No."]
+                     ]
+                 ]
+             , UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "node-info-values" #+
+                     [ UI.div #. "" #+ [string "Block No."]
                      ]
                  ]
              ]
+         , element elPeersList
          ]
 
   blockchainTabContent
@@ -430,6 +439,7 @@ mkNodeWidget = do
           , (ElChainDensity,            elChainDensity)
           , (ElTxsProcessed,            elTxsProcessed)
           , (ElPeersNumber,             elPeersNumber)
+          , (ElPeersList,               elPeersList)
           , (ElTraceAcceptorHost,       elTraceAcceptorHost)
           , (ElTraceAcceptorPort,       elTraceAcceptorPort)
           , (ElMempoolTxsNumber,        elMempoolTxsNumber)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -6,6 +6,7 @@ module Cardano.Benchmarking.RTView.NodeState.Types
     , NodeState (..)
     , NodeInfo (..)
     , NodeMetrics (..)
+    , PeerInfo (..)
     , defaultNodesState
     ) where
 
@@ -31,7 +32,13 @@ type NodesState = Map Text NodeState
 data NodeState = NodeState
   { nsInfo    :: !NodeInfo
   , nsMetrics :: !NodeMetrics
-  }
+  } deriving Show
+
+data PeerInfo = PeerInfo
+  { piEndpoint    :: !String
+  , piSlotNumber  :: !String
+  , piBlockNumber :: !String
+  } deriving (Eq, Show)
 
 data NodeInfo = NodeInfo
   { niNodeRelease       :: !String
@@ -45,9 +52,10 @@ data NodeInfo = NodeInfo
   , niChainDensity      :: !Double
   , niTxsProcessed      :: !Integer
   , niPeersNumber       :: !Integer
+  , niPeersInfo         :: ![PeerInfo]
   , niTraceAcceptorHost :: !String
   , niTraceAcceptorPort :: !String
-  }
+  } deriving Show
 
 data NodeMetrics = NodeMetrics
   { nmMempoolTxsNumber        :: !Word64
@@ -94,7 +102,7 @@ data NodeMetrics = NodeMetrics
   , nmRTSGcElapsed            :: !Double
   , nmRTSGcNum                :: !Integer
   , nmRTSGcMajorNum           :: !Integer
-  }
+  } deriving Show
 
 defaultNodesState
   :: Configuration
@@ -132,6 +140,7 @@ defaultNodeInfo now = NodeInfo
   , niChainDensity      = 0.0
   , niTxsProcessed      = 0
   , niPeersNumber       = 0
+  , niPeersInfo         = []
   , niTraceAcceptorHost = "-"
   , niTraceAcceptorPort = "-"
   }


### PR DESCRIPTION
Add the list of peers in "Peers" tab.

Please note that currently, this tab shows only list of addresses with ports. Values of `Slot No.` and `Block No.` don't update properly.