### PR TITLE
CAD-806: Liveness monitoring

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
@@ -46,9 +46,9 @@ import           Cardano.Benchmarking.RTView.Server
 
 -- | Run the service.
 runCardanoRTView :: RTViewParams -> IO ()
-runCardanoRTView (RTViewParams pathToConfig pathToStatic port) = do
-  config <- readConfig pathToConfig
-  acceptors <- checkIfTraceAcceptorIsDefined config pathToConfig
+runCardanoRTView params = do
+  config <- readConfig (rtvConfig params)
+  acceptors <- checkIfTraceAcceptorIsDefined config (rtvConfig params)
   makeSureTraceAcceptorsAreUnique acceptors
 
   (tr :: Trace IO Text, switchBoard) <- Setup.setupTrace_ config "cardano-rt-view"
@@ -66,7 +66,7 @@ runCardanoRTView (RTViewParams pathToConfig pathToStatic port) = do
   --   3. server (it serves requests from user's browser and shows nodes' metrics in the real time).
   acceptorThr <- async $ launchMetricsAcceptor config accTr switchBoard
   updaterThr  <- async $ launchNodeStateUpdater tr switchBoard nodesStateMVar
-  serverThr   <- async $ launchServer nodesStateMVar pathToStatic port acceptors
+  serverThr   <- async $ launchServer nodesStateMVar params acceptors
 
   void $ waitAnyCancel [acceptorThr, updaterThr, serverThr]
 

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
@@ -6,20 +6,28 @@ module Cardano.Benchmarking.RTView.CLI
 import           Cardano.Prelude hiding ( option )
 import           Prelude
                    ( String )
+import           Data.Time.Clock
+                   ( NominalDiffTime )
 import           Options.Applicative
                    ( Parser
                    , auto, bashCompleter, completer, help
                    , long, metavar, option, strOption
+                   , showDefault, value
                    )
 import           Network.Socket
                    ( PortNumber )
 
 -- | Type for CLI parameters required for the service.
-data RTViewParams =
-  RTViewParams
-    FilePath
-    FilePath
-    PortNumber
+data RTViewParams = RTViewParams
+  { rtvConfig             :: !FilePath
+  , rtvStatic             :: !FilePath
+  , rtvPort               :: !PortNumber
+  , rtvNodeInfoLife       :: !NominalDiffTime
+  , rtvPeersInfoLife      :: !NominalDiffTime
+  , rtvBlockchainInfoLife :: !NominalDiffTime
+  , rtvResourcesInfoLife  :: !NominalDiffTime
+  , rtvRTSInfoLife        :: !NominalDiffTime
+  }
 
 parseRTViewParams :: Parser RTViewParams
 parseRTViewParams =
@@ -35,6 +43,26 @@ parseRTViewParams =
     <*> parsePort
           "port"
           "The port number"
+    <*> parseDiffTime
+          "node-info-life"
+          "Lifetime of node info"
+          5
+    <*> parseDiffTime
+          "peers-info-life"
+          "Lifetime of peers info"
+          20
+    <*> parseDiffTime
+          "blockchain-info-life"
+          "Lifetime of blockchain info"
+          35
+    <*> parseDiffTime
+          "resources-info-life"
+          "Lifetime of resources info"
+          8
+    <*> parseDiffTime
+          "rts-info-life"
+          "Lifetime of GHC RTS info"
+          45
 
 -- Aux parsers
 
@@ -61,3 +89,16 @@ parsePort optname desc =
        <> help desc
     )
 
+parseDiffTime
+  :: String
+  -> String
+  -> NominalDiffTime
+  -> Parser NominalDiffTime
+parseDiffTime optname desc defaultTime =
+    option ((fromIntegral :: Int -> NominalDiffTime) <$> auto) (
+          long optname
+       <> metavar "DIFFTIME"
+       <> help desc
+       <> value defaultTime
+       <> showDefault
+    )

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
@@ -6,8 +6,6 @@ module Cardano.Benchmarking.RTView.CLI
 import           Cardano.Prelude hiding ( option )
 import           Prelude
                    ( String )
-import           Data.Time.Clock
-                   ( NominalDiffTime )
 import           Options.Applicative
                    ( Parser
                    , auto, bashCompleter, completer, help
@@ -22,10 +20,10 @@ data RTViewParams = RTViewParams
   { rtvConfig             :: !FilePath
   , rtvStatic             :: !FilePath
   , rtvPort               :: !PortNumber
-  , rtvNodeInfoLife       :: !NominalDiffTime
-  , rtvBlockchainInfoLife :: !NominalDiffTime
-  , rtvResourcesInfoLife  :: !NominalDiffTime
-  , rtvRTSInfoLife        :: !NominalDiffTime
+  , rtvNodeInfoLife       :: !Word64
+  , rtvBlockchainInfoLife :: !Word64
+  , rtvResourcesInfoLife  :: !Word64
+  , rtvRTSInfoLife        :: !Word64
   }
 
 parseRTViewParams :: Parser RTViewParams
@@ -78,22 +76,25 @@ parsePort
   -> String
   -> Parser PortNumber
 parsePort optname desc =
-    option ((fromIntegral :: Int -> PortNumber) <$> auto) (
-          long optname
-       <> metavar "PORT"
-       <> help desc
-    )
+  option ((fromIntegral :: Int -> PortNumber) <$> auto) (
+       long optname
+    <> metavar "PORT"
+    <> help desc
+  )
 
 parseDiffTime
   :: String
   -> String
-  -> NominalDiffTime
-  -> Parser NominalDiffTime
-parseDiffTime optname desc defaultTime =
-    option ((fromIntegral :: Int -> NominalDiffTime) <$> auto) (
-          long optname
-       <> metavar "DIFFTIME"
-       <> help desc
-       <> value defaultTime
-       <> showDefault
-    )
+  -> Int
+  -> Parser Word64
+parseDiffTime optname desc defaultTimeInSec =
+  option (secToNanosec <$> auto) (
+       long optname
+    <> metavar "DIFFTIME"
+    <> help desc
+    <> value (secToNanosec defaultTimeInSec)
+    <> showDefault
+  )
+ where
+  secToNanosec :: Int -> Word64
+  secToNanosec s = fromIntegral $ s * 1000000000

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
@@ -23,7 +23,6 @@ data RTViewParams = RTViewParams
   , rtvStatic             :: !FilePath
   , rtvPort               :: !PortNumber
   , rtvNodeInfoLife       :: !NominalDiffTime
-  , rtvPeersInfoLife      :: !NominalDiffTime
   , rtvBlockchainInfoLife :: !NominalDiffTime
   , rtvResourcesInfoLife  :: !NominalDiffTime
   , rtvRTSInfoLife        :: !NominalDiffTime
@@ -47,10 +46,6 @@ parseRTViewParams =
           "node-info-life"
           "Lifetime of node info"
           5
-    <*> parseDiffTime
-          "peers-info-life"
-          "Lifetime of peers info"
-          20
     <*> parseDiffTime
           "blockchain-info-life"
           "Lifetime of blockchain info"

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -73,6 +73,18 @@ data ElementName
   | ElRTSGcElapsed
   | ElRTSGcNum
   | ElRTSGcMajorNum
+  -- Outdated warnings.
+  | ElNodeReleaseOutdateWarning
+  | ElNodeVersionOutdateWarning
+  | ElNodeCommitHrefOutdateWarning
+  | ElUptimeOutdateWarning
+  | ElSlotOutdateWarning
+  | ElBlocksNumberOutdateWarning
+  | ElChainDensityOutdateWarning
+  | ElRTSGcCpuOutdateWarning
+  | ElRTSGcElapsedOutdateWarning
+  | ElRTSGcNumOutdateWarning
+  | ElRTSGcMajorNumOutdateWarning
   -- Progress bars.
   | ElMempoolBytesProgress
   | ElMempoolTxsProgress

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -87,15 +87,24 @@ data ElementName
   | ElRTSGcMajorNumOutdateWarning
   -- Progress bars.
   | ElMempoolBytesProgress
+  | ElMempoolBytesProgressBox
   | ElMempoolTxsProgress
+  | ElMempoolTxsProgressBox
   | ElMemoryProgress
+  | ElMemoryProgressBox
   | ElCPUProgress
+  | ElCPUProgressBox
   | ElDiskReadProgress
+  | ElDiskReadProgressBox
   | ElDiskWriteProgress
+  | ElDiskWriteProgressBox
   | ElNetworkInProgress
+  | ElNetworkInProgressBox
   | ElNetworkOutProgress
+  | ElNetworkOutProgressBox
   | ElRTSMemoryProgress
-  deriving (Eq, Ord)
+  | ElRTSMemoryProgressBox
+  deriving (Eq, Ord, Show)
 
 data ElementValue
   = ElementInteger Integer

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -76,6 +76,7 @@ data ElementName
   -- Outdated warnings.
   | ElNodeReleaseOutdateWarning
   | ElNodeVersionOutdateWarning
+  | ElNodePlatformOutdateWarning
   | ElNodeCommitHrefOutdateWarning
   | ElUptimeOutdateWarning
   | ElSlotOutdateWarning

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -68,21 +68,26 @@ mkNodeWidget = do
   elRTSGcNum                <- string "0"
   elRTSGcMajorNum           <- string "0"
 
-  elMempoolBytesProgress    <- UI.div #. "w3-teal" #+
+  -- Progress bars.
+  elMempoolBytesProgress    <- UI.div #. (show ElMempoolBytesProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elMempoolBytes
                                  , UI.span #. "percents-slash-h-spacer" #+ [string "/"]
                                  , element elMempoolBytesPercent
                                  , string "%"
                                  ]
-  elMempoolTxsProgress      <- UI.div #. "w3-teal" #+
+  elMempoolBytesProgressBox <- UI.div #. (show ElMempoolBytesProgressBox) #+ [element elMempoolBytesProgress]
+
+  elMempoolTxsProgress      <- UI.div #. (show ElMempoolTxsProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elMempoolTxsNumber
                                  , UI.span #. "percents-slash-h-spacer" #+ [string "/"]
                                  , element elMempoolTxsPercent
                                  , string "%"
                                  ]
-  elMemoryProgress          <- UI.div #. "w3-teal" #+
+  elMempoolTxsProgressBox   <- UI.div #. (show ElMempoolTxsProgressBox) #+ [element elMempoolTxsProgress]
+
+  elMemoryProgress          <- UI.div #. (show ElMemoryProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elMemory
                                  , UI.span #. "bar-value-unit" #+ [string "MB"]
@@ -91,37 +96,49 @@ mkNodeWidget = do
                                  , element elMemoryMax
                                  , UI.span #. "bar-value-unit" #+ [string "MB"]
                                  ]
-  elCPUProgress             <- UI.div #. "w3-indigo" #+
+  elMemoryProgressBox       <- UI.div #. (show ElMemoryProgressBox) #+ [element elMemoryProgress]
+
+  elCPUProgress             <- UI.div #. (show ElCPUProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elCPUPercent
                                  , string "%"
                                  ]
-  elDiskUsageRProgress      <- UI.div #. "w3-deep-orange" #+
+  elCPUProgressBox          <- UI.div #. (show ElCPUProgressBox) #+ [element elCPUProgress]
+
+  elDiskUsageRProgress      <- UI.div #. (show ElDiskReadProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elDiskUsageR
                                  , UI.span #. "bar-value-unit" #+ [string "KB/s"]
                                  ]
-  elDiskUsageWProgress      <- UI.div #. "w3-deep-orange" #+
+  elDiskUsageRProgressBox   <- UI.div #. (show ElDiskReadProgressBox) #+ [element elDiskUsageRProgress]
+
+  elDiskUsageWProgress      <- UI.div #. (show ElDiskWriteProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elDiskUsageW
                                  , UI.span #. "bar-value-unit" #+ [string "KB/s"]
                                  ]
-  elNetworkUsageInProgress  <- UI.div #. "w3-purple" #+
-                                 [ UI.span #. "h-spacer" #+ []
-                                 , element elNetworkUsageIn
-                                 , UI.span #. "bar-value-unit" #+ [string "KB/s"]
-                                 ]
-  elNetworkUsageOutProgress <- UI.div #. "w3-purple" #+
-                                 [ UI.span #. "h-spacer" #+ []
-                                 , element elNetworkUsageOut
-                                 , UI.span #. "bar-value-unit" #+ [string "KB/s"]
-                                 ]
+  elDiskUsageWProgressBox   <- UI.div #. (show ElDiskWriteProgressBox) #+ [element elDiskUsageWProgress]
 
-  elRTSMemoryProgress       <- UI.div #. "w3-teal" #+
+  elNetworkUsageInProgress     <- UI.div #. (show ElNetworkInProgress) #+
+                                    [ UI.span #. "h-spacer" #+ []
+                                    , element elNetworkUsageIn
+                                    , UI.span #. "bar-value-unit" #+ [string "KB/s"]
+                                    ]
+  elNetworkUsageInProgressBox  <- UI.div #. (show ElNetworkInProgressBox) #+ [element elNetworkUsageInProgress]
+
+  elNetworkUsageOutProgress    <- UI.div #. (show ElNetworkOutProgress) #+
+                                    [ UI.span #. "h-spacer" #+ []
+                                    , element elNetworkUsageOut
+                                    , UI.span #. "bar-value-unit" #+ [string "KB/s"]
+                                    ]
+  elNetworkUsageOutProgressBox <- UI.div #. (show ElNetworkOutProgressBox) #+ [element elNetworkUsageOutProgress]
+
+  elRTSMemoryProgress       <- UI.div #. (show ElRTSMemoryProgress) #+
                                  [ UI.span #. "h-spacer" #+ []
                                  , element elRTSMemoryUsed
                                  , UI.span #. "bar-value-unit" #+ [string "MB"]
                                  ]
+  elRTSMemoryProgressBox    <- UI.div #. (show ElRTSMemoryProgressBox) #+ [element elRTSMemoryProgress]
 
   elNodeCommitHref <- UI.anchor # set UI.href ""
                                 # set UI.target "_blank"
@@ -132,7 +149,7 @@ mkNodeWidget = do
   elNodeVersionOutdateWarning    <- infoMark "The value is outdated"
   elNodeCommitHrefOutdateWarning <- infoMark "The value is outdated"
   elUptimeOutdateWarning         <- infoMark "The value is outdated"
-  
+
   elSlotOutdateWarning           <- infoMark "The value is outdated"
   elBlocksNumberOutdateWarning   <- infoMark "The value is outdated"
   elChainDensityOutdateWarning   <- infoMark "The value is outdated"
@@ -259,7 +276,7 @@ mkNodeWidget = do
                                , infoMark "Capacity in bytes"
                                ]
                            ]
-                       , UI.div #. "w3-light-green" #+ [element elMempoolBytesProgress]
+                       , element elMempoolBytesProgressBox
                        ])
                     (UI.div #. "w3-container" #+
                        [ UI.div #. "w3-row" #+
@@ -269,7 +286,7 @@ mkNodeWidget = do
                                , infoMark "Capacity"
                                ]
                            ]
-                       , UI.div #. "w3-light-green" #+ [element elMempoolTxsProgress]
+                       , element elMempoolTxsProgressBox
                        ])
                 , vSpacer "node-metrics-v-spacer"
                 , vSpacer "node-metrics-v-spacer"
@@ -301,7 +318,7 @@ mkNodeWidget = do
                             , UI.span #. "value-unit" #+ [string "MB"]
                             ]
                         ]
-                    , UI.div #. "w3-light-green" #+ [element elMemoryProgress]
+                    , element elMemoryProgressBox
                     ]
                 , vSpacer "node-metrics-v-spacer"
                 , UI.div #. "w3-container" #+
@@ -312,7 +329,7 @@ mkNodeWidget = do
                             , UI.span #. "value-unit" #+ [string "%"]
                             ]
                         ]
-                    , UI.div #. "w3-cyan" #+ [element elCPUProgress]
+                    , element elCPUProgressBox
                     ]
                 , vSpacer "node-metrics-v-spacer"
                 , twoElementsInRow
@@ -325,7 +342,7 @@ mkNodeWidget = do
                                , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
-                       , UI.div #. "w3-amber" #+ [element elDiskUsageRProgress]
+                       , element elDiskUsageRProgressBox
                        ])
                     (UI.div #. "w3-container" #+
                        [ UI.div #. "w3-row" #+
@@ -336,7 +353,7 @@ mkNodeWidget = do
                                , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
-                       , UI.div #. "w3-amber" #+ [element elDiskUsageWProgress]
+                       , element elDiskUsageWProgressBox
                        ])
                 , vSpacer "node-metrics-v-spacer"
                 , twoElementsInRow
@@ -348,7 +365,7 @@ mkNodeWidget = do
                                , UI.span #. "value-unit" #+ [string "KB/s"]
                                ]
                            ]
-                       , UI.div #. "w3-pale-red" #+ [element elNetworkUsageInProgress]
+                       , element elNetworkUsageInProgressBox
                        ])
                     (UI.div #. "w3-container" #+
                        [ UI.div #. "w3-row" #+
@@ -358,7 +375,7 @@ mkNodeWidget = do
                                , UI.span #. "value-unit" #+ [string "KB/s"]
                                ]
                            ]
-                       , UI.div #. "w3-pale-red" #+ [element elNetworkUsageOutProgress]
+                       , element elNetworkUsageOutProgressBox
                        ])
                 ]
             ]
@@ -375,7 +392,7 @@ mkNodeWidget = do
                          , UI.span #. "value-unit" #+ [string "MB"]
                          ]
                      ]
-                 , UI.div #. "w3-light-green" #+ [element elRTSMemoryProgress]
+                 , element elRTSMemoryProgressBox
                  ]
              , vSpacer "node-metrics-v-spacer"
              , vSpacer "node-metrics-v-spacer"
@@ -537,14 +554,23 @@ mkNodeWidget = do
           , (ElRTSGcMajorNumOutdateWarning,  elRTSGcMajorNumOutdateWarning)
           -- Progress bars
           , (ElMempoolBytesProgress,    elMempoolBytesProgress)
+          , (ElMempoolBytesProgressBox, elMempoolBytesProgressBox)
           , (ElMempoolTxsProgress,      elMempoolTxsProgress)
+          , (ElMempoolTxsProgressBox,   elMempoolTxsProgressBox)
           , (ElMemoryProgress,          elMemoryProgress)
+          , (ElMemoryProgressBox,       elMemoryProgressBox)
           , (ElCPUProgress,             elCPUProgress)
+          , (ElCPUProgressBox,          elCPUProgressBox)
           , (ElDiskReadProgress,        elDiskUsageRProgress)
+          , (ElDiskReadProgressBox,     elDiskUsageRProgressBox)
           , (ElDiskWriteProgress,       elDiskUsageWProgress)
+          , (ElDiskWriteProgressBox,    elDiskUsageWProgressBox)
           , (ElNetworkInProgress,       elNetworkUsageInProgress)
+          , (ElNetworkInProgressBox,    elNetworkUsageInProgressBox)
           , (ElNetworkOutProgress,      elNetworkUsageOutProgress)
+          , (ElNetworkOutProgressBox,   elNetworkUsageOutProgressBox)
           , (ElRTSMemoryProgress,       elRTSMemoryProgress)
+          , (ElRTSMemoryProgressBox,    elRTSMemoryProgressBox)
           ]
 
   return (nodeWidget, nodeStateElems)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -147,6 +147,7 @@ mkNodeWidget = do
 
   elNodeReleaseOutdateWarning    <- infoMark "The value is outdated"
   elNodeVersionOutdateWarning    <- infoMark "The value is outdated"
+  elNodePlatformOutdateWarning   <- infoMark "The value is outdated"
   elNodeCommitHrefOutdateWarning <- infoMark "The value is outdated"
   elUptimeOutdateWarning         <- infoMark "The value is outdated"
 
@@ -193,6 +194,7 @@ mkNodeWidget = do
                  [ UI.div #. "" #+
                      [ UI.span #. "" #+ [element elNodeReleaseOutdateWarning]
                      , UI.div #. "" #+ [element elNodeVersionOutdateWarning]
+                     , UI.div #. "" #+ [element elNodePlatformOutdateWarning]
                      , UI.div #. "" #+ [element elNodeCommitHrefOutdateWarning]
                      , vSpacer "node-info-v-spacer"
                      , UI.div #. "" #+ [UI.span # set UI.html "&nbsp;" #+ []]
@@ -543,6 +545,7 @@ mkNodeWidget = do
           -- Outdated warnings
           , (ElNodeReleaseOutdateWarning,    elNodeReleaseOutdateWarning)
           , (ElNodeVersionOutdateWarning,    elNodeVersionOutdateWarning)
+          , (ElNodePlatformOutdateWarning,   elNodePlatformOutdateWarning)
           , (ElNodeCommitHrefOutdateWarning, elNodeCommitHrefOutdateWarning)
           , (ElUptimeOutdateWarning,         elUptimeOutdateWarning)
           , (ElSlotOutdateWarning,           elSlotOutdateWarning)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -128,11 +128,25 @@ mkNodeWidget = do
                                 # set UI.title__ "Browse cardano-node repository on this commit"
                                 #+ [string ""]
 
+  elNodeReleaseOutdateWarning    <- infoMark "The value is outdated"
+  elNodeVersionOutdateWarning    <- infoMark "The value is outdated"
+  elNodeCommitHrefOutdateWarning <- infoMark "The value is outdated"
+  elUptimeOutdateWarning         <- infoMark "The value is outdated"
+  
+  elSlotOutdateWarning           <- infoMark "The value is outdated"
+  elBlocksNumberOutdateWarning   <- infoMark "The value is outdated"
+  elChainDensityOutdateWarning   <- infoMark "The value is outdated"
+
+  elRTSGcCpuOutdateWarning       <- infoMark "The value is outdated"
+  elRTSGcElapsedOutdateWarning   <- infoMark "The value is outdated"
+  elRTSGcNumOutdateWarning       <- infoMark "The value is outdated"
+  elRTSGcMajorNumOutdateWarning  <- infoMark "The value is outdated"
+
   -- Create content area for each tab.
   nodeTabContent
     <- UI.div #. "tab-container" # showIt #+
          [ UI.div #. "w3-row" #+
-             [ UI.div #. "w3-half w3-theme" #+
+             [ UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "" #+
                      [ UI.div #. "" #+ [string "Node release:"]
                      , UI.div #. "" #+ [string "Node version:"]
@@ -145,7 +159,7 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [string "Node uptime:"]
                      ]
                  ]
-             , UI.div #. "w3-half w3-theme" #+
+             , UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "node-info-values" #+
                      [ UI.span #. "release-name" #+ [element elNodeRelease]
                      , UI.div #. "" #+ [element elNodeVersion]
@@ -156,6 +170,18 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [element elTraceAcceptorPort]
                      , vSpacer "node-info-v-spacer"
                      , UI.div #. "" #+ [element elUptime]
+                     ]
+                 ]
+             , UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "" #+
+                     [ UI.span #. "" #+ [element elNodeReleaseOutdateWarning]
+                     , UI.div #. "" #+ [element elNodeVersionOutdateWarning]
+                     , UI.div #. "" #+ [element elNodeCommitHrefOutdateWarning]
+                     , vSpacer "node-info-v-spacer"
+                     , UI.div #. "" #+ [UI.span # set UI.html "&nbsp;" #+ []]
+                     , UI.div #. "" #+ [UI.span # set UI.html "&nbsp;" #+ []]
+                     , vSpacer "node-info-v-spacer"
+                     , UI.div #. "" #+ [element elUptimeOutdateWarning]
                      ]
                  ]
              ]
@@ -189,14 +215,14 @@ mkNodeWidget = do
   blockchainTabContent
     <- UI.div #. "tab-container" # hideIt #+
          [ UI.div #. "w3-row" #+
-             [ UI.div #. "w3-half w3-theme" #+
+             [ UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "" #+
                      [ UI.div #. "" #+ [string "Epoch / Slot in epoch:"]
                      , UI.div #. "" #+ [string "Blocks number:"]
                      , UI.div #. "" #+ [string "Chain density:"]
                      ]
                  ]
-             , UI.div #. "w3-half w3-theme" #+
+             , UI.div #. "w3-third w3-theme" #+
                  [ UI.div #. "node-info-values" #+
                      [ UI.div #. "" #+
                          [ element elEpoch
@@ -208,6 +234,13 @@ mkNodeWidget = do
                          [ element elChainDensity
                          , UI.span #. "density-percent" #+ [string "%"]
                          ]
+                     ]
+                 ]
+             , UI.div #. "w3-third w3-theme" #+
+                 [ UI.div #. "" #+
+                     [ UI.div #. "" #+ [element elSlotOutdateWarning]
+                     , UI.div #. "" #+ [element elBlocksNumberOutdateWarning]
+                     , UI.div #. "" #+ [element elChainDensityOutdateWarning]
                      ]
                  ]
              ]
@@ -223,11 +256,7 @@ mkNodeWidget = do
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (Bytes)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elMempoolCapacityBytes
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark" #+ [string "🛈"]
-                                   , UI.span #. "w3-text w3-tag w3-indigo w3-small w3-animate-opacity w3-round-xlarge" #+
-                                       [string "Capacity in bytes"]
-                                   ]
+                               , infoMark "Capacity in bytes"
                                ]
                            ]
                        , UI.div #. "w3-light-green" #+ [element elMempoolBytesProgress]
@@ -237,11 +266,7 @@ mkNodeWidget = do
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (TXs)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elMempoolCapacity
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark" #+ [string "🛈"]
-                                   , UI.span #. "w3-text w3-tag w3-indigo w3-small w3-animate-opacity w3-round-xlarge" #+
-                                       [string "Capacity"]
-                                   ]
+                               , infoMark "Capacity"
                                ]
                            ]
                        , UI.div #. "w3-light-green" #+ [element elMempoolTxsProgress]
@@ -297,11 +322,7 @@ mkNodeWidget = do
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elDiskUsageRMaxTotal
                                , UI.span #. "value-unit" #+ [string "KB/s"]
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark"
-                                             # set UI.title__ "Maximum value over the last two minutes"
-                                             #+ [string "🛈"]
-                                   ]
+                               , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
                        , UI.div #. "w3-amber" #+ [element elDiskUsageRProgress]
@@ -312,11 +333,7 @@ mkNodeWidget = do
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
                                [ element elDiskUsageWMaxTotal
                                , UI.span #. "value-unit" #+ [string "KB/s"]
-                               , UI.span #. "w3-tooltip" #+
-                                   [ UI.span #. "info-mark"
-                                             # set UI.title__ "Maximum value over the last two minutes"
-                                             #+ [string "🛈"]
-                                   ]
+                               , infoMark "Maximum value over the last two minutes"
                                ]
                            ]
                        , UI.div #. "w3-amber" #+ [element elDiskUsageWProgress]
@@ -363,7 +380,7 @@ mkNodeWidget = do
              , vSpacer "node-metrics-v-spacer"
              , vSpacer "node-metrics-v-spacer"
              , UI.div #. "w3-row" #+
-                 [ UI.div #. "w3-half w3-theme" #+
+                 [ UI.div #. "w3-third w3-theme" #+
                      [ UI.div #. "" #+
                          [ UI.div #. "" #+ [string "GC CPU:"]
                          , UI.div #. "" #+ [string "GC Elapsed:"]
@@ -371,7 +388,7 @@ mkNodeWidget = do
                          , UI.div #. "" #+ [string "GC Major Number:"]
                          ]
                      ]
-                 , UI.div #. "w3-half w3-theme" #+
+                 , UI.div #. "w3-third w3-theme" #+
                      [ UI.div #. "node-info-values" #+
                          [ UI.div #. "" #+
                              [ element elRTSGcCpu
@@ -383,6 +400,14 @@ mkNodeWidget = do
                              ]
                          , UI.div #. "" #+ [element elRTSGcNum]
                          , UI.div #. "" #+ [element elRTSGcMajorNum]
+                         ]
+                     ]
+                 , UI.div #. "w3-third w3-theme" #+
+                     [ UI.div #. "" #+
+                         [ UI.div #. "" #+ [element elRTSGcCpuOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcElapsedOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcNumOutdateWarning]
+                         , UI.div #. "" #+ [element elRTSGcMajorNumOutdateWarning]
                          ]
                      ]
                  ]
@@ -498,6 +523,18 @@ mkNodeWidget = do
           , (ElRTSGcElapsed,            elRTSGcElapsed)
           , (ElRTSGcNum,                elRTSGcNum)
           , (ElRTSGcMajorNum,           elRTSGcMajorNum)
+          -- Outdated warnings
+          , (ElNodeReleaseOutdateWarning,    elNodeReleaseOutdateWarning)
+          , (ElNodeVersionOutdateWarning,    elNodeVersionOutdateWarning)
+          , (ElNodeCommitHrefOutdateWarning, elNodeCommitHrefOutdateWarning)
+          , (ElUptimeOutdateWarning,         elUptimeOutdateWarning)
+          , (ElSlotOutdateWarning,           elSlotOutdateWarning)
+          , (ElBlocksNumberOutdateWarning,   elBlocksNumberOutdateWarning)
+          , (ElChainDensityOutdateWarning,   elChainDensityOutdateWarning)
+          , (ElRTSGcCpuOutdateWarning,       elRTSGcCpuOutdateWarning)
+          , (ElRTSGcElapsedOutdateWarning,   elRTSGcElapsedOutdateWarning)
+          , (ElRTSGcNumOutdateWarning,       elRTSGcNumOutdateWarning)
+          , (ElRTSGcMajorNumOutdateWarning,  elRTSGcMajorNumOutdateWarning)
           -- Progress bars
           , (ElMempoolBytesProgress,    elMempoolBytesProgress)
           , (ElMempoolTxsProgress,      elMempoolTxsProgress)
@@ -550,3 +587,9 @@ hideIt = set UI.style [("display", "none")]
 makeItActive, makeItInactive :: UI Element -> UI Element
 makeItActive   = set UI.class_ "w3-bar-item w3-button w3-khaki"
 makeItInactive = set UI.class_ "w3-bar-item w3-button"
+
+infoMark :: String -> UI Element
+infoMark aTitle =
+  UI.span #. "info-mark"
+          #  set UI.title__ aTitle
+          #+ [string "🛈"]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -12,7 +12,9 @@ import qualified Data.List as L
 import           Data.Map.Strict
                    ( (!) )
 import           Data.Time.Clock
-                   ( UTCTime (..) )
+                   ( NominalDiffTime, UTCTime (..)
+                   , diffUTCTime, getCurrentTime
+                   )
 import           Data.Time.Format
                    ( defaultTimeLocale, formatTime )
 import           Data.Text
@@ -30,9 +32,11 @@ import           Cardano.BM.Data.Configuration
                    ( RemoteAddrNamed (..), RemoteAddr (..) )
 import           Cardano.BM.Data.Severity
                    ( Severity (..) )
+import           Cardano.Benchmarking.RTView.CLI
+                   ( RTViewParams (..) )
 import           Cardano.Benchmarking.RTView.GUI.Elements
                    ( ElementName (..), ElementValue (..)
-                   , NodesStateElements
+                   , NodeStateElements, NodesStateElements
                    )
 import           Cardano.Benchmarking.RTView.NodeState.Types
                    ( NodeInfo (..), NodeMetrics (..), NodeError (..)
@@ -43,10 +47,11 @@ import           Cardano.Benchmarking.RTView.NodeState.Types
 --   on the page automatically, because threepenny-gui is based on websockets.
 updateGUI
   :: NodesState
+  -> RTViewParams
   -> [RemoteAddrNamed]
   -> NodesStateElements
   -> UI ()
-updateGUI nodesState acceptors nodesStateElems =
+updateGUI nodesState params acceptors nodesStateElems =
   forM_ nodesStateElems $ \(nameOfNode, elements) -> do
     let nodeState = nodesState ! nameOfNode
         (acceptorHost, acceptorPort) = findTraceAcceptorNetInfo nameOfNode acceptors
@@ -107,6 +112,8 @@ updateGUI nodesState acceptors nodesStateElems =
     void $ updateProgressBar (nmNetworkUsageInPercent nm)  $ elements ! ElNetworkInProgress
     void $ updateProgressBar (nmNetworkUsageOutPercent nm) $ elements ! ElNetworkOutProgress
     void $ updateProgressBar (nmRTSMemoryUsedPercent nm)   $ elements ! ElRTSMemoryProgress
+
+    markOutdatedElements params ni nm elements
 
 updateElementValue
   :: ElementValue
@@ -197,3 +204,86 @@ findTraceAcceptorNetInfo nameOfNode acceptors =
     Nothing -> ("-", "-")
  where
   maybeActiveNode = flip L.find acceptors $ \(RemoteAddrNamed name _) -> name == nameOfNode
+
+-- | If some metric wasn't receive for a long time -
+--   we mark corresponding value in GUI as outdated one.
+markOutdatedElements
+  :: RTViewParams
+  -> NodeInfo
+  -> NodeMetrics
+  -> NodeStateElements
+  -> UI ()
+markOutdatedElements params ni nm els = do
+  now <- liftIO $ getCurrentTime
+  -- Different metrics have different lifetime.
+  let niLife   = rtvNodeInfoLife params
+      _pLife   = rtvPeersInfoLife params
+      bcLife   = rtvBlockchainInfoLife params
+      _resLife = rtvResourcesInfoLife params
+      rtsLife  = rtvRTSInfoLife params
+
+
+  markValueW now (niUpTimeLastUpdate ni)       niLife [ els ! ElUptime
+                                                      , els ! ElNodeRelease
+                                                      , els ! ElNodeVersion
+                                                      , els ! ElNodeCommitHref
+                                                      ]
+                                                      [ els ! ElUptimeOutdateWarning
+                                                      , els ! ElNodeReleaseOutdateWarning
+                                                      , els ! ElNodeVersionOutdateWarning
+                                                      , els ! ElNodeCommitHrefOutdateWarning
+                                                      ]
+  
+  markValue  now (niEpochLastUpdate ni)        bcLife (els ! ElEpoch)
+  markValueW now (niSlotLastUpdate ni)         bcLife [els ! ElSlot]
+                                                      [els ! ElSlotOutdateWarning]
+  markValueW now (niBlocksNumberLastUpdate ni) bcLife [els ! ElBlocksNumber]
+                                                      [els ! ElBlocksNumberOutdateWarning]
+  markValueW now (niChainDensityLastUpdate ni) bcLife [els ! ElChainDensity]
+                                                      [els ! ElChainDensityOutdateWarning]
+  
+  markValueW now (nmRTSGcCpuLastUpdate nm)      rtsLife [els ! ElRTSGcCpu]
+                                                        [els ! ElRTSGcCpuOutdateWarning]
+  markValueW now (nmRTSGcElapsedLastUpdate nm)  rtsLife [els ! ElRTSGcElapsed]
+                                                        [els ! ElRTSGcElapsedOutdateWarning]
+  markValueW now (nmRTSGcNumLastUpdate nm)      rtsLife [els ! ElRTSGcNum]
+                                                        [els ! ElRTSGcNumOutdateWarning]
+  markValueW now (nmRTSGcMajorNumLastUpdate nm) rtsLife [els ! ElRTSGcMajorNum]
+                                                        [els ! ElRTSGcMajorNumOutdateWarning]
+
+  -- markProgressBar 
+
+markValue
+  :: UTCTime
+  -> UTCTime
+  -> NominalDiffTime
+  -> Element
+  -> UI ()
+markValue now lastUpdate lifetime el =
+  if diffUTCTime now lastUpdate > lifetime
+    then void $ markAsOutdated el
+    else void $ markAsUpToDate el
+
+markValueW
+  :: UTCTime
+  -> UTCTime
+  -> NominalDiffTime
+  -> [Element]
+  -> [Element]
+  -> UI ()
+markValueW now lastUpdate lifetime els warnings =
+  if diffUTCTime now lastUpdate > lifetime
+    then do
+      mapM_ (void . markAsOutdated) els
+      mapM_ (void . showWarning) warnings
+    else do
+      mapM_ (void . markAsUpToDate) els
+      mapM_ (void . hideWarning) warnings
+
+showWarning, hideWarning :: Element -> UI Element
+showWarning w = element w # set UI.style [("display", "inline")]
+hideWarning w = element w # set UI.style [("display", "none")]
+
+markAsOutdated, markAsUpToDate :: Element -> UI Element
+markAsOutdated el = element el # set UI.class_ "outdated-value"
+markAsUpToDate el = element el # set UI.class_ ""

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -236,11 +236,13 @@ markOutdatedElements params ni nm els = do
   markValueW now (niUpTimeLastUpdate ni)       niLife [ els ! ElUptime
                                                       , els ! ElNodeRelease
                                                       , els ! ElNodeVersion
+                                                      , els ! ElNodePlatform
                                                       , els ! ElNodeCommitHref
                                                       ]
                                                       [ els ! ElUptimeOutdateWarning
                                                       , els ! ElNodeReleaseOutdateWarning
                                                       , els ! ElNodeVersionOutdateWarning
+                                                      , els ! ElNodePlatformOutdateWarning
                                                       , els ! ElNodeCommitHrefOutdateWarning
                                                       ]
 

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -50,6 +50,7 @@ data NodeError = NodeError
   } deriving Show
 
 data NodeInfo = NodeInfo
+<<<<<<< HEAD
   { niNodeRelease       :: !String
   , niNodeVersion       :: !String
   , niNodeCommit        :: !String
@@ -66,6 +67,29 @@ data NodeInfo = NodeInfo
   , niTraceAcceptorHost :: !String
   , niTraceAcceptorPort :: !String
   , niNodeErrors        :: ![NodeError]
+=======
+  { niNodeRelease            :: !String
+  , niNodeVersion            :: !String
+  , niNodeCommit             :: !String
+  , niNodeShortCommit        :: !String
+  , niStartTime              :: !UTCTime
+  , niUpTime                 :: !UTCTime
+  , niUpTimeLastUpdate       :: !UTCTime
+  , niEpoch                  :: !Integer
+  , niEpochLastUpdate        :: !UTCTime
+  , niSlot                   :: !Integer
+  , niSlotLastUpdate         :: !UTCTime
+  , niBlocksNumber           :: !Integer
+  , niBlocksNumberLastUpdate :: !UTCTime
+  , niChainDensity           :: !Double
+  , niChainDensityLastUpdate :: !UTCTime
+  , niTxsProcessed           :: !Integer
+  , niPeersNumber            :: !Integer
+  , niPeersInfo              :: ![PeerInfo]
+  , niTraceAcceptorHost      :: !String
+  , niTraceAcceptorPort      :: !String
+  , niNodeErrors             :: ![NodeError]
+>>>>>>> 588c21b... CAD-806: Live monitoring.
   } deriving Show
 
 data NodeMetrics = NodeMetrics
@@ -112,9 +136,13 @@ data NodeMetrics = NodeMetrics
   , nmRTSMemoryUsed           :: !Double
   , nmRTSMemoryUsedPercent    :: !Double
   , nmRTSGcCpu                :: !Double
+  , nmRTSGcCpuLastUpdate      :: !UTCTime
   , nmRTSGcElapsed            :: !Double
+  , nmRTSGcElapsedLastUpdate  :: !UTCTime
   , nmRTSGcNum                :: !Integer
+  , nmRTSGcNumLastUpdate      :: !UTCTime
   , nmRTSGcMajorNum           :: !Integer
+  , nmRTSGcMajorNumLastUpdate :: !UTCTime
   } deriving Show
 
 defaultNodesState
@@ -137,6 +165,7 @@ defaultNodeState = NodeState
 
 defaultNodeInfo :: NodeInfo
 defaultNodeInfo = NodeInfo
+<<<<<<< HEAD
   { niNodeRelease       = "-"
   , niNodeVersion       = "-"
   , niNodeCommit        = "-"
@@ -153,6 +182,29 @@ defaultNodeInfo = NodeInfo
   , niTraceAcceptorHost = "-"
   , niTraceAcceptorPort = "-"
   , niNodeErrors        = []
+=======
+  { niNodeRelease            = "-"
+  , niNodeVersion            = "-"
+  , niNodeCommit             = "-"
+  , niNodeShortCommit        = "-"
+  , niStartTime              = UTCTime (ModifiedJulianDay 0) 0
+  , niUpTime                 = UTCTime (ModifiedJulianDay 0) 0
+  , niUpTimeLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
+  , niEpoch                  = 0
+  , niEpochLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , niSlot                   = 0
+  , niSlotLastUpdate         = UTCTime (ModifiedJulianDay 0) 0
+  , niBlocksNumber           = 0
+  , niBlocksNumberLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niChainDensity           = 0.0
+  , niChainDensityLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niTxsProcessed           = 0
+  , niPeersNumber            = 0
+  , niPeersInfo              = []
+  , niTraceAcceptorHost      = "-"
+  , niTraceAcceptorPort      = "-"
+  , niNodeErrors             = []
+>>>>>>> 588c21b... CAD-806: Live monitoring.
   }
 
 defaultNodeMetrics :: NodeMetrics
@@ -200,9 +252,13 @@ defaultNodeMetrics = NodeMetrics
   , nmRTSMemoryUsed           = 0.1
   , nmRTSMemoryUsedPercent    = 1.0
   , nmRTSGcCpu                = 0.1
+  , nmRTSGcCpuLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcElapsed            = 0.1
+  , nmRTSGcElapsedLastUpdate  = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcNum                = 0
+  , nmRTSGcNumLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
   , nmRTSGcMajorNum           = 0
+  , nmRTSGcMajorNumLastUpdate = UTCTime (ModifiedJulianDay 0) 0
   }
  where
   maxBytesPerTx = 4096 :: Word64

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -54,14 +54,9 @@ data NodeInfo = NodeInfo
   , niNodeVersion            :: !String
   , niNodeCommit             :: !String
   , niNodeShortCommit        :: !String
-<<<<<<< HEAD
   , niNodePlatform           :: !String
-  , niUpTime                 :: !UTCTime
-  , niUpTimeLastUpdate       :: !UTCTime
-=======
   , niUpTime                 :: !Word64
   , niUpTimeLastUpdate       :: !Word64
->>>>>>> CAD-806: Live monitoring, monotonic time instead of UTCTime.
   , niEpoch                  :: !Integer
   , niEpochLastUpdate        :: !Word64
   , niSlot                   :: !Integer
@@ -162,14 +157,9 @@ defaultNodeInfo = NodeInfo
   , niNodeVersion            = "-"
   , niNodeCommit             = "-"
   , niNodeShortCommit        = "-"
-<<<<<<< HEAD
   , niNodePlatform           = "?"
-  , niUpTime                 = UTCTime (ModifiedJulianDay 0) 0
-  , niUpTimeLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
-=======
   , niUpTime                 = 0
   , niUpTimeLastUpdate       = 0
->>>>>>> CAD-806: Live monitoring, monotonic time instead of UTCTime.
   , niEpoch                  = 0
   , niEpochLastUpdate        = 0
   , niSlot                   = 0

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -50,29 +50,11 @@ data NodeError = NodeError
   } deriving Show
 
 data NodeInfo = NodeInfo
-<<<<<<< HEAD
-  { niNodeRelease       :: !String
-  , niNodeVersion       :: !String
-  , niNodeCommit        :: !String
-  , niNodeShortCommit   :: !String
-  , niNodePlatform      :: !String
-  , niUpTime            :: !UTCTime
-  , niEpoch             :: !Integer
-  , niSlot              :: !Integer
-  , niBlocksNumber      :: !Integer
-  , niChainDensity      :: !Double
-  , niTxsProcessed      :: !Integer
-  , niPeersNumber       :: !Integer
-  , niPeersInfo         :: ![PeerInfo]
-  , niTraceAcceptorHost :: !String
-  , niTraceAcceptorPort :: !String
-  , niNodeErrors        :: ![NodeError]
-=======
   { niNodeRelease            :: !String
   , niNodeVersion            :: !String
   , niNodeCommit             :: !String
   , niNodeShortCommit        :: !String
-  , niStartTime              :: !UTCTime
+  , niNodePlatform           :: !String
   , niUpTime                 :: !UTCTime
   , niUpTimeLastUpdate       :: !UTCTime
   , niEpoch                  :: !Integer
@@ -89,7 +71,6 @@ data NodeInfo = NodeInfo
   , niTraceAcceptorHost      :: !String
   , niTraceAcceptorPort      :: !String
   , niNodeErrors             :: ![NodeError]
->>>>>>> 588c21b... CAD-806: Live monitoring.
   } deriving Show
 
 data NodeMetrics = NodeMetrics
@@ -172,29 +153,11 @@ defaultNodeState = NodeState
 
 defaultNodeInfo :: NodeInfo
 defaultNodeInfo = NodeInfo
-<<<<<<< HEAD
-  { niNodeRelease       = "-"
-  , niNodeVersion       = "-"
-  , niNodeCommit        = "-"
-  , niNodeShortCommit   = "-"
-  , niNodePlatform      = "?"
-  , niUpTime            = UTCTime (ModifiedJulianDay 0) 0
-  , niEpoch             = 0
-  , niSlot              = 0
-  , niBlocksNumber      = 0
-  , niChainDensity      = 0.0
-  , niTxsProcessed      = 0
-  , niPeersNumber       = 0
-  , niPeersInfo         = []
-  , niTraceAcceptorHost = "-"
-  , niTraceAcceptorPort = "-"
-  , niNodeErrors        = []
-=======
   { niNodeRelease            = "-"
   , niNodeVersion            = "-"
   , niNodeCommit             = "-"
   , niNodeShortCommit        = "-"
-  , niStartTime              = UTCTime (ModifiedJulianDay 0) 0
+  , niNodePlatform           = "?"
   , niUpTime                 = UTCTime (ModifiedJulianDay 0) 0
   , niUpTimeLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
   , niEpoch                  = 0
@@ -211,7 +174,6 @@ defaultNodeInfo = NodeInfo
   , niTraceAcceptorHost      = "-"
   , niTraceAcceptorPort      = "-"
   , niNodeErrors             = []
->>>>>>> 588c21b... CAD-806: Live monitoring.
   }
 
 defaultNodeMetrics :: NodeMetrics

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -54,17 +54,22 @@ data NodeInfo = NodeInfo
   , niNodeVersion            :: !String
   , niNodeCommit             :: !String
   , niNodeShortCommit        :: !String
+<<<<<<< HEAD
   , niNodePlatform           :: !String
   , niUpTime                 :: !UTCTime
   , niUpTimeLastUpdate       :: !UTCTime
+=======
+  , niUpTime                 :: !Word64
+  , niUpTimeLastUpdate       :: !Word64
+>>>>>>> CAD-806: Live monitoring, monotonic time instead of UTCTime.
   , niEpoch                  :: !Integer
-  , niEpochLastUpdate        :: !UTCTime
+  , niEpochLastUpdate        :: !Word64
   , niSlot                   :: !Integer
-  , niSlotLastUpdate         :: !UTCTime
+  , niSlotLastUpdate         :: !Word64
   , niBlocksNumber           :: !Integer
-  , niBlocksNumberLastUpdate :: !UTCTime
+  , niBlocksNumberLastUpdate :: !Word64
   , niChainDensity           :: !Double
-  , niChainDensityLastUpdate :: !UTCTime
+  , niChainDensityLastUpdate :: !Word64
   , niTxsProcessed           :: !Integer
   , niPeersNumber            :: !Integer
   , niPeersInfo              :: ![PeerInfo]
@@ -84,11 +89,11 @@ data NodeMetrics = NodeMetrics
   , nmMemoryMax                 :: !Double
   , nmMemoryMaxTotal            :: !Double
   , nmMemoryPercent             :: !Double
-  , nmMemoryLastUpdate          :: !UTCTime
+  , nmMemoryLastUpdate          :: !Word64
   , nmCPUPercent                :: !Double
   , nmCPULast                   :: !Integer
   , nmCPUNs                     :: !Word64
-  , nmCPULastUpdate             :: !UTCTime
+  , nmCPULastUpdate             :: !Word64
   , nmDiskUsageR                :: !Double
   , nmDiskUsageRMax             :: !Double
   , nmDiskUsageRMaxTotal        :: !Double
@@ -96,7 +101,7 @@ data NodeMetrics = NodeMetrics
   , nmDiskUsageRLast            :: !Word64
   , nmDiskUsageRNs              :: !Word64
   , nmDiskUsageRAdaptTime       :: !UTCTime
-  , nmDiskUsageRLastUpdate      :: !UTCTime
+  , nmDiskUsageRLastUpdate      :: !Word64
   , nmDiskUsageW                :: !Double
   , nmDiskUsageWMax             :: !Double
   , nmDiskUsageWMaxTotal        :: !Double
@@ -104,33 +109,33 @@ data NodeMetrics = NodeMetrics
   , nmDiskUsageWLast            :: !Word64
   , nmDiskUsageWNs              :: !Word64
   , nmDiskUsageWAdaptTime       :: !UTCTime
-  , nmDiskUsageWLastUpdate      :: !UTCTime
+  , nmDiskUsageWLastUpdate      :: !Word64
   , nmNetworkUsageIn            :: !Double
   , nmNetworkUsageInPercent     :: !Double
   , nmNetworkUsageInMax         :: !Double
   , nmNetworkUsageInMaxTotal    :: !Double
   , nmNetworkUsageInLast        :: !Word64
   , nmNetworkUsageInNs          :: !Word64
-  , nmNetworkUsageInLastUpdate  :: !UTCTime
+  , nmNetworkUsageInLastUpdate  :: !Word64
   , nmNetworkUsageOut           :: !Double
   , nmNetworkUsageOutPercent    :: !Double
   , nmNetworkUsageOutMax        :: !Double
   , nmNetworkUsageOutMaxTotal   :: !Double
   , nmNetworkUsageOutLast       :: !Word64
   , nmNetworkUsageOutNs         :: !Word64
-  , nmNetworkUsageOutLastUpdate :: !UTCTime
+  , nmNetworkUsageOutLastUpdate :: !Word64
   , nmRTSMemoryAllocated        :: !Double
   , nmRTSMemoryUsed             :: !Double
   , nmRTSMemoryUsedPercent      :: !Double
-  , nmRTSMemoryLastUpdate       :: !UTCTime
+  , nmRTSMemoryLastUpdate       :: !Word64
   , nmRTSGcCpu                  :: !Double
-  , nmRTSGcCpuLastUpdate        :: !UTCTime
+  , nmRTSGcCpuLastUpdate        :: !Word64
   , nmRTSGcElapsed              :: !Double
-  , nmRTSGcElapsedLastUpdate    :: !UTCTime
+  , nmRTSGcElapsedLastUpdate    :: !Word64
   , nmRTSGcNum                  :: !Integer
-  , nmRTSGcNumLastUpdate        :: !UTCTime
+  , nmRTSGcNumLastUpdate        :: !Word64
   , nmRTSGcMajorNum             :: !Integer
-  , nmRTSGcMajorNumLastUpdate   :: !UTCTime
+  , nmRTSGcMajorNumLastUpdate   :: !Word64
   } deriving Show
 
 defaultNodesState
@@ -157,17 +162,22 @@ defaultNodeInfo = NodeInfo
   , niNodeVersion            = "-"
   , niNodeCommit             = "-"
   , niNodeShortCommit        = "-"
+<<<<<<< HEAD
   , niNodePlatform           = "?"
   , niUpTime                 = UTCTime (ModifiedJulianDay 0) 0
   , niUpTimeLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
+=======
+  , niUpTime                 = 0
+  , niUpTimeLastUpdate       = 0
+>>>>>>> CAD-806: Live monitoring, monotonic time instead of UTCTime.
   , niEpoch                  = 0
-  , niEpochLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , niEpochLastUpdate        = 0
   , niSlot                   = 0
-  , niSlotLastUpdate         = UTCTime (ModifiedJulianDay 0) 0
+  , niSlotLastUpdate         = 0
   , niBlocksNumber           = 0
-  , niBlocksNumberLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niBlocksNumberLastUpdate = 0
   , niChainDensity           = 0.0
-  , niChainDensityLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , niChainDensityLastUpdate = 0
   , niTxsProcessed           = 0
   , niPeersNumber            = 0
   , niPeersInfo              = []
@@ -188,11 +198,11 @@ defaultNodeMetrics = NodeMetrics
   , nmMemoryMax                 = 0.0
   , nmMemoryMaxTotal            = 200.0
   , nmMemoryPercent             = 0.0
-  , nmMemoryLastUpdate          = UTCTime (ModifiedJulianDay 0) 0
+  , nmMemoryLastUpdate          = 0
   , nmCPUPercent                = 0.5
   , nmCPULast                   = 0
   , nmCPUNs                     = 10000
-  , nmCPULastUpdate             = UTCTime (ModifiedJulianDay 0) 0
+  , nmCPULastUpdate             = 0
   , nmDiskUsageR                = 0.0
   , nmDiskUsageRMax             = 0.0
   , nmDiskUsageRMaxTotal        = 0.0
@@ -200,7 +210,7 @@ defaultNodeMetrics = NodeMetrics
   , nmDiskUsageRLast            = 0
   , nmDiskUsageRNs              = 10000
   , nmDiskUsageRAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
-  , nmDiskUsageRLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageRLastUpdate      = 0
   , nmDiskUsageW                = 0.0
   , nmDiskUsageWMax             = 0.0
   , nmDiskUsageWMaxTotal        = 0.0
@@ -208,33 +218,33 @@ defaultNodeMetrics = NodeMetrics
   , nmDiskUsageWLast            = 0
   , nmDiskUsageWNs              = 10000
   , nmDiskUsageWAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
-  , nmDiskUsageWLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageWLastUpdate      = 0
   , nmNetworkUsageIn            = 0.0
   , nmNetworkUsageInPercent     = 0.0
   , nmNetworkUsageInMax         = 0.0
   , nmNetworkUsageInMaxTotal    = 0.0
   , nmNetworkUsageInLast        = 0
   , nmNetworkUsageInNs          = 10000
-  , nmNetworkUsageInLastUpdate  = UTCTime (ModifiedJulianDay 0) 0
+  , nmNetworkUsageInLastUpdate  = 0
   , nmNetworkUsageOut           = 0.0
   , nmNetworkUsageOutPercent    = 0.0
   , nmNetworkUsageOutMax        = 0.0
   , nmNetworkUsageOutMaxTotal   = 0.0
   , nmNetworkUsageOutLast       = 0
   , nmNetworkUsageOutNs         = 10000
-  , nmNetworkUsageOutLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , nmNetworkUsageOutLastUpdate = 0
   , nmRTSMemoryAllocated        = 1.0
   , nmRTSMemoryUsed             = 0.1
   , nmRTSMemoryUsedPercent      = 1.0
-  , nmRTSMemoryLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSMemoryLastUpdate       = 0
   , nmRTSGcCpu                  = 0.1
-  , nmRTSGcCpuLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcCpuLastUpdate        = 0
   , nmRTSGcElapsed              = 0.1
-  , nmRTSGcElapsedLastUpdate    = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcElapsedLastUpdate    = 0
   , nmRTSGcNum                  = 0
-  , nmRTSGcNumLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcNumLastUpdate        = 0
   , nmRTSGcMajorNum             = 0
-  , nmRTSGcMajorNumLastUpdate   = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcMajorNumLastUpdate   = 0
   }
  where
   maxBytesPerTx = 4096 :: Word64

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -93,56 +93,63 @@ data NodeInfo = NodeInfo
   } deriving Show
 
 data NodeMetrics = NodeMetrics
-  { nmMempoolTxsNumber        :: !Word64
-  , nmMempoolTxsPercent       :: !Double
-  , nmMempoolBytes            :: !Word64
-  , nmMempoolBytesPercent     :: !Double
-  , nmMempoolCapacity         :: !Word64
-  , nmMempoolCapacityBytes    :: !Word64
-  , nmMemory                  :: !Double
-  , nmMemoryMax               :: !Double
-  , nmMemoryMaxTotal          :: !Double
-  , nmMemoryPercent           :: !Double
-  , nmCPUPercent              :: !Double
-  , nmCPULast                 :: !Integer
-  , nmCPUNs                   :: !Word64
-  , nmDiskUsageR              :: !Double
-  , nmDiskUsageRMax           :: !Double
-  , nmDiskUsageRMaxTotal      :: !Double
-  , nmDiskUsageRPercent       :: !Double
-  , nmDiskUsageRLast          :: !Word64
-  , nmDiskUsageRNs            :: !Word64
-  , nmDiskUsageRAdaptTime     :: !UTCTime
-  , nmDiskUsageW              :: !Double
-  , nmDiskUsageWMax           :: !Double
-  , nmDiskUsageWMaxTotal      :: !Double
-  , nmDiskUsageWPercent       :: !Double
-  , nmDiskUsageWLast          :: !Word64
-  , nmDiskUsageWNs            :: !Word64
-  , nmDiskUsageWAdaptTime     :: !UTCTime
-  , nmNetworkUsageIn          :: !Double
-  , nmNetworkUsageInPercent   :: !Double
-  , nmNetworkUsageInMax       :: !Double
-  , nmNetworkUsageInMaxTotal  :: !Double
-  , nmNetworkUsageInLast      :: !Word64
-  , nmNetworkUsageInNs        :: !Word64
-  , nmNetworkUsageOut         :: !Double
-  , nmNetworkUsageOutPercent  :: !Double
-  , nmNetworkUsageOutMax      :: !Double
-  , nmNetworkUsageOutMaxTotal :: !Double
-  , nmNetworkUsageOutLast     :: !Word64
-  , nmNetworkUsageOutNs       :: !Word64
-  , nmRTSMemoryAllocated      :: !Double
-  , nmRTSMemoryUsed           :: !Double
-  , nmRTSMemoryUsedPercent    :: !Double
-  , nmRTSGcCpu                :: !Double
-  , nmRTSGcCpuLastUpdate      :: !UTCTime
-  , nmRTSGcElapsed            :: !Double
-  , nmRTSGcElapsedLastUpdate  :: !UTCTime
-  , nmRTSGcNum                :: !Integer
-  , nmRTSGcNumLastUpdate      :: !UTCTime
-  , nmRTSGcMajorNum           :: !Integer
-  , nmRTSGcMajorNumLastUpdate :: !UTCTime
+  { nmMempoolTxsNumber          :: !Word64
+  , nmMempoolTxsPercent         :: !Double
+  , nmMempoolBytes              :: !Word64
+  , nmMempoolBytesPercent       :: !Double
+  , nmMempoolCapacity           :: !Word64
+  , nmMempoolCapacityBytes      :: !Word64
+  , nmMemory                    :: !Double
+  , nmMemoryMax                 :: !Double
+  , nmMemoryMaxTotal            :: !Double
+  , nmMemoryPercent             :: !Double
+  , nmMemoryLastUpdate          :: !UTCTime
+  , nmCPUPercent                :: !Double
+  , nmCPULast                   :: !Integer
+  , nmCPUNs                     :: !Word64
+  , nmCPULastUpdate             :: !UTCTime
+  , nmDiskUsageR                :: !Double
+  , nmDiskUsageRMax             :: !Double
+  , nmDiskUsageRMaxTotal        :: !Double
+  , nmDiskUsageRPercent         :: !Double
+  , nmDiskUsageRLast            :: !Word64
+  , nmDiskUsageRNs              :: !Word64
+  , nmDiskUsageRAdaptTime       :: !UTCTime
+  , nmDiskUsageRLastUpdate      :: !UTCTime
+  , nmDiskUsageW                :: !Double
+  , nmDiskUsageWMax             :: !Double
+  , nmDiskUsageWMaxTotal        :: !Double
+  , nmDiskUsageWPercent         :: !Double
+  , nmDiskUsageWLast            :: !Word64
+  , nmDiskUsageWNs              :: !Word64
+  , nmDiskUsageWAdaptTime       :: !UTCTime
+  , nmDiskUsageWLastUpdate      :: !UTCTime
+  , nmNetworkUsageIn            :: !Double
+  , nmNetworkUsageInPercent     :: !Double
+  , nmNetworkUsageInMax         :: !Double
+  , nmNetworkUsageInMaxTotal    :: !Double
+  , nmNetworkUsageInLast        :: !Word64
+  , nmNetworkUsageInNs          :: !Word64
+  , nmNetworkUsageInLastUpdate  :: !UTCTime
+  , nmNetworkUsageOut           :: !Double
+  , nmNetworkUsageOutPercent    :: !Double
+  , nmNetworkUsageOutMax        :: !Double
+  , nmNetworkUsageOutMaxTotal   :: !Double
+  , nmNetworkUsageOutLast       :: !Word64
+  , nmNetworkUsageOutNs         :: !Word64
+  , nmNetworkUsageOutLastUpdate :: !UTCTime
+  , nmRTSMemoryAllocated        :: !Double
+  , nmRTSMemoryUsed             :: !Double
+  , nmRTSMemoryUsedPercent      :: !Double
+  , nmRTSMemoryLastUpdate       :: !UTCTime
+  , nmRTSGcCpu                  :: !Double
+  , nmRTSGcCpuLastUpdate        :: !UTCTime
+  , nmRTSGcElapsed              :: !Double
+  , nmRTSGcElapsedLastUpdate    :: !UTCTime
+  , nmRTSGcNum                  :: !Integer
+  , nmRTSGcNumLastUpdate        :: !UTCTime
+  , nmRTSGcMajorNum             :: !Integer
+  , nmRTSGcMajorNumLastUpdate   :: !UTCTime
   } deriving Show
 
 defaultNodesState
@@ -209,56 +216,63 @@ defaultNodeInfo = NodeInfo
 
 defaultNodeMetrics :: NodeMetrics
 defaultNodeMetrics = NodeMetrics
-  { nmMempoolTxsNumber        = 0
-  , nmMempoolTxsPercent       = 0.0
-  , nmMempoolBytes            = 0
-  , nmMempoolBytesPercent     = 0.0
-  , nmMempoolCapacity         = 200
-  , nmMempoolCapacityBytes    = 200 * maxBytesPerTx
-  , nmMemory                  = 0.0
-  , nmMemoryMax               = 0.0
-  , nmMemoryMaxTotal          = 200.0
-  , nmMemoryPercent           = 0.0
-  , nmCPUPercent              = 0.5
-  , nmCPULast                 = 0
-  , nmCPUNs                   = 10000
-  , nmDiskUsageR              = 0.0
-  , nmDiskUsageRMax           = 0.0
-  , nmDiskUsageRMaxTotal      = 0.0
-  , nmDiskUsageRPercent       = 0.0
-  , nmDiskUsageRLast          = 0
-  , nmDiskUsageRNs            = 10000
-  , nmDiskUsageRAdaptTime     = UTCTime (ModifiedJulianDay 0) 0
-  , nmDiskUsageW              = 0.0
-  , nmDiskUsageWMax           = 0.0
-  , nmDiskUsageWMaxTotal      = 0.0
-  , nmDiskUsageWPercent       = 0.0
-  , nmDiskUsageWLast          = 0
-  , nmDiskUsageWNs            = 10000
-  , nmDiskUsageWAdaptTime     = UTCTime (ModifiedJulianDay 0) 0
-  , nmNetworkUsageIn          = 0.0
-  , nmNetworkUsageInPercent   = 0.0
-  , nmNetworkUsageInMax       = 0.0
-  , nmNetworkUsageInMaxTotal  = 0.0
-  , nmNetworkUsageInLast      = 0
-  , nmNetworkUsageInNs        = 10000
-  , nmNetworkUsageOut         = 0.0
-  , nmNetworkUsageOutPercent  = 0.0
-  , nmNetworkUsageOutMax      = 0.0
-  , nmNetworkUsageOutMaxTotal = 0.0
-  , nmNetworkUsageOutLast     = 0
-  , nmNetworkUsageOutNs       = 10000
-  , nmRTSMemoryAllocated      = 1.0
-  , nmRTSMemoryUsed           = 0.1
-  , nmRTSMemoryUsedPercent    = 1.0
-  , nmRTSGcCpu                = 0.1
-  , nmRTSGcCpuLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
-  , nmRTSGcElapsed            = 0.1
-  , nmRTSGcElapsedLastUpdate  = UTCTime (ModifiedJulianDay 0) 0
-  , nmRTSGcNum                = 0
-  , nmRTSGcNumLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
-  , nmRTSGcMajorNum           = 0
-  , nmRTSGcMajorNumLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  { nmMempoolTxsNumber          = 0
+  , nmMempoolTxsPercent         = 0.0
+  , nmMempoolBytes              = 0
+  , nmMempoolBytesPercent       = 0.0
+  , nmMempoolCapacity           = 200
+  , nmMempoolCapacityBytes      = 200 * maxBytesPerTx
+  , nmMemory                    = 0.0
+  , nmMemoryMax                 = 0.0
+  , nmMemoryMaxTotal            = 200.0
+  , nmMemoryPercent             = 0.0
+  , nmMemoryLastUpdate          = UTCTime (ModifiedJulianDay 0) 0
+  , nmCPUPercent                = 0.5
+  , nmCPULast                   = 0
+  , nmCPUNs                     = 10000
+  , nmCPULastUpdate             = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageR                = 0.0
+  , nmDiskUsageRMax             = 0.0
+  , nmDiskUsageRMaxTotal        = 0.0
+  , nmDiskUsageRPercent         = 0.0
+  , nmDiskUsageRLast            = 0
+  , nmDiskUsageRNs              = 10000
+  , nmDiskUsageRAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageRLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageW                = 0.0
+  , nmDiskUsageWMax             = 0.0
+  , nmDiskUsageWMaxTotal        = 0.0
+  , nmDiskUsageWPercent         = 0.0
+  , nmDiskUsageWLast            = 0
+  , nmDiskUsageWNs              = 10000
+  , nmDiskUsageWAdaptTime       = UTCTime (ModifiedJulianDay 0) 0
+  , nmDiskUsageWLastUpdate      = UTCTime (ModifiedJulianDay 0) 0
+  , nmNetworkUsageIn            = 0.0
+  , nmNetworkUsageInPercent     = 0.0
+  , nmNetworkUsageInMax         = 0.0
+  , nmNetworkUsageInMaxTotal    = 0.0
+  , nmNetworkUsageInLast        = 0
+  , nmNetworkUsageInNs          = 10000
+  , nmNetworkUsageInLastUpdate  = UTCTime (ModifiedJulianDay 0) 0
+  , nmNetworkUsageOut           = 0.0
+  , nmNetworkUsageOutPercent    = 0.0
+  , nmNetworkUsageOutMax        = 0.0
+  , nmNetworkUsageOutMaxTotal   = 0.0
+  , nmNetworkUsageOutLast       = 0
+  , nmNetworkUsageOutNs         = 10000
+  , nmNetworkUsageOutLastUpdate = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSMemoryAllocated        = 1.0
+  , nmRTSMemoryUsed             = 0.1
+  , nmRTSMemoryUsedPercent      = 1.0
+  , nmRTSMemoryLastUpdate       = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcCpu                  = 0.1
+  , nmRTSGcCpuLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcElapsed              = 0.1
+  , nmRTSGcElapsedLastUpdate    = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcNum                  = 0
+  , nmRTSGcNumLastUpdate        = UTCTime (ModifiedJulianDay 0) 0
+  , nmRTSGcMajorNum             = 0
+  , nmRTSGcMajorNumLastUpdate   = UTCTime (ModifiedJulianDay 0) 0
   }
  where
   maxBytesPerTx = 4096 :: Word64

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
@@ -134,18 +134,18 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
               _ -> return currentNodesState
            | "cardano.node-metrics" `T.isInfixOf` aName ->
             case aContent of
-              LogValue "RTS.maxUsedMemBytes" (Bytes bytesAllocated) ->
-                nodesStateWith $ updateRTSBytesAllocated ns bytesAllocated
-              LogValue "RTS.gcLiveBytes" (Bytes usedMemBytes) ->
-                nodesStateWith $ updateRTSBytesUsed ns usedMemBytes
+              LogValue "RTS.bytesAllocated" (Bytes bytesAllocated) ->
+                nodesStateWith $ updateBytesAllocated ns bytesAllocated
+              LogValue "RTS.usedMemBytes" (Bytes usedMemBytes) ->
+                nodesStateWith $ updateBytesUsed ns usedMemBytes
               LogValue "RTS.gcCpuNs" (Nanoseconds gcCpuNs) ->
-                nodesStateWith $ updateGcCpuNs ns gcCpuNs
+                nodesStateWith $ updateGcCpuNs ns gcCpuNs now
               LogValue "RTS.gcElapsedNs" (Nanoseconds gcElapsedNs) ->
-                nodesStateWith $ updateGcElapsedNs ns gcElapsedNs
+                nodesStateWith $ updateGcElapsedNs ns gcElapsedNs now
               LogValue "RTS.gcNum" (PureI gcNum) ->
-                nodesStateWith $ updateGcNum ns gcNum
+                nodesStateWith $ updateGcNum ns gcNum now
               LogValue "RTS.gcMajorNum" (PureI gcMajorNum) ->
-                nodesStateWith $ updateGcMajorNum ns gcMajorNum
+                nodesStateWith $ updateGcMajorNum ns gcMajorNum now
               _ -> return currentNodesState
            | "cardano.node.BlockFetchDecision.peersList" `T.isInfixOf` aName ->
             case aContent of
@@ -180,13 +180,13 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
            | otherwise ->
             case aContent of
               LogValue "density" (PureD density) ->
-                nodesStateWith $ updateChainDensity ns density
+                nodesStateWith $ updateChainDensity ns density now
               LogValue "blockNum" (PureI blockNum) ->
-                nodesStateWith $ updateBlocksNumber ns blockNum
+                nodesStateWith $ updateBlocksNumber ns blockNum now
               LogValue "slotInEpoch" (PureI slotNum) ->
-                nodesStateWith $ updateSlotInEpoch ns slotNum
+                nodesStateWith $ updateSlotInEpoch ns slotNum now
               LogValue "epoch" (PureI epoch) ->
-                nodesStateWith $ updateEpoch ns epoch
+                nodesStateWith $ updateEpoch ns epoch now
               _ -> return currentNodesState
       Nothing ->
         -- This is a problem, because it means that configuration is unexpected one:
@@ -209,7 +209,12 @@ itIsErrorMessage aMeta =
 updateNodeUpTime :: NodeState -> Word64 -> NodeState
 updateNodeUpTime ns upTimeInNs = ns { nsInfo = newNi }
  where
-  newNi = currentNi { niUpTime = upTime }
+  newNi =
+    currentNi
+      { niStartTime = startTime
+      , niUpTime    = upTime
+      , niUpTimeLastUpdate = now
+      }
   currentNi = nsInfo ns
   upTimeInSec = fromIntegral upTimeInNs / 1000000000
   -- We show up time as time with seconds, so we don't need fractions of second.
@@ -548,36 +553,46 @@ updateRTSBytesUsed ns usedMemBytes = ns { nsMetrics = newNm }
   currentNm = nsMetrics ns
   mBytes    = fromIntegral usedMemBytes / 1024 / 1024 :: Double
 
-updateGcCpuNs :: NodeState -> Word64 -> NodeState
-updateGcCpuNs ns gcCpuNs = ns { nsMetrics = newNm }
+updateGcCpuNs :: NodeState -> Word64 -> UTCTime -> NodeState
+updateGcCpuNs ns gcCpuNs now = ns { nsMetrics = newNm }
  where
-  newNm     = currentNm { nmRTSGcCpu = seconds }
+  newNm     = currentNm { nmRTSGcCpu = seconds
+                        , nmRTSGcCpuLastUpdate = now
+                        }
   currentNm = nsMetrics ns
   seconds   = (fromIntegral gcCpuNs) / 1000000000 :: Double
 
-updateGcElapsedNs :: NodeState -> Word64 -> NodeState
-updateGcElapsedNs ns gcElapsedNs = ns { nsMetrics = newNm }
+updateGcElapsedNs :: NodeState -> Word64 -> UTCTime -> NodeState
+updateGcElapsedNs ns gcElapsedNs now = ns { nsMetrics = newNm }
  where
-  newNm     = currentNm { nmRTSGcElapsed = seconds }
+  newNm     = currentNm { nmRTSGcElapsed = seconds
+                        , nmRTSGcElapsedLastUpdate = now
+                        }
   currentNm = nsMetrics ns
   seconds   = (fromIntegral gcElapsedNs) / 1000000000 :: Double
 
-updateGcNum :: NodeState -> Integer -> NodeState
-updateGcNum ns gcNum = ns { nsMetrics = newNm }
+updateGcNum :: NodeState -> Integer -> UTCTime -> NodeState
+updateGcNum ns gcNum now = ns { nsMetrics = newNm }
  where
-  newNm     = currentNm { nmRTSGcNum = gcNum }
+  newNm     = currentNm { nmRTSGcNum = gcNum
+                        , nmRTSGcNumLastUpdate = now
+                        }
   currentNm = nsMetrics ns
 
-updateGcMajorNum :: NodeState -> Integer -> NodeState
-updateGcMajorNum ns gcMajorNum = ns { nsMetrics = newNm }
+updateGcMajorNum :: NodeState -> Integer -> UTCTime -> NodeState
+updateGcMajorNum ns gcMajorNum now = ns { nsMetrics = newNm }
  where
-  newNm     = currentNm { nmRTSGcMajorNum = gcMajorNum }
+  newNm     = currentNm { nmRTSGcMajorNum = gcMajorNum
+                        , nmRTSGcMajorNumLastUpdate = now
+                        }
   currentNm = nsMetrics ns
 
-updateChainDensity :: NodeState -> Double -> NodeState
-updateChainDensity ns density = ns { nsInfo = newNi }
+updateChainDensity :: NodeState -> Double -> UTCTime -> NodeState
+updateChainDensity ns density now = ns { nsInfo = newNi }
  where
-  newNi = (nsInfo ns) { niChainDensity = chainDensity }
+  newNi = (nsInfo ns) { niChainDensity = chainDensity
+                      , niChainDensityLastUpdate = now
+                      }
   chainDensity = 0.05 + density * 100.0
 
 updatePeersNumber :: NodeState -> Integer -> NodeState
@@ -585,17 +600,23 @@ updatePeersNumber ns peersNum = ns { nsInfo = newNi }
  where
   newNi = (nsInfo ns) { niPeersNumber = peersNum }
 
-updateBlocksNumber :: NodeState -> Integer -> NodeState
-updateBlocksNumber ns blockNum = ns { nsInfo = newNi }
+updateBlocksNumber :: NodeState -> Integer -> UTCTime -> NodeState
+updateBlocksNumber ns blockNum now = ns { nsInfo = newNi }
  where
-  newNi = (nsInfo ns) { niBlocksNumber = blockNum }
+  newNi = (nsInfo ns) { niBlocksNumber = blockNum 
+                      , niBlocksNumberLastUpdate = now
+                      }
 
-updateSlotInEpoch :: NodeState -> Integer -> NodeState
-updateSlotInEpoch ns slotNum = ns { nsInfo = newNi }
+updateSlotInEpoch :: NodeState -> Integer -> UTCTime -> NodeState
+updateSlotInEpoch ns slotNum now = ns { nsInfo = newNi }
  where
-  newNi = (nsInfo ns) { niSlot = slotNum }
+  newNi = (nsInfo ns) { niSlot = slotNum
+                      , niSlotLastUpdate = now
+                      }
 
-updateEpoch :: NodeState -> Integer -> NodeState
-updateEpoch ns epoch = ns { nsInfo = newNi }
+updateEpoch :: NodeState -> Integer -> UTCTime -> NodeState
+updateEpoch ns epoch now = ns { nsInfo = newNi }
  where
-  newNi = (nsInfo ns) { niEpoch = epoch }
+  newNi = (nsInfo ns) { niEpoch = epoch
+                      , niEpochLastUpdate = now
+                      }

--- a/cardano-rt-view/static/css/cardano-rt-view.css
+++ b/cardano-rt-view/static/css/cardano-rt-view.css
@@ -155,3 +155,182 @@ a:visited:hover {
     color: #999;
     font-weight: normal;
 }
+
+.ElRTSMemoryProgress {
+    background-color: #009688;
+    color: white;
+}
+
+.ElRTSMemoryProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElRTSMemoryProgressBox {
+    background-color: #8bc34a;
+}
+
+.ElRTSMemoryProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElMemoryProgress {
+    background-color: #009688;
+    color: white;
+}
+
+.ElMemoryProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElMemoryProgressBox {
+    background-color: #8bc34a;
+    color: white;
+}
+
+.ElMemoryProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElMempoolBytesProgress {
+    background-color: #009688;
+    color: white;
+}
+
+.ElMempoolBytesProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElMempoolBytesProgressBox {
+    background-color: #8bc34a;
+    color: white;
+}
+
+.ElMempoolBytesProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElMempoolTxsProgress {
+    background-color: #009688;
+    color: white;
+}
+
+.ElMempoolTxsProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElMempoolTxsProgressBox {
+    background-color: #8bc34a;
+    color: white;
+}
+
+.ElMempoolTxsProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElCPUProgress {
+    background-color: #3f51b5;
+    color: white;
+}
+
+.ElCPUProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElCPUProgressBox {
+    background-color: #00bcd4;
+    color: white;
+}
+
+.ElCPUProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElDiskReadProgress {
+    background-color: #ff5722;
+    color: white;
+}
+
+.ElDiskReadProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElDiskReadProgressBox {
+    background-color: #ffc107;
+    color: white;
+}
+
+.ElDiskReadProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElDiskWriteProgress {
+    background-color: #ff5722;
+    color: white;
+}
+
+.ElDiskWriteProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElDiskWriteProgressBox {
+    background-color: #ffc107;
+    color: white;
+}
+
+.ElDiskWriteProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElNetworkInProgress {
+    background-color: #9c27b0;
+    color: white;
+}
+
+.ElNetworkInProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElNetworkInProgressBox {
+    background-color: #ffdddd;
+    color: white;
+}
+
+.ElNetworkInProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}
+
+.ElNetworkOutProgress {
+    background-color: #9c27b0;
+    color: white;
+}
+
+.ElNetworkOutProgress-outdated {
+    background-color: #999;
+    color: #999 !important;
+}
+
+.ElNetworkOutProgressBox {
+    background-color: #ffdddd;
+    color: white;
+}
+
+.ElNetworkOutProgressBox-outdated {
+    background-color: #aaa;
+    color: #999 !important;
+}

--- a/cardano-rt-view/static/css/cardano-rt-view.css
+++ b/cardano-rt-view/static/css/cardano-rt-view.css
@@ -150,3 +150,8 @@ a:visited:hover {
 .node-port {
     padding-left: 10px;
 }
+
+.outdated-value {
+    color: #999;
+    font-weight: normal;
+}


### PR DESCRIPTION
Now each group of metrics has its "lifetime period". And if some metric wasn't received too long - the corresponding value in GUI will be marked as outdated: gray color with info title. If that metric will be received again - the corresponding value in GUI will be marked as up-to-date again.

There are new CLI arguments for each group's lifetime period.