### PR TITLE
CAD-901: Peers list.

### DIFF
--- a/cardano-rt-view/cardano-rt-view.cabal
+++ b/cardano-rt-view/cardano-rt-view.cabal
@@ -25,6 +25,7 @@ library
                        Cardano.Benchmarking.RTView.GUI.NodeWidget
                        Cardano.Benchmarking.RTView.GUI.Updater
 
+                       Cardano.Benchmarking.RTView.NodeState.Parsers
                        Cardano.Benchmarking.RTView.NodeState.Types
                        Cardano.Benchmarking.RTView.NodeState.Updater
 
@@ -48,7 +49,6 @@ library
                      , text
                      , time
                      , threepenny-gui
-                     , unordered-containers
 
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Parsers.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Parsers.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Benchmarking.RTView.NodeState.Parsers
+    ( extractPeersInfo
+    , updateCurrentPeersInfo
+    ) where
+
+import           Cardano.Prelude
+
+import qualified Data.Aeson as A
+import           Data.Aeson
+                   ( Object
+                   , (.:)
+                   )
+import           Data.List
+                   ( last )
+import qualified Data.Text as T
+
+import           Cardano.Benchmarking.RTView.NodeState.Types
+                   ( PeerInfo (..) )
+
+extractPeersInfo :: Object -> [PeerInfo]
+extractPeersInfo peersObj =
+  case result of
+    A.Success connectedPeers ->
+      let addrs = map (extractRemoteAddr . peer) $ peers connectedPeers
+      in [PeerInfo (T.unpack addr) "" "" | addr <- addrs]
+    A.Error _ -> []
+ where
+  result :: A.Result ConnectedPeers
+  result = A.fromJSON $ A.Object peersObj
+
+  -- We know that 'peer' contains 'Show'-result of 'ConnectionId'.
+  extractRemoteAddr :: Text -> Text
+  extractRemoteAddr = T.init . last . T.words
+
+-- | Check if such peer already connected, and if so - take its slotNum and blockNum.
+updateCurrentPeersInfo :: [PeerInfo] -> [PeerInfo] -> [PeerInfo]
+updateCurrentPeersInfo currentPeersInfo [] = currentPeersInfo
+updateCurrentPeersInfo currentPeersInfo newPeersInfo =
+  flip map newPeersInfo $ \newPI@(PeerInfo connId _ _) ->
+    let existingPI = find (\(PeerInfo cId _ _) -> cId == connId) currentPeersInfo
+    in case existingPI of
+         Nothing -> newPI
+         Just pI -> PeerInfo connId (piSlotNumber pI) (piBlockNumber pI)
+
+-- Types for decoding from JSON-representation. The only information we need here is ConnectionId.
+
+data ConnectedPeers = ConnectedPeers
+  { peers :: ![ConnectedPeer]
+  }
+
+data ConnectedPeer = ConnectedPeer
+  { peer :: !Text
+  }
+
+instance A.FromJSON ConnectedPeers where
+  parseJSON = A.withObject "ConnectedPeers" $ \v -> ConnectedPeers
+    <$> v .: "peers"
+
+instance A.FromJSON ConnectedPeer where
+  parseJSON = A.withObject "ConnectedPeer" $ \v -> ConnectedPeer
+    <$> v .: "peer"


### PR DESCRIPTION
There were two problems:

1. The list of connected peers took a lot of time to be updated because RTService took wrong metrics as a source of corresponding information.
2. If the real number of peers decreased - the list of connected peers on "Peers" tab wasn't updated.

Currently, these problems are solved:

1. The list of connected peers is taken from `"cardano.node.BlockFetchDecision.peersList"` metric, it's the same list TUI uses to show the number of connected peers.
2. If the real number of peers decreased - the list of connected peers on "Peers" tab will be updated as well.

Please note that **this PR** only works with peers' endpoints (addresses with ports), it doesn't touch `slotNo` and `blockNo` (because this information should be taken from other metrics). Another change that should be done is a small change in `cardano-node` (exactly - in `cardano-node/src/Cardano/Tracing/Tracers.hs`): https://github.com/input-output-hk/cardano-node/pull/875