### PR TITLE
CAD-806: Liveness monitoring.

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
@@ -46,9 +46,9 @@ import           Cardano.Benchmarking.RTView.Server
 
 -- | Run the service.
 runCardanoRTView :: RTViewParams -> IO ()
-runCardanoRTView (RTViewParams pathToConfig pathToStatic port) = do
-  config <- readConfig pathToConfig
-  acceptors <- checkIfTraceAcceptorIsDefined config pathToConfig
+runCardanoRTView params = do
+  config <- readConfig (rtvConfig params)
+  acceptors <- checkIfTraceAcceptorIsDefined config (rtvConfig params)
   makeSureTraceAcceptorsAreUnique acceptors
 
   (tr :: Trace IO Text, switchBoard) <- Setup.setupTrace_ config "cardano-rt-view"
@@ -66,7 +66,7 @@ runCardanoRTView (RTViewParams pathToConfig pathToStatic port) = do
   --   3. server (it serves requests from user's browser and shows nodes' metrics in the real time).
   acceptorThr <- async $ launchMetricsAcceptor config accTr switchBoard
   updaterThr  <- async $ launchNodeStateUpdater tr switchBoard nodesStateMVar
-  serverThr   <- async $ launchServer nodesStateMVar pathToStatic port acceptors
+  serverThr   <- async $ launchServer nodesStateMVar params acceptors
 
   void $ waitAnyCancel [acceptorThr, updaterThr, serverThr]
 

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
@@ -6,20 +6,28 @@ module Cardano.Benchmarking.RTView.CLI
 import           Cardano.Prelude hiding ( option )
 import           Prelude
                    ( String )
+import           Data.Time.Clock
+                   ( NominalDiffTime )
 import           Options.Applicative
                    ( Parser
                    , auto, bashCompleter, completer, help
                    , long, metavar, option, strOption
+                   , showDefault, value
                    )
 import           Network.Socket
                    ( PortNumber )
 
 -- | Type for CLI parameters required for the service.
-data RTViewParams =
-  RTViewParams
-    FilePath
-    FilePath
-    PortNumber
+data RTViewParams = RTViewParams
+  { rtvConfig             :: !FilePath
+  , rtvStatic             :: !FilePath
+  , rtvPort               :: !PortNumber
+  , rtvNodeInfoLife       :: !NominalDiffTime
+  , rtvPeersInfoLife      :: !NominalDiffTime
+  , rtvBlockchainInfoLife :: !NominalDiffTime
+  , rtvResourcesInfoLife  :: !NominalDiffTime
+  , rtvRTSInfoLife        :: !NominalDiffTime
+  }
 
 parseRTViewParams :: Parser RTViewParams
 parseRTViewParams =
@@ -35,6 +43,26 @@ parseRTViewParams =
     <*> parsePort
           "port"
           "The port number"
+    <*> parseDiffTime
+          "node-info-life"
+          "Lifetime of node info"
+          5
+    <*> parseDiffTime
+          "peers-info-life"
+          "Lifetime of peers info"
+          20
+    <*> parseDiffTime
+          "blockchain-info-life"
+          "Lifetime of blockchain info"
+          35
+    <*> parseDiffTime
+          "resources-info-life"
+          "Lifetime of resources info"
+          8
+    <*> parseDiffTime
+          "rts-info-life"
+          "Lifetime of GHC RTS info"
+          45
 
 -- Aux parsers
 
@@ -61,3 +89,16 @@ parsePort optname desc =
        <> help desc
     )
 
+parseDiffTime
+  :: String
+  -> String
+  -> NominalDiffTime
+  -> Parser NominalDiffTime
+parseDiffTime optname desc defaultTime =
+    option ((fromIntegral :: Int -> NominalDiffTime) <$> auto) (
+          long optname
+       <> metavar "DIFFTIME"
+       <> help desc
+       <> value defaultTime
+       <> showDefault
+    )

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -72,6 +72,18 @@ data ElementName
   | ElRTSGcElapsed
   | ElRTSGcNum
   | ElRTSGcMajorNum
+  -- Outdated warnings.
+  | ElNodeReleaseOutdateWarning
+  | ElNodeVersionOutdateWarning
+  | ElNodeCommitHrefOutdateWarning
+  | ElUptimeOutdateWarning
+  | ElSlotOutdateWarning
+  | ElBlocksNumberOutdateWarning
+  | ElChainDensityOutdateWarning
+  | ElRTSGcCpuOutdateWarning
+  | ElRTSGcElapsedOutdateWarning
+  | ElRTSGcNumOutdateWarning
+  | ElRTSGcMajorNumOutdateWarning
   -- Progress bars.
   | ElMempoolBytesProgress
   | ElMempoolTxsProgress

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -127,11 +127,25 @@ mkNodeWidget = do
                                 # set UI.title__ "Browse cardano-node repository on this commit"
                                 #+ [string ""]
 
+  elNodeReleaseOutdateWarning    <- infoMark "The value is outdated"
+  elNodeVersionOutdateWarning    <- infoMark "The value is outdated"
+  elNodeCommitHrefOutdateWarning <- infoMark "The value is outdated"
+  elUptimeOutdateWarning         <- infoMark "The value is outdated"
+  
+  elSlotOutdateWarning           <- infoMark "The value is outdated"
+  elBlocksNumberOutdateWarning   <- infoMark "The value is outdated"
+  elChainDensityOutdateWarning   <- infoMark "The value is outdated"
+
+  elRTSGcCpuOutdateWarning       <- infoMark "The value is outdated"
+  elRTSGcElapsedOutdateWarning   <- infoMark "The value is outdated"
+  elRTSGcNumOutdateWarning       <- infoMark "The value is outdated"
+  elRTSGcMajorNumOutdateWarning  <- infoMark "The value is outdated"
+
   -- Create content area for each tab.
   nodeTabContent
     <- UI.div #. "tab-container" # showIt #+
          [ UI.div #. "w3-row" #+
-             [ UI.div #. "w3-half w3-theme" #+
+             [ UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "" #+
                      [ UI.div #. "" #+ [string "Node release:"]
                      , UI.div #. "" #+ [string "Node version:"]
@@ -143,7 +157,7 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [string "Node uptime:"]
                      ]
                  ]
-             , UI.div #. "w3-half w3-theme" #+
+             , UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "node-info-values" #+
                      [ UI.span #. "release-name" #+ [element elNodeRelease]
                      , UI.div #. "" #+ [element elNodeVersion]
@@ -153,6 +167,18 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [element elTraceAcceptorPort]
                      , vSpacer "node-info-v-spacer"
                      , UI.div #. "" #+ [element elUptime]
+                     ]
+                 ]
+             , UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "" #+
+                     [ UI.span #. "" #+ [element elNodeReleaseOutdateWarning]
+                     , UI.div #. "" #+ [element elNodeVersionOutdateWarning]
+                     , UI.div #. "" #+ [element elNodeCommitHrefOutdateWarning]
+                     , vSpacer "node-info-v-spacer"
+                     , UI.div #. "" #+ [UI.span # set UI.html "&nbsp;" #+ []]
+                     , UI.div #. "" #+ [UI.span # set UI.html "&nbsp;" #+ []]
+                     , vSpacer "node-info-v-spacer"
+                     , UI.div #. "" #+ [element elUptimeOutdateWarning]
                      ]
                  ]
              ]
@@ -186,14 +212,14 @@ mkNodeWidget = do
   blockchainTabContent
     <- UI.div #. "tab-container" # hideIt #+
          [ UI.div #. "w3-row" #+
-             [ UI.div #. "w3-half w3-theme" #+
+             [ UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "" #+
                      [ UI.div #. "" #+ [string "Epoch / Slot in epoch:"]
                      , UI.div #. "" #+ [string "Blocks number:"]
                      , UI.div #. "" #+ [string "Chain density:"]
                      ]
                  ]
-             , UI.div #. "w3-half w3-theme" #+
+             , UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "node-info-values" #+
                      [ UI.div #. "" #+
                          [ element elEpoch
@@ -205,6 +231,13 @@ mkNodeWidget = do
                          [ element elChainDensity
                          , UI.span #. "density-percent" #+ [string "%"]
                          ]
+                     ]
+                 ]
+             , UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "" #+
+                     [ UI.div #. "" #+ [element elSlotOutdateWarning]
+                     , UI.div #. "" #+ [element elBlocksNumberOutdateWarning]
+                     , UI.div #. "" #+ [element elChainDensityOutdateWarning]
                      ]
                  ]
              ]
@@ -220,11 +253,7 @@ mkNodeWidget = do
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (Bytes)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elMempoolCapacityBytes
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark" #+ [string "🛈"]
-                                   , UI.span #. "w3-text w3-tag w3-indigo w3-small w3-animate-opacity w3-round-xlarge" #+
-                                       [string "Capacity in bytes"]
-                                   ]
+                               , infoMark "Capacity in bytes"
                                ]
                            ]
                        , UI.div #. "w3-light-green" #+ [element elMempoolBytesProgress]
@@ -234,11 +263,7 @@ mkNodeWidget = do
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (TXs)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elMempoolCapacity
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark" #+ [string "🛈"]
-                                   , UI.span #. "w3-text w3-tag w3-indigo w3-small w3-animate-opacity w3-round-xlarge" #+
-                                       [string "Capacity"]
-                                   ]
+                               , infoMark "Capacity"
                                ]
                            ]
                        , UI.div #. "w3-light-green" #+ [element elMempoolTxsProgress]
@@ -294,11 +319,7 @@ mkNodeWidget = do
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elDiskUsageRMaxTotal
                                , UI.span #. "value-unit" #+ [string "KB/s"]
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark"
-                                             # set UI.title__ "Maximum value over the last two minutes"
-                                             #+ [string "🛈"]
-                                   ]
+                               , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
                        , UI.div #. "w3-amber" #+ [element elDiskUsageRProgress]
@@ -309,11 +330,7 @@ mkNodeWidget = do
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elDiskUsageWMaxTotal
                                , UI.span #. "value-unit" #+ [string "KB/s"]
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark"
-                                             # set UI.title__ "Maximum value over the last two minutes"
-                                             #+ [string "🛈"]
-                                   ]
+                               , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
                        , UI.div #. "w3-amber" #+ [element elDiskUsageWProgress]
@@ -360,7 +377,7 @@ mkNodeWidget = do
              , vSpacer "node-metrics-v-spacer"
              , vSpacer "node-metrics-v-spacer"
              , UI.div #. "w3-row" #+
-                 [ UI.div #. "w3-half w3-theme" #+
+                 [ UI.div #. "w3-third w3-theme" #+
                      [ UI.div #. "" #+
                          [ UI.div #. "" #+ [string "GC CPU:"]
                          , UI.div #. "" #+ [string "GC Elapsed:"]
@@ -368,7 +385,7 @@ mkNodeWidget = do
                          , UI.div #. "" #+ [string "GC Major Number:"]
                          ]
                      ]
-                 , UI.div #. "w3-half w3-theme" #+
+                 , UI.div #. "w3-third w3-theme" #+
                      [ UI.div #. "node-info-values" #+
                          [ UI.div #. "" #+
                              [ element elRTSGcCpu
@@ -380,6 +397,14 @@ mkNodeWidget = do
                              ]
                          , UI.div #. "" #+ [element elRTSGcNum]
                          , UI.div #. "" #+ [element elRTSGcMajorNum]
+                         ]
+                     ]
+                 , UI.div #. "w3-third w3-theme" #+
+                     [ UI.div #. "" #+
+                         [ UI.div #. "" #+ [element elRTSGcCpuOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcElapsedOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcNumOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcMajorNumOutdateWarning]
                          ]
                      ]
                  ]
@@ -494,6 +519,18 @@ mkNodeWidget = do
           , (ElRTSGcElapsed,            elRTSGcElapsed)
           , (ElRTSGcNum,                elRTSGcNum)
           , (ElRTSGcMajorNum,           elRTSGcMajorNum)
+          -- Outdated warnings
+          , (ElNodeReleaseOutdateWarning,    elNodeReleaseOutdateWarning)
+          , (ElNodeVersionOutdateWarning,    elNodeVersionOutdateWarning)
+          , (ElNodeCommitHrefOutdateWarning, elNodeCommitHrefOutdateWarning)
+          , (ElUptimeOutdateWarning,         elUptimeOutdateWarning)
+          , (ElSlotOutdateWarning,           elSlotOutdateWarning)
+          , (ElBlocksNumberOutdateWarning,   elBlocksNumberOutdateWarning)
+          , (ElChainDensityOutdateWarning,   elChainDensityOutdateWarning)
+          , (ElRTSGcCpuOutdateWarning,       elRTSGcCpuOutdateWarning)
+          , (ElRTSGcElapsedOutdateWarning,   elRTSGcElapsedOutdateWarning)
+          , (ElRTSGcNumOutdateWarning,       elRTSGcNumOutdateWarning)
+          , (ElRTSGcMajorNumOutdateWarning,  elRTSGcMajorNumOutdateWarning)
           -- Progress bars
           , (ElMempoolBytesProgress,    elMempoolBytesProgress)
           , (ElMempoolTxsProgress,      elMempoolTxsProgress)
@@ -546,3 +583,9 @@ hideIt = set UI.style [("display", "none")]
 makeItActive, makeItInactive :: UI Element -> UI Element
 makeItActive   = set UI.class_ "w3-bar-item w3-button w3-khaki"
 makeItInactive = set UI.class_ "w3-bar-item w3-button"
+
+infoMark :: String -> UI Element
+infoMark aTitle =
+  UI.span #. "info-mark"
+          #  set UI.title__ aTitle
+          #+ [string "🛈"]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -50,22 +50,27 @@ data NodeError = NodeError
   } deriving Show
 
 data NodeInfo = NodeInfo
-  { niNodeRelease       :: !String
-  , niNodeVersion       :: !String
-  , niNodeCommit        :: !String
-  , niNodeShortCommit   :: !String
-  , niStartTime         :: !UTCTime
-  , niUpTime            :: !UTCTime
-  , niEpoch             :: !Integer
-  , niSlot              :: !Integer
-  , niBlocksNumber      :: !Integer
-  , niChainDensity      :: !Double
-  , niTxsProcessed      :: !Integer
-  , niPeersNumber       :: !Integer
-  , niPeersInfo         :: ![PeerInfo]
-  , niTraceAcceptorHost :: !String
-  , niTraceAcceptorPort :: !String
-  , niNodeErrors        :: ![NodeError]
+  { niNodeRelease            :: !String
+  , niNodeVersion            :: !String
+  , niNodeCommit             :: !String
+  , niNodeShortCommit        :: !String
+  , niStartTime              :: !UTCTime
+  , niUpTime                 :: !UTCTime
+  , niUpTimeLastUpdate       :: !UTCTime
+  , niEpoch                  :: !Integer
+  , niEpochLastUpdate        :: !UTCTime
+  , niSlot                   :: !Integer
+  , niSlotLastUpdate         :: !UTCTime
+  , niBlocksNumber           :: !Integer
+  , niBlocksNumberLastUpdate :: !UTCTime
+  , niChainDensity           :: !Double
+  , niChainDensityLastUpdate :: !UTCTime
+  , niTxsProcessed           :: !Integer
+  , niPeersNumber            :: !Integer
+  , niPeersInfo              :: ![PeerInfo]
+  , niTraceAcceptorHost      :: !String
+  , niTraceAcceptorPort      :: !String
+  , niNodeErrors             :: ![NodeError]
   } deriving Show
 
 data NodeMetrics = NodeMetrics
@@ -112,9 +117,13 @@ data NodeMetrics = NodeMetrics
   , nmRTSMemoryUsed           :: !Double
   , nmRTSMemoryUsedPercent    :: !Double
   , nmRTSGcCpu                :: !Double
+  , nmRTSGcCpuLastUpdate      :: !UTCTime
   , nmRTSGcElapsed            :: !Double
+  , nmRTSGcElapsedLastUpdate  :: !UTCTime
   , nmRTSGcNum                :: !Integer
+  , nmRTSGcNumLastUpdate      :: !UTCTime
   , nmRTSGcMajorNum           :: !Integer
+  , nmRTSGcMajorNumLastUpdate :: !UTCTime
   } deriving Show
 
 defaultNodesState
@@ -137,22 +146,27 @@ defaultNodeState = NodeState
 
 defaultNodeInfo :: NodeInfo
 defaultNodeInfo = NodeInfo
-  { niNodeRelease       = "-"
-  , niNodeVersion       = "-"
-  , niNodeCommit        = "-"
-  , niNodeShortCommit   = "-"
-  , niStartTime         = UTCTime (ModifiedJulianDay 0) 0
-  , niUpTime            = UTCTime (ModifiedJulianDay 0) 0
-  , niEpoch             = 0
-  , niSlot              = 0
-  , niBlocksNumber      = 0
-  , niChainDensity      = 0.0
-  , niTxsProcessed      = 0
-  , niPeersNumber       = 0
-  , niPeersInfo         = []
-  , niTraceAcceptorHost = "-"
-  , niTraceAcceptorPort = "-"
-  , niNodeErrors        = []
+  { niNodeRelease            = "-"
+  , niNodeVersion            = "-"
+  , niNodeCommit             = "-"
+  , niNodeShortCommit        = "-"
+  , niStartTime              = UTCTime (ModifiedJulianDay 0) 0
+  , niUpTime                 = UTCTime (ModifiedJulianDay 0) 0
+  , niUpTimeLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
+  , niEpoch                  = 0
+  , niEpochLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , niSlot                   = 0
+  , niSlotLastUpdate         = UTCTime (ModifiedJulianDay 0) 0
+  , niBlocksNumber           = 0
+  , niBlocksNumberLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niChainDensity           = 0.0
+  , niChainDensityLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niTxsProcessed           = 0
+  , niPeersNumber            = 0
+  , niPeersInfo              = []
+  , niTraceAcceptorHost      = "-"
+  , niTraceAcceptorPort      = "-"
+  , niNodeErrors             = []
   }
 
 defaultNodeMetrics :: NodeMetrics
@@ -200,9 +214,13 @@ defaultNodeMetrics = NodeMetrics
   , nmRTSMemoryUsed           = 0.1
   , nmRTSMemoryUsedPercent    = 1.0
   , nmRTSGcCpu                = 0.1
+  , nmRTSGcCpuLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcElapsed            = 0.1
+  , nmRTSGcElapsedLastUpdate  = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcNum                = 0
+  , nmRTSGcNumLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcMajorNum           = 0
+  , nmRTSGcMajorNumLastUpdate = UTCTime (ModifiedJulianDay 0) 0
   }
  where
   maxBytesPerTx = 4096 :: Word64

--- a/cardano-rt-view/static/css/cardano-rt-view.css
+++ b/cardano-rt-view/static/css/cardano-rt-view.css
@@ -150,3 +150,8 @@ a:visited:hover {
 .node-port {
     padding-left: 10px;
 }
+
+.outdated-value {
+    color: #999;
+    font-weight: normal;
+}


### PR DESCRIPTION
Now each group of metrics has its "lifetime period". And if some metric wasn't received too long - the corresponding value in GUI will be marked as outdated: gray color with info title. If that metric will be received again - the corresponding value in GUI will be marked as up-to-date again.

There are new CLI arguments for each group's lifetime period. 

Please note that progress bars' behavior **wasn't** changed in this PR. Since we already plan to show progress bars in different colors (depending on percentage) it will be simpler to make these "outdated" changes later.