### PR TITLE
CAD-918: switch to cabal.project-based pinning for the node and db-sync

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,13 +3,54 @@ index-state: 2020-04-01T00:00:00Z
 packages:
     cardano-rt-view
     cardano-tx-generator
-    ext/cardano-node.git/cardano-api
-    ext/cardano-node.git/cardano-cli
-    ext/cardano-node.git/cardano-node
-    ext/cardano-node.git/cardano-config
+    --ext/cardano-node.git/cardano-api
+    --ext/cardano-node.git/cardano-cli
+    --ext/cardano-node.git/cardano-node
+    --ext/cardano-node.git/cardano-config
     --ext/cardano-db-sync.git/cardano-db
     --ext/cardano-db-sync.git/cardano-db-sync
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22
+  --sha256: 0zg6f8dbgn3kaki7r1lbmb1hsqkiw1h0j443d338lrv2zk2ggicg
+  subdir: cardano-api
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22
+  --sha256: 0zg6f8dbgn3kaki7r1lbmb1hsqkiw1h0j443d338lrv2zk2ggicg
+  subdir: cardano-cli
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22
+  --sha256: 0zg6f8dbgn3kaki7r1lbmb1hsqkiw1h0j443d338lrv2zk2ggicg
+  subdir: cardano-config
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22
+  --sha256: 0zg6f8dbgn3kaki7r1lbmb1hsqkiw1h0j443d338lrv2zk2ggicg
+  subdir: cardano-node
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-db-sync
+  tag: 8842aa6c14e258942419a1853b0d98f1415bfafc
+  --sha256: 05xpck7a0a2vkannyipqwpxqi3n62h6ipl3z056z74hl3xgfiq92
+  subdir: cardano-db
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-db-sync
+  tag: 8842aa6c14e258942419a1853b0d98f1415bfafc
+  --sha256: 05xpck7a0a2vkannyipqwpxqi3n62h6ipl3z056z74hl3xgfiq92
+  subdir: cardano-db-sync
 
 source-repository-package
   type: git

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "c3fe0c1647aada96ef6af983610a876335658206",
-        "sha256": "1nmva81x6rjl6bjpwjjyjvrvmv1xzibrjk3lkm77wzfz09bl2rnf",
+        "rev": "ca80aeb33e8ca854dca77c1098a90136b9dabf2e",
+        "sha256": "0sp9v7l68xq1kg4862pcpjji918lgb6jlak4p6lpv2k4h93dypv2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/c3fe0c1647aada96ef6af983610a876335658206.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/ca80aeb33e8ca854dca77c1098a90136b9dabf2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
- switch to cabal.project-based pinning for the node and db-sync
- bump iohk-nix