### PR TITLE
CAD-992, CAD-974, CAD-1130, CAD-1241, CAD-1231: txgen: shelley support + single shared pool + cleaner submission + updates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
-  - label: hydra-eval-errors
-    command: 'nix-build ./nix -A iohkNix.hydraEvalErrors && ./result/bin/hydra-eval-errors.py'
-    agents:
-      system: x86_64-linux
+  # - label: hydra-eval-errors
+  #   command: 'nix-build ./nix -A iohkNix.hydraEvalErrors && ./result/bin/hydra-eval-errors.py'
+  #   agents:
+  #     system: x86_64-linux
 
   - label: 'check-cabal-project'
     command: 'nix-build ./nix -A iohkNix.checkCabalProject -o check-cabal-project.sh && ./check-cabal-project.sh'

--- a/cabal.project
+++ b/cabal.project
@@ -15,29 +15,29 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 46f296f8a9f3f497d9bd41e20c8398d2b5730c86
-  --sha256: 05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl
+  tag: f8a2da1edc2d1c5389c41d069ae9e2d8e848958a
+  --sha256: 05nv40b6p1mwfvfxpas7b5d470dniym4vpslnxqpj3i0w7qcicpb
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 46f296f8a9f3f497d9bd41e20c8398d2b5730c86
-  --sha256: 05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl
+  tag: f8a2da1edc2d1c5389c41d069ae9e2d8e848958a
+  --sha256: 05nv40b6p1mwfvfxpas7b5d470dniym4vpslnxqpj3i0w7qcicpb
   subdir: cardano-cli
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 46f296f8a9f3f497d9bd41e20c8398d2b5730c86
-  --sha256: 05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl
+  tag: f8a2da1edc2d1c5389c41d069ae9e2d8e848958a
+  --sha256: 05nv40b6p1mwfvfxpas7b5d470dniym4vpslnxqpj3i0w7qcicpb
   subdir: cardano-config
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 46f296f8a9f3f497d9bd41e20c8398d2b5730c86
-  --sha256: 05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl
+  tag: f8a2da1edc2d1c5389c41d069ae9e2d8e848958a
+  --sha256: 05nv40b6p1mwfvfxpas7b5d470dniym4vpslnxqpj3i0w7qcicpb
   subdir: cardano-node
 
 source-repository-package
@@ -321,6 +321,13 @@ source-repository-package
   location: https://github.com/input-output-hk/ouroboros-network
   tag: ceafa31844e6e9883d5d5634544045eab9c5f2e9
   --sha256: 08zkx4si4kb761n4hcmp1dmfppfgjm56z3flsdfd7qvm9kn4l78l
+  subdir: ouroboros-consensus-cardano
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: ceafa31844e6e9883d5d5634544045eab9c5f2e9
+  --sha256: 08zkx4si4kb761n4hcmp1dmfppfgjm56z3flsdfd7qvm9kn4l78l
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
@@ -329,13 +336,6 @@ source-repository-package
   tag: ceafa31844e6e9883d5d5634544045eab9c5f2e9
   --sha256: 08zkx4si4kb761n4hcmp1dmfppfgjm56z3flsdfd7qvm9kn4l78l
   subdir: ouroboros-consensus-shelley-test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: ceafa31844e6e9883d5d5634544045eab9c5f2e9
-  --sha256: 08zkx4si4kb761n4hcmp1dmfppfgjm56z3flsdfd7qvm9kn4l78l
-  subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
@@ -389,8 +389,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/well-typed/cborg.git
-  tag: 6886be5f7ca98fa44750ed5d44be6b84227aae67
-  --sha256: 0cknyvsn9nksxz2g07354yp2jb5wf81v7wfjrbw2js3b8hb5r6n0
+  tag: 42a83192749774268337258f4f94c97584b80ca6
+  --sha256: 1smjni26p14p41d1zjpk59jn28zfnpblin5rq6ipp4cjpjiril04
   subdir: cborg
 
 source-repository-package

--- a/cardano-tx-generator/app/cardano-tx-generator.hs
+++ b/cardano-tx-generator/app/cardano-tx-generator.hs
@@ -30,4 +30,4 @@ main = do
   txGenInfo :: ParserInfo GenerateTxs
   txGenInfo =
     info (parseCommand <**> helper)
-         (fullDesc <> header "cardano-tx-generator-byron - the transaction generator for Cardano's Byron node.")
+         (fullDesc <> header "cardano-tx-generator - the transaction generator for Cardano's Byron node.")

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -21,6 +21,7 @@ library
                        Cardano.Benchmarking.GeneratorTx.Submission
                        Cardano.Benchmarking.GeneratorTx.CLI.Parsers
                        Cardano.Benchmarking.GeneratorTx.CLI.Run
+                       Cardano.Benchmarking.Util
 
   other-modules:       Paths_cardano_tx_generator
 
@@ -28,15 +29,19 @@ library
                      , async
                      , base >=4.12 && <5
                      , bytestring
+                     , cardano-api
                      , cardano-config
+                     , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger
-                     -- , cardano-node
+                     , cardano-node
                      , cardano-prelude
+                     , cardano-shell
                      , contra-tracer
                      , cborg >= 0.2.2 && < 0.3
                      , containers
                      , directory
+                     , extra
                      , filepath
                      , formatting
                      , http-client
@@ -46,17 +51,22 @@ library
                      , iproute
                      , network
                      , network-mux
+                     , optics
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
+                     , ouroboros-consensus-shelley
                      , ouroboros-network
                      , ouroboros-network-framework
                      , safe-exceptions
                      , serialise
+                     , shelley-spec-ledger
+                     , split
                      , stm
                      , text
                      , time
+                     , time-compat
                      , tracer-transformers
                      , transformers
                      , transformers-except
@@ -79,9 +89,9 @@ library
                        -Wpartial-fields
                        -Wcompat
 
-executable cardano-tx-generator-byron
+executable cardano-tx-generator
   hs-source-dirs:      app
-  main-is:             cardano-tx-generator-byron.hs
+  main-is:             cardano-tx-generator.hs
   default-language:    Haskell2010
   ghc-options:         -threaded
                        -Wall

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -11,7 +11,7 @@ data TxGenError =
   -- ^ Error occurred while creating the target node address.
   | NeedMinimumThreeSigningKeyFiles ![FilePath]
   -- ^ Need at least 3 signing key files.
-  | TooSmallTPSRate !Float
+  | TooSmallTPSRate !Double
   -- ^ TPS is less than lower limit.
   | SecretKeyDeserialiseError !Text
   | SecretKeyReadError !Text

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -1,69 +1,116 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Benchmarking.GeneratorTx.Submission
-  ( ROEnv(..)
-  , RPCTxSubmission(..)
-  , TraceBenchTxSubmit(..)
+  ( TraceBenchTxSubmit(..)
   , TraceLowLevelSubmit (..)
-  , bulkSubmission
-  , submitTx
+  , ShelleyBlock
+  , BenchTraceConstraints
+  , Params(..)
+  , mkParamsByron
+  , mkParamsShelley
+  , paramsConfig
+  , trBase
+  , trTxSubmit
+  , trConnect
+  , trSubmitMux
+  , trLowLevel
+  , trN2N
+  , submitTx'
   , NodeToNodeSubmissionTrace(..)
+  , TPSRate(..)
+  , SubmissionParams(..)
+  , Submission
+  , SubmissionThreadReport
+  , mkSubmission
+  , mkSubmissionSummary
   , txSubmissionClient
+  , simpleTxFeeder
+  , tpsLimitedTxFeeder
   ) where
 
-import           Prelude (error, id)
+import           Prelude (fail)
 import           Cardano.Prelude hiding (ByteString, atomically, retry, threadDelay)
+import           Optics.Setter
+import           Optics.TH (makeFieldLabelsWith, noPrefixFieldLabels)
 
-import           Control.Exception (assert)
+import           Control.Arrow ((&&&))
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.STM (STM)
+import           Control.Concurrent.STM.TBQueue (TBQueue)
+import qualified Control.Concurrent.STM as STM
+import           Control.Monad (replicateM)
 import           Control.Monad.Class.MonadST (MonadST)
-import           Control.Monad.Class.MonadSTM (MonadSTM, TMVar, TVar,
-                   atomically, newEmptyTMVarM, putTMVar, readTVar, retry,
-                   takeTMVar, tryTakeTMVar)
 import qualified Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTime (MonadTime(..), Time, addTime,
-                   diffTime, getMonotonicTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
+import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Monad.Class.MonadThrow (MonadThrow)
 
 import           Data.Aeson (ToJSON (..), (.=))
 import qualified Data.Aeson as A
 import           Data.ByteString.Lazy (ByteString)
-import           Data.List.NonEmpty (fromList)
-import qualified Data.Sequence as Seq
-import qualified Data.Set as Set
+import qualified Data.List as L
+import qualified Data.List.Extra as L
+import qualified Data.List.NonEmpty as NE
 import           Data.String (String)
 import qualified Data.Text as T
-import           Data.Time.Clock (DiffTime)
+import           Data.Time.Clock
+                   ( DiffTime, NominalDiffTime, UTCTime)
+import qualified Data.Time.Clock as Clock
 import           Data.Void (Void)
 
 import           Cardano.BM.Tracing
 import           Cardano.BM.Data.Tracer (emptyObject, mkObject, trStructured)
 import           Control.Tracer (Tracer, traceWith)
 
+import qualified Codec.CBOR.Term as CBOR
+import           Network.Mux (MuxTrace(..), WithMuxBearer(..))
+import           Ouroboros.Network.NodeToClient (ConnectionId, Handshake, LocalAddress, TraceSendRecv)
+
+import           Cardano.TracingOrphanInstances.Byron()
+import           Cardano.TracingOrphanInstances.Common()
+import           Cardano.TracingOrphanInstances.Consensus()
+import           Cardano.TracingOrphanInstances.Mock()
+import           Cardano.TracingOrphanInstances.Network()
+import           Cardano.TracingOrphanInstances.Shelley()
+
 import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
 import           Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool (GenTx)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import           Ouroboros.Consensus.Config (TopLevelConfig(..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
-                   ( GenTxId, HasTxId, txId, txInBlockSize)
+                   ( GenTxId, HasTxId, TxId, txId, txInBlockSize)
 import           Ouroboros.Consensus.Network.NodeToClient
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
                   (HasNetworkProtocolVersion (..), nodeToClientProtocolVersion, supportedNodeToClientVersions)
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import           Ouroboros.Consensus.Node.Run (RunNode(..))
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import           Ouroboros.Consensus.Util.Condense (Condense(..))
 
 import           Ouroboros.Network.Mux
                    ( MuxMode(..), OuroborosApplication(..),
@@ -85,314 +132,52 @@ import           Ouroboros.Network.NodeToClient (IOManager,
                                                  foldMapVersions,
                                                  versionedNodeToClientProtocols)
 import qualified Ouroboros.Network.NodeToClient as NodeToClient
-import           Ouroboros.Network.NodeToClient.Version (NodeToClientVersion)
 
+import           Cardano.Config.Logging (LoggingLayer (..))
 import           Cardano.Config.Types (SocketPath(..))
 
--- | Bulk submisson of transactions.
---
---   This is intended to be used as a seperate process that interfaces
---   between some form of transaction generation mechanism
---   (e.g. benchmarking) and the local Ouroboros protocol peer. It has
---   configurable latency hiding (number of transactions to try to
---   keep ahead of actual submission) and has tracing that both
---   reports observables related to transaction submission and whether
---   the tx generation is able to keep up the pace.
---
---   For the details of the protocol description see
---   `TxSubmission` and its associated instances
---   (e.g. `Message`).
-bulkSubmission
-  :: forall blk txid tx .
-     ( Ord txid
-     , Mempool.HasTxId tx
-     , RunNode blk
-     , tx ~ Mempool.GenTx blk, txid ~ Mempool.GenTxId blk)
-  => (ROEnv txid tx -> ROEnv txid tx)
-  -- changes to default settings
-  -> Tracer IO (TraceBenchTxSubmit txid)
-  -> TVar IO Bool
-  -- Set to True to indicate subsystem should terminate
-  -> TMVar IO [tx]
-  -- non-empty list of transactions to be forwarded,
-  -- empty list indicates terminating
-  -> TMVar IO (RPCTxSubmission IO txid tx)
-  -- the RPC variable shared with
-  -- `TxSubmission` local peer
-  -> IO ()
-bulkSubmission updEnv tr termVar txIn rpcIn =
-  -- liftIO $ putStrLn "bulkSubmission__0"
-  defaultRWEnv >>= evalStateT (go $ updEnv defaultROEnv)
- where
-  go :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
-  go env = do
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, env: " ++ show env
-    shutdown <- gets (\RWEnv{terminating, inFlight, notYetSent} ->
-                       terminating &&
-                       Seq.null inFlight &&
-                       Seq.null notYetSent)
-    if shutdown
-    then do -- terminating normally, inform local peer
-      -- check if remote peer is waiting on us
-      -- lift . traceWith tr . TraceBenchTxSubDebug $ "TERMINATING normally"
-      (opP, op) <- maybe (False, error "internal error")
-                         (\x -> (True,snd x)) <$> gets availableOp
---        liftIO $ putStrLn $ "TERMINATING normally, opP: " ++ show opP
-      lift . atomically $
-        if opP
-        then putTMVar op Nothing
-        else do
-          reqTxIds <- takeTMVar rpcIn -- no other message should occur as nothing is in flight
-          case reqTxIds of
-            RPCRequestTxIds _ resp -> putTMVar resp Nothing
-            _ -> return ()
-    else  -- process next interaction
-      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, process next interaction"
-      go1 env
+import           Cardano.Benchmarking.GeneratorTx.NodeToNode
+                    (SendRecvConnect,
+                     SendRecvTxSubmission)
 
-  go1 :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
-  go1 env = do
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, env: " ++ show env
-    terminating' <- gets terminating
-    notYetSent'  <- gets notYetSent
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, terminating': " ++ show terminating'
 
-    -- perform the blocking inquiry
-    (nowTerminating, newTxs, rpc) <- lift . atomically $ do
-      -- just looking for the transition to terminating here
-      term' <- if terminating'
-               then pure False
-               else readTVar termVar
-      -- try get more txs if our target backlog permits
-      txs' <- if Seq.length notYetSent' < targetBacklog env &&
-                 not terminating'
-              then tryTakeTMVar txIn
-              else pure Nothing
-      -- always willing to interact with local peer
-      rpc' <- tryTakeTMVar rpcIn
-      -- check there was some change to process
-      unless (term' || isJust txs' || isJust rpc') retry
-      -- treat empty input transaction list as equiv to
-      -- terminating
-      let (term,txs) =
-            case txs' of
-              Just x | null x
-                       -> (True, Nothing)
-              _        -> (term', txs')
-      pure (term || terminating', txs, rpc')
+{-------------------------------------------------------------------------------
+  First, cometh the basic types
+-------------------------------------------------------------------------------}
 
-    -- Update terminating, if needed
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, update terminating, if needed"
-    when (nowTerminating && not terminating') $
-      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, update terminating: True"
-      modify (\x -> x {terminating = True})
+-- | Transactions not yet even announced.
+newtype UnReqd  tx = UnReqd  [tx]
 
-    -- incorporate new transactions from the generator into
-    -- NotYetSent
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, incorporate new transactions from the generator into NotYetSent"
-    flip (maybe (pure ())) newTxs $ \xs -> do
-      let newTxs' = map (\x -> (getTxId x, x, getTxSize x)) xs
-      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, newTxs' size: " ++ show (length newTxs')
-      lift . traceWith tr . TraceBenchTxSubRecv $ map (\(a,_,_) -> a) newTxs'
-      modify (\x -> x {notYetSent = notYetSent x Seq.>< Seq.fromList newTxs'})
+-- | Transactions we decided to announce now.
+newtype ToAnnce tx = ToAnnce [tx]
 
-    -- if remote peer is waiting on us and there is something to be
-    -- sent: reply to the outstanding operation.
-    opP <- isJust <$> gets availableOp
-    haveStuffP <- (not . Seq.null) <$> gets notYetSent
-    when (opP && haveStuffP) $ processOp env
+-- | Transactions announced, yet unacked by peer.
+newtype UnAcked tx = UnAcked [tx]
 
-    -- process any interaction with the local peer
-    flip (maybe (pure ())) rpc $ processRPC env
+-- | Transactions acked by peer.
+newtype Acked tx = Acked [tx]
 
-    -- and recurse
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, recurse"
-    go env
+-- | Peer acknowledged this many txids of the outstanding window.
+newtype Ack = Ack Int deriving (Enum, Eq, Integral, Num, Ord, Real)
 
-  getTxId :: tx -> txid
-  getTxId = Mempool.txId
+-- | Peer requested this many txids to add to the outstanding window.
+newtype Req = Req Int deriving (Enum, Eq, Integral, Num, Ord, Real)
 
-  getTxSize :: tx -> TxSizeInBytes
-  getTxSize = txInBlockSize
+-- | This many Txs sent to peer.
+newtype Sent = Sent Int deriving (Enum, Eq, Generic, Integral, Num, Ord, Real, Show)
 
-  processOp :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
-  processOp env = do
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, env: " ++ show env
-    (window, op) <- (maybe (error "internal error")) id <$> gets availableOp
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, window: " ++ show window
-    (send,store) <- Seq.splitAt window <$> gets notYetSent
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, send size: " ++ show (length send)
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, store size: " ++ show (length store)
-    let send' = toList send
-    checkRateLimiter
-    lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
-    lift . atomically $ putTMVar op (Just $ [(a,c) | (a,_,c) <-  send'])
-    setRateLimiter env [ c | (_,_,c) <- send']
-    modify (\x -> x { availableOp = Nothing
-                    , inFlight    = inFlight x Seq.>< send
-                    , notYetSent  = store })
-    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, done."
+-- | This many Txs requested by the peer, but not available for sending.
+newtype Unav = Unav Int deriving (Enum, Eq, Generic, Integral, Num, Ord, Real, Show)
 
-  processRPC :: ROEnv txid tx -> RPCTxSubmission IO txid tx -> StateT (RWEnv IO txid tx) IO ()
-  processRPC env =
-    \case
-      RPCRequestTxs  txids resp -> do
-        -- lift . traceWith tr . TraceBenchTxSubDebug $ "processRPC, RPCRequestTxs"
-        lift . traceWith tr $ TraceBenchTxSubServReq txids
-        let txset = Set.fromList txids
-        result <- Seq.filter (\(x,_,_) -> Set.member x txset) <$> gets inFlight
-        lift . atomically $ putTMVar resp [b |(_,b,_) <- toList result]
+newtype TPSRate = TPSRate Double deriving (Eq, Generic, Ord, Show)
 
-      -- if blocking (deferred response) then the window has to be
-      -- greater than zero, otherwise you can never respond (as the
-      -- list has to be non empty)
-      RPCRequestTxIds (acked, window) resp -> assert (window > 0) $ do
-      -- prompt reply NOT expected (blocking)
-        -- lift . traceWith tr . TraceBenchTxSubDebug $ "processRPC, RPCRequestTxIds"
-        haveWork <- (not . Seq.null) <$> gets notYetSent
-        if haveWork
-        then do
-          checkRateLimiter
-          (send,store) <- Seq.splitAt (fromIntegral window) <$> gets notYetSent
-          let send' = toList send
-          lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
-          lift . atomically $ putTMVar resp (Just $ [(a,c) | (a,_,c) <-  send'])
-          setRateLimiter env [ c | (_,_,c) <- send']
-          modify (\x -> x { inFlight    = inFlight x Seq.>< send
-                            , notYetSent  = store })
-          noteBusy
-        else do
-          noteIdle
-          modify (\x -> x { availableOp = Just (fromIntegral window, resp)})
+instance ToJSON Sent
+instance ToJSON Unav
+instance ToJSON TPSRate
 
-        -- deal with acked txs
-        processAcks acked
-
-      RPCRequestTxIdsPromptly (acked, window) resp -> do
-      -- prompt reply expected
-        haveWork <- (not . Seq.null) <$> gets notYetSent
-        if haveWork
-        then do
-          checkRateLimiter
-          (send,store) <- Seq.splitAt (fromIntegral window) <$> gets notYetSent
-          let send' = toList send
-          lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
-          lift . atomically $ putTMVar resp [(a,c) | (a,_,c) <-  send']
-          setRateLimiter env [ c | (_,_,c) <- send']
-          modify (\x -> x { inFlight    = inFlight x Seq.>< send
-                          , notYetSent  = store })
-          noteBusy
-        else do
-          noteIdle
-          lift . atomically $ putTMVar resp []
-          modify (\x -> x { availableOp = Nothing })
-
-        -- deal with acked txs
-        processAcks acked
-
-  checkRateLimiter :: StateT (RWEnv IO txid tx) IO ()
-  checkRateLimiter = do
-    waitUntil <- gets proceedAfter
-    sleepFor <- (\x -> waitUntil `diffTime` x) <$> lift getMonotonicTime
-    when (sleepFor > 0) . lift $ do
-      traceWith tr $ TraceBenchTxSubRateLimit sleepFor
-      threadDelay sleepFor
-
-  setRateLimiter
-    :: ROEnv txid tx
-    -> [TxSizeInBytes]
-    -> StateT (RWEnv IO txid tx) IO ()
-  setRateLimiter env tls = do
-    let txLimit   = (* fromIntegral (length tls)) <$> txNumServiceTime  env
-        sizeLimit = (* fromIntegral (sum    tls)) <$> txSizeServiceTime env
-        limit     = max txLimit sizeLimit
-    flip (maybe (pure ())) limit $ \d -> do
-      liftIO . traceWith tr . TraceBenchTxSubDebug
-        $ "******* sleeping for " ++ show d
-      waitUntil <- (addTime d) <$> lift getMonotonicTime
-      modify (\x -> x { proceedAfter = waitUntil })
-
-  processAcks :: Word16 -> StateT (RWEnv IO txid tx) IO ()
-  processAcks acked  =  when (acked > 0) $ do
-    (done, left) <- (Seq.splitAt (fromIntegral acked)) <$> gets inFlight
-    lift . traceWith tr $ TraceBenchTxSubServAck [a | (a,_,_) <- toList done]
-    modify (\x -> x {inFlight = left})
-
-  noteIdle :: StateT (RWEnv IO txid tx) IO ()
-  noteIdle = do
---      liftIO $ putStrLn $ "noteIdle"
-    wasBusy <- (== Busy) <$> gets activityState
-    when wasBusy $ do
-      lift . traceWith tr $ TraceBenchTxSubIdle
---        liftIO $ putStrLn $ "noteIdle, Idle!"
-      modify (\x -> x { activityState = Idle})
-
-  noteBusy :: StateT (RWEnv IO txid tx) IO ()
-  noteBusy = do -- just can't get those memory write cycles out of my head
---      liftIO $ putStrLn $ "noteBusy"
-    wasIdle <- (== Idle) <$> gets activityState
-    when wasIdle $
---        liftIO $ putStrLn $ "noteBusy, Busy!"
-      modify (\x -> x { activityState = Busy})
-
-data ActivityState = Idle | Busy deriving (Eq)
-
--- | The readonly environment
-data ROEnv txid tx = ROEnv
-  { targetBacklog     :: Int -- ^ how many to try to keep in back pocket, >0
-  , txNumServiceTime  :: Maybe DiffTime -- ^ seconds per tx
-  , txSizeServiceTime :: Maybe DiffTime -- ^ seconds per tx octet
-  } deriving Show
-
-defaultROEnv :: ROEnv txid tx
-defaultROEnv = ROEnv
-  { targetBacklog     = 1
-  , txNumServiceTime  = Nothing
-  , txSizeServiceTime = Nothing
-  }
-
-data RWEnv m txid tx = RWEnv
-  { terminating     :: Bool
-  , activityState   :: ActivityState
-  , proceedAfter    :: Time
-  , availableOp     :: Maybe (Int, TMVar m (Maybe [(txid, TxSizeInBytes)]))
-  -- ^ the window and the response action
-  , inFlight
-  , notYetSent      :: Seq (txid, tx,  TxSizeInBytes)
-  }
-
-defaultRWEnv :: MonadTime m => m (RWEnv m txid tx)
-defaultRWEnv = do
-  now <- getMonotonicTime
-  pure $ RWEnv
-    { terminating     = False
-    , activityState   = Idle
-    , proceedAfter    = now
-    , availableOp     = Nothing
-    , inFlight        = mempty
-    , notYetSent      = mempty
-    }
-
--- | RPC interaction with `TxSubmission`
-data RPCTxSubmission m txid tx
-  = RPCRequestTxIdsPromptly (Word16, Word16) (TMVar m [(txid, TxSizeInBytes)])
-  -- ^ Request contains the acknowledged number and the size of the
-  --   open window. Response contains the list of transactions (that
-  --   can be empty - see the `TxSubmission` description of
-  --   `StBlockingStyle` for more details). A prompt response
-  --   is expected.
-  |  RPCRequestTxIds (Word16, Word16) (TMVar m (Maybe [(txid, TxSizeInBytes)]))
-  -- ^ Request contains the acknowledged number and the size of the
-  --   open window. Response contains the list of transactions (that
-  --   can not be empty - see the `TxSubmission` description
-  --   of `StBlockingStyle` for more details); `Nothing`
-  --   indicates no more transaction submissions and a clean
-  --   shutdown. A prompt response is not expected.
-  | RPCRequestTxs [txid] (TMVar m [tx])
-  -- ^ Request contains the list of transaction identifiers which are
-  --   returned in the response.
-
--- | Tracer
+{-------------------------------------------------------------------------------
+  Overall benchmarking trace
+-------------------------------------------------------------------------------}
 data TraceBenchTxSubmit txid
   = TraceBenchTxSubRecv [txid]
   -- ^ Received from generator.
@@ -410,20 +195,38 @@ data TraceBenchTxSubmit txid
   -- ^ Transactions the server implicitly dropped.
   | TraceBenchTxSubServOuts [txid]
   -- ^ Transactions outstanding.
+  | TraceBenchTxSubServUnav [txid]
+  -- ^ Transactions requested, but unavailable in the outstanding set.
+  | TraceBenchTxSubServFed [txid]
+  -- ^ Transactions fed by the feeder.
+  | TraceBenchTxSubServCons [txid]
+  -- ^ Transactions consumed by a submitter.
   | TraceBenchTxSubIdle
   -- ^ Remote peer requested new transasctions but none were
   --   available, generator not keeping up?
   | TraceBenchTxSubRateLimit DiffTime
   -- ^ Rate limiter bit, this much delay inserted to keep within
   --   configured rate.
+  | TraceBenchTxSubSummary SubmissionSummary
+  -- ^ SubmissionSummary.
   | TraceBenchTxSubDebug String
   | TraceBenchTxSubError Text
   deriving (Show)
 
-instance ToJSON (Mempool.GenTxId ByronBlock) where
+instance HasSeverityAnnotation (TraceBenchTxSubmit (Mempool.GenTxId blk))
+
+instance HasPrivacyAnnotation (TraceBenchTxSubmit (Mempool.GenTxId blk))
+
+instance Show (GenTxId blk) => Transformable Text IO (TraceBenchTxSubmit (Mempool.GenTxId blk)) where
+  -- transform to JSON Object
+  trTransformer = trStructured
+
+instance {-# OVERLAPS #-} Show (GenTxId blk)
+ => ToJSON (Mempool.GenTxId blk) where
   toJSON txid = A.String (T.pack $ show txid)
 
-instance ToObject (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock)) where
+instance Show (GenTxId blk)
+ => ToObject (TraceBenchTxSubmit (Mempool.GenTxId blk)) where
   toObject MinimalVerbosity _ = emptyObject -- do not log
   toObject NormalVerbosity t =
     case t of
@@ -434,8 +237,12 @@ instance ToObject (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock)) where
       TraceBenchTxSubServAck _   -> mkObject ["kind" .= A.String "TraceBenchTxSubServAck"]
       TraceBenchTxSubServDrop _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServDrop"]
       TraceBenchTxSubServOuts _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServOuts"]
+      TraceBenchTxSubServUnav _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServUnav"]
+      TraceBenchTxSubServFed _   -> mkObject ["kind" .= A.String "TraceBenchTxSubServFed"]
+      TraceBenchTxSubServCons _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServCons"]
       TraceBenchTxSubIdle        -> mkObject ["kind" .= A.String "TraceBenchTxSubIdle"]
       TraceBenchTxSubRateLimit _ -> mkObject ["kind" .= A.String "TraceBenchTxSubRateLimit"]
+      TraceBenchTxSubSummary _   -> mkObject ["kind" .= A.String "TraceBenchTxSubSummary"]
       TraceBenchTxSubDebug _     -> mkObject ["kind" .= A.String "TraceBenchTxSubDebug"]
       TraceBenchTxSubError _     -> mkObject ["kind" .= A.String "TraceBenchTxSubError"]
   toObject MaximalVerbosity t =
@@ -468,12 +275,28 @@ instance ToObject (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock)) where
         mkObject [ "kind"  .= A.String "TraceBenchTxSubServOuts"
                  , "txIds" .= toJSON txIds
                  ]
+      TraceBenchTxSubServUnav txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServUnav"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServFed txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServFed"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServCons txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServCons"
+                 , "txIds" .= toJSON txIds
+                 ]
       TraceBenchTxSubIdle ->
         mkObject [ "kind" .= A.String "TraceBenchTxSubIdle"
                  ]
       TraceBenchTxSubRateLimit limit ->
         mkObject [ "kind"  .= A.String "TraceBenchTxSubRateLimit"
                  , "limit" .= toJSON limit
+                 ]
+      TraceBenchTxSubSummary summary ->
+        mkObject [ "kind"    .= A.String "TraceBenchTxSubSummary"
+                 , "summary" .= toJSON summary
                  ]
       TraceBenchTxSubDebug s ->
         mkObject [ "kind" .= A.String "TraceBenchTxSubDebug"
@@ -484,26 +307,26 @@ instance ToObject (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock)) where
                  , "msg"  .= A.String s
                  ]
 
-instance ToObject (Mempool.GenTxId ByronBlock) where
+instance Show (GenTxId blk) => ToObject (Mempool.GenTxId blk) where
   toObject MinimalVerbosity _    = emptyObject -- do not log
   toObject NormalVerbosity _     = mkObject [ "kind" .= A.String "GenTxId"]
   toObject MaximalVerbosity txid = mkObject [ "kind" .= A.String "GenTxId"
                                             , "txId" .= toJSON txid
                                             ]
 
-instance HasSeverityAnnotation (Mempool.GenTxId ByronBlock)
+instance HasSeverityAnnotation (Mempool.GenTxId blk)
 
-instance HasPrivacyAnnotation (Mempool.GenTxId ByronBlock)
+instance HasPrivacyAnnotation (Mempool.GenTxId blk)
 
-instance Transformable Text IO (Mempool.GenTxId ByronBlock) where
+instance Show (GenTxId blk) => Transformable Text IO (Mempool.GenTxId blk) where
   trTransformer = trStructured
 
-instance HasSeverityAnnotation (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock))
-
-instance HasPrivacyAnnotation (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock))
-
-instance Transformable Text IO (TraceBenchTxSubmit (Mempool.GenTxId ByronBlock)) where
-  -- transform to JSON Object
+{-------------------------------------------------------------------------------
+  N2N submission trace
+-------------------------------------------------------------------------------}
+instance HasSeverityAnnotation NodeToNodeSubmissionTrace
+instance HasPrivacyAnnotation  NodeToNodeSubmissionTrace
+instance Transformable Text IO NodeToNodeSubmissionTrace where
   trTransformer = trStructured
 
 -- | Low-tevel tracer
@@ -546,28 +369,133 @@ instance (MonadIO m) => Transformable Text m TraceLowLevelSubmit where
   -- transform to JSON Object
   trTransformer = trStructured
 
-{-------------------------------------------------------------------------------
-  Main logic
--------------------------------------------------------------------------------}
+type ShelleyBlock = Shelley.ShelleyBlock TPraosStandardCrypto
 
-submitTx :: ( RunNode blk )
-         => IOManager
+data BenchTracers m blk =
+  BenchTracers
+  { btBase_       :: Trace  m Text
+  , btTxSubmit_   :: Tracer m (TraceBenchTxSubmit (GenTxId blk))
+  , btConnect_    :: Tracer m SendRecvConnect
+  , btSubmission_ :: Tracer m (SendRecvTxSubmission blk)
+  , btLowLevel_   :: Tracer m TraceLowLevelSubmit
+  , btN2N_        :: Tracer m NodeToNodeSubmissionTrace
+  }
+
+-- TODO: move out to Types.hs
+data Params blk where
+  ParamsByron
+    :: TopLevelConfig ByronBlock
+    -> BenchTracers IO ByronBlock
+    -> Params ByronBlock
+  ParamsShelley
+    :: TopLevelConfig ShelleyBlock
+    -> BenchTracers IO ShelleyBlock
+    -> Params ShelleyBlock
+
+tracers :: Params blk -> BenchTracers IO blk
+tracers (ParamsByron   _ trs) = trs
+tracers (ParamsShelley _ trs) = trs
+
+trBase       :: Params blk -> Trace IO Text
+trTxSubmit   :: Params blk -> Tracer IO (TraceBenchTxSubmit (GenTxId blk))
+trConnect    :: Params blk -> Tracer IO SendRecvConnect
+trSubmitMux  :: Params blk -> Tracer IO (SendRecvTxSubmission blk)
+trLowLevel   :: Params blk -> Tracer IO TraceLowLevelSubmit
+trN2N        :: Params blk -> Tracer IO NodeToNodeSubmissionTrace
+trBase       = btBase_       . tracers
+trTxSubmit   = btTxSubmit_   . tracers
+trConnect    = btConnect_    . tracers
+trSubmitMux  = btSubmission_ . tracers
+trLowLevel   = btLowLevel_   . tracers
+trN2N        = btN2N_        . tracers
+
+mkParamsByron
+  :: Consensus.Protocol IO ByronBlock Consensus.ProtocolRealPBFT -> LoggingLayer -> Params ByronBlock
+mkParamsByron ptcl = ParamsByron pInfoConfig . createTracers
+ where
+   ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
+
+mkParamsShelley
+  :: Consensus.Protocol IO ShelleyBlock Consensus.ProtocolRealTPraos -> LoggingLayer -> Params ShelleyBlock
+mkParamsShelley ptcl = ParamsShelley pInfoConfig . createTracers
+ where
+   ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
+
+type BenchTraceConstraints blk =
+  ( Condense (GenTxId blk)
+  , Show (GenTxId blk)
+  , ToJSON (TxId (GenTx blk))
+  , Transformable Text IO (TraceBenchTxSubmit (GenTxId blk))
+  , Transformable Text IO (SendRecvTxSubmission blk)
+  )
+
+createTracers
+  :: forall blk
+  .  BenchTraceConstraints blk
+  => LoggingLayer
+  -> BenchTracers IO blk
+createTracers loggingLayer =
+  BenchTracers
+    baseTrace
+    benchTracer
+    connectTracer
+    submitTracer
+    lowLevelSubmitTracer
+    n2nSubmitTracer
+ where
+  baseTrace :: Trace IO Text
+  baseTrace = llBasicTrace loggingLayer
+
+  tr :: Trace IO Text
+  tr = llAppendName loggingLayer "cli" baseTrace
+
+  tr' :: Trace IO Text
+  tr' = appendName "generate-txs" tr
+
+  benchTracer :: Tracer IO (TraceBenchTxSubmit (GenTxId blk))
+  benchTracer = toLogObjectVerbose (appendName "benchmark" tr')
+
+  connectTracer :: Tracer IO SendRecvConnect
+  connectTracer = toLogObjectVerbose (appendName "connect" tr')
+
+  submitTracer :: Tracer IO (SendRecvTxSubmission blk)
+  submitTracer = toLogObjectVerbose (appendName "submit" tr')
+
+  lowLevelSubmitTracer :: Tracer IO TraceLowLevelSubmit
+  lowLevelSubmitTracer = toLogObjectVerbose (appendName "llSubmit" tr')
+
+  n2nSubmitTracer :: Tracer IO NodeToNodeSubmissionTrace
+  n2nSubmitTracer = toLogObjectVerbose (appendName "submit2" tr')
+
+-- TODO: move out to Types.hs
+paramsConfig :: Params blk -> TopLevelConfig blk
+paramsConfig (ParamsByron   c _) = c
+paramsConfig (ParamsShelley c _) = c
+
+-- * Submission
+--
+submitTx' :: (RunNode blk)
+         => Params blk
+         -> IOManager
          -> SocketPath
-         -> TopLevelConfig blk
          -> GenTx blk
-         -> Tracer IO TraceLowLevelSubmit
          -> IO ()
-submitTx iocp sockpath cfg tx tracer =
+submitTx' p iocp sockpath tx =
     let path = unSocketPath sockpath
+        muxTracer :: Show peer => Tracer IO (WithMuxBearer peer MuxTrace)
+        muxTracer = toLogObject $ appendName "Mux" (trBase p)
+        handshakeTracer :: Tracer IO
+                           (WithMuxBearer (ConnectionId LocalAddress)
+                            (TraceSendRecv (Handshake NodeToClient.NodeToClientVersion CBOR.Term)))
+        handshakeTracer = toLogObject $ appendName "Handshake" (trBase p)
     in NodeToClient.connectTo
          (NodeToClient.localSnocket iocp path)
          NetworkConnectTracers {
-             nctMuxTracer       = nullTracer,
-             nctHandshakeTracer = nullTracer
+             nctMuxTracer       = muxTracer,
+             nctHandshakeTracer = handshakeTracer
            }
-         (localInitiatorNetworkApplication tracer cfg tx)
+         (localInitiatorNetworkApplication (trLowLevel p) (paramsConfig p) tx)
          path
-
 
 localInitiatorNetworkApplication
   :: forall blk m .
@@ -650,84 +578,320 @@ txSubmissionClientSingle tx = LocalTxSub.LocalTxSubmissionClient $
     pure $ LocalTxSub.SendMsgSubmitTx tx $ \mreject ->
       pure (LocalTxSub.SendMsgDone mreject)
 
-instance ToObject NodeToNodeSubmissionTrace where
-  toObject MinimalVerbosity = const emptyObject -- do not log
-  toObject _ = \case
-    ReqIdsBlocking  ack req -> mkObject [ "kind" .= A.String "ReqIdsBlocking"
-                                        , "ack"  .= A.toJSON ack
-                                        , "req"  .= A.toJSON req ]
-    IdsListBlocking sent    -> mkObject [ "kind" .= A.String "IdsListBlocking"
-                                        , "sent" .= A.toJSON sent ]
-    ReqIdsPrompt    ack req -> mkObject [ "kind" .= A.String "ReqIdsPrompt"
-                                        , "ack"  .= A.toJSON ack
-                                        , "req"  .= A.toJSON req ]
-    IdsListPrompt   sent    -> mkObject [ "kind" .= A.String "IdsListPrompt"
-                                        , "sent" .= A.toJSON sent ]
-    EndOfProtocol           -> mkObject [ "kind" .= A.String "EndOfProtocol" ]
-    ReqTxs          req     -> mkObject [ "kind" .= A.String "ReqTxs"
-                                        , "req"  .= A.toJSON req ]
-    TxList          sent    -> mkObject [ "kind" .= A.String "TxList"
-                                        , "sent" .= A.toJSON sent ]
-
-instance HasSeverityAnnotation NodeToNodeSubmissionTrace
-instance HasPrivacyAnnotation  NodeToNodeSubmissionTrace
-instance Transformable Text IO NodeToNodeSubmissionTrace where
-  trTransformer = trStructured
-
 data NodeToNodeSubmissionTrace
-  = ReqIdsBlocking  Word16 Word16
+  = ReqIdsBlocking  Ack Req
   | IdsListBlocking Int
 
-  | ReqIdsPrompt    Word16 Word16
+  | ReqIdsPrompt    Ack Req
   | IdsListPrompt   Int
 
   | ReqTxs          Int
   | TxList          Int
 
   | EndOfProtocol
+  | KThxBye
 
+instance ToObject NodeToNodeSubmissionTrace where
+  toObject MinimalVerbosity = const emptyObject -- do not log
+  toObject _ = \case
+    ReqIdsBlocking  (Ack ack) (Req req) ->
+                               mkObject [ "kind" .= A.String "ReqIdsBlocking"
+                                        , "ack"  .= A.toJSON ack
+                                        , "req"  .= A.toJSON req ]
+    IdsListBlocking sent    -> mkObject [ "kind" .= A.String "IdsListBlocking"
+                                        , "sent" .= A.toJSON sent ]
+    ReqIdsPrompt    (Ack ack) (Req req) ->
+                               mkObject [ "kind" .= A.String "ReqIdsPrompt"
+                                        , "ack"  .= A.toJSON ack
+                                        , "req"  .= A.toJSON req ]
+    IdsListPrompt   sent    -> mkObject [ "kind" .= A.String "IdsListPrompt"
+                                        , "sent" .= A.toJSON sent ]
+    EndOfProtocol           -> mkObject [ "kind" .= A.String "EndOfProtocol" ]
+    KThxBye                 -> mkObject [ "kind" .= A.String "KThxBye" ]
+    ReqTxs          req     -> mkObject [ "kind" .= A.String "ReqTxs"
+                                        , "req"  .= A.toJSON req ]
+    TxList          sent    -> mkObject [ "kind" .= A.String "TxList"
+                                        , "sent" .= A.toJSON sent ]
+
+{-------------------------------------------------------------------------------
+  Parametrisation & state
+-------------------------------------------------------------------------------}
+
+data SubmissionParams
+  = SubmissionParams
+    { spTps         :: !TPSRate
+    , spTargets     :: !Natural
+    , spQueueLen    :: !Natural
+    }
+
+data Submission (m :: Type -> Type) (blk :: Type)
+  = Submission
+    { sParams      :: !SubmissionParams
+    , sStartTime   :: !UTCTime
+    , sThreads     :: !Natural
+    , sTxSendQueue :: !(TBQueue (Maybe (GenTx blk)))
+    , sReportsRefs :: ![STM.TMVar SubmissionThreadReport]
+    , sTrace       :: !(Tracer m (TraceBenchTxSubmit (GenTxId blk)))
+    }
+
+mkSubmission
+  :: MonadIO m
+  => Tracer m (TraceBenchTxSubmit (GenTxId blk))
+  -> SubmissionParams
+  -> m (Submission m blk)
+mkSubmission sTrace sParams@SubmissionParams{spTargets=sThreads, spQueueLen} =
+ liftIO $ do
+  sStartTime <- Clock.getCurrentTime
+  sTxSendQueue <- STM.newTBQueueIO spQueueLen
+  sReportsRefs <- STM.atomically $ replicateM (fromIntegral sThreads) STM.newEmptyTMVar
+  pure Submission{..}
+
+{-------------------------------------------------------------------------------
+  Results
+-------------------------------------------------------------------------------}
+
+-- | Summary of a submission run.
+data SubmissionSummary
+  = SubmissionSummary
+    { ssTxSent        :: !Sent
+    , ssTxUnavailable :: !Unav
+    , ssElapsed       :: !NominalDiffTime
+    , ssEffectiveTps  :: !TPSRate
+    , ssThreadwiseTps :: ![TPSRate]
+    } deriving (Show, Generic)
+instance ToJSON SubmissionSummary
+
+data SubmissionThreadStats
+  = SubmissionThreadStats
+    { stsAcked         :: {-# UNPACK #-} !Ack
+    , stsSent          :: {-# UNPACK #-} !Sent
+    , stsUnavailable   :: {-# UNPACK #-} !Unav
+    }
+
+data SubmissionThreadReport
+  = SubmissionThreadReport
+    { strStats         :: !SubmissionThreadStats
+    , strThreadIndex   :: !Natural
+    , strEndOfProtocol :: !UTCTime
+    }
+makeFieldLabelsWith noPrefixFieldLabels ''SubmissionThreadStats
+
+mkSubmissionSummary
+  :: MonadIO m
+  => Submission m tx
+  -> m SubmissionSummary
+mkSubmissionSummary
+  Submission{ sStartTime, sReportsRefs}
+ = do
+  reports <- sequence (liftIO . STM.atomically . STM.readTMVar <$> sReportsRefs)
+  now <- liftIO Clock.getCurrentTime
+  let ssElapsed = Clock.diffUTCTime now sStartTime
+      ssTxSent@(Sent sent) = sum $ (stsSent . strStats) <$> reports
+      ssTxUnavailable = sum $ (stsUnavailable . strStats) <$> reports
+      ssEffectiveTps = txDiffTimeTPS sent ssElapsed
+      ssThreadwiseTps = threadReportTps <$> reports
+  pure SubmissionSummary{..}
+ where
+   txDiffTimeTPS :: Int -> NominalDiffTime -> TPSRate
+   txDiffTimeTPS n delta =
+     TPSRate $ realToFrac $ fromIntegral n / delta
+
+   threadReportTps :: SubmissionThreadReport -> TPSRate
+   threadReportTps
+     SubmissionThreadReport
+       { strStats=SubmissionThreadStats{stsAcked=Ack ack}, strEndOfProtocol } =
+         txDiffTimeTPS ack (Clock.diffUTCTime strEndOfProtocol sStartTime)
+
+{-------------------------------------------------------------------------------
+  Submission queue:  feeding and consumption
+-------------------------------------------------------------------------------}
+simpleTxFeeder
+  :: forall m blk
+  . (MonadIO m, HasTxId (GenTx blk))
+  => Submission m blk -> [GenTx blk] -> m ()
+simpleTxFeeder
+ Submission{sTrace, sThreads, sTxSendQueue} txs = do
+  foldM_ (const feedTx) () txs
+  -- Issue the termination notifications.
+  replicateM_ (fromIntegral sThreads) $
+    liftIO $ STM.atomically $ STM.writeTBQueue sTxSendQueue Nothing
+ where
+   feedTx :: GenTx blk -> m ()
+   feedTx tx = do
+     liftIO $ STM.atomically $ STM.writeTBQueue sTxSendQueue (Just tx)
+     traceWith sTrace $ TraceBenchTxSubServFed [txId tx]
+
+tpsLimitedTxFeeder
+  :: forall m blk
+  . (MonadIO m)
+  => Submission m blk -> [GenTx blk] -> m ()
+tpsLimitedTxFeeder
+ Submission{ sParams=SubmissionParams{spTps=TPSRate rate}
+           , sThreads
+           , sTxSendQueue } txs = do
+  now <- liftIO Clock.getCurrentTime
+  foldM_ feedTx (now, 0) txs
+  -- Issue the termination notifications.
+  replicateM_ (fromIntegral sThreads) .
+    liftIO . STM.atomically $ STM.writeTBQueue sTxSendQueue Nothing
+ where
+   feedTx :: (UTCTime, NominalDiffTime) -> GenTx blk -> m (UTCTime, NominalDiffTime)
+   feedTx (lastPreDelay, lastDelay) tx = do
+     liftIO . STM.atomically $ STM.writeTBQueue sTxSendQueue (Just tx)
+     now <- liftIO Clock.getCurrentTime
+     let targetDelay = realToFrac $ 1.0 / rate
+         loopCost = (now `Clock.diffUTCTime` lastPreDelay) - lastDelay
+         delay = targetDelay - loopCost
+     liftIO . threadDelay . ceiling $ (realToFrac delay * 1000000.0 :: Double)
+     pure (now, delay)
+
+consumeTxs
+  :: forall m blk
+  . (MonadIO m)
+  => Submission m blk -> Req -> m (Bool, UnReqd (GenTx blk))
+consumeTxs Submission{sTxSendQueue} req
+  = liftIO . STM.atomically $ go req []
+ where
+   go :: Req -> [GenTx blk] -> STM (Bool, UnReqd (GenTx blk))
+   go 0 acc = pure (False, UnReqd acc)
+   go n acc = STM.readTBQueue sTxSendQueue >>=
+              \case
+                Nothing -> pure (True, UnReqd acc)
+                Just tx -> go (n - 1) (tx:acc)
+
+{-------------------------------------------------------------------------------
+  The submission client
+-------------------------------------------------------------------------------}
 txSubmissionClient
   :: forall m block txid tx .
-     ( MonadSTM m
-     , txid ~ Mempool.GenTxId block
-     , tx ~ GenTx block)
-  => Tracer m NodeToNodeSubmissionTrace
-  -> TMVar m (RPCTxSubmission m txid tx)
+     ( MonadIO m
+     , Mempool.HasTxId (GenTx block)
+     , RunNode block
+     , txid ~ GenTxId block
+     , tx ~ GenTx block
+     )
+  => Tracer m (TraceBenchTxSubmit txid)
+  -> Tracer m NodeToNodeSubmissionTrace
+  -> Submission m block
+  -> Natural
+  -- This return type is forced by Ouroboros.Network.NodeToNode.connectTo
   -> TxSubmissionClient txid tx m ()
-txSubmissionClient tr tmvReq =
-  TxSubmissionClient $ pure client
+txSubmissionClient
+    bmtr tr
+    sub@Submission{sReportsRefs}
+    threadIx =
+  TxSubmissionClient $ do
+    pure $ client False (UnAcked []) (SubmissionThreadStats 0 0 0)
  where
-  client = ClientStIdle
-    { recvMsgRequestTxIds = \blocking acked window ->
-        case blocking of
-          TokBlocking -> do -- prompt reply not required
-            traceWith tr $ ReqIdsBlocking acked window
-            resp' <- newEmptyTMVarM
-            atomically . putTMVar tmvReq $
-              RPCRequestTxIds (acked, window) resp'
-            -- might be some delay at this point
-            r <- atomically $ takeTMVar resp'
-            case r of
-              Nothing  -> do
-                traceWith tr $ EndOfProtocol
-                pure $ SendMsgDone ()
-              Just txs -> do
-                traceWith tr $ IdsListPrompt (length txs)
-                pure $ SendMsgReplyTxIds (BlockingReply $ fromList txs) client
-          TokNonBlocking -> do -- prompt reply required
-            traceWith tr $ ReqIdsPrompt acked window
-            resp' <- newEmptyTMVarM
-            atomically . putTMVar tmvReq $
-              RPCRequestTxIdsPromptly (acked, window) resp'
-            txs <- atomically $ takeTMVar resp'
-            traceWith tr $ IdsListBlocking (length txs)
-            pure $ SendMsgReplyTxIds (NonBlockingReply txs) client
-    , recvMsgRequestTxs = \txids -> do
-        traceWith tr $ ReqTxs (length txids)
-        resp' <- newEmptyTMVarM
-        atomically $ putTMVar tmvReq $ RPCRequestTxs txids resp'
-        r <- atomically $ takeTMVar resp'
-        traceWith tr $ TxList (length r)
-        pure $ SendMsgReplyTxs r client
-    , recvMsgKThxBye = return ()
+   -- Nothing means we've ran out of things to either announce or send.
+   decideAnnouncement :: TokBlockingStyle a
+                      -> Ack -> UnReqd tx -> UnAcked tx
+                      -> m (Either Text (ToAnnce tx, UnAcked tx, Acked tx))
+   decideAnnouncement b (Ack ack) (UnReqd annNow) (UnAcked unAcked) =
+     if   tokIsBlocking b && ack /= length unAcked
+     then pure $ Left "decideAnnouncement: TokBlocking, but length unAcked != ack"
+     else pure $ Right (ToAnnce annNow, UnAcked newUnacked, Acked acked)
+       where
+         stillUnacked, newUnacked, acked :: [tx]
+         (stillUnacked, acked) = L.splitAtEnd ack unAcked
+         newUnacked = annNow <> stillUnacked
+
+   -- Sadly, we can't just return what we want, we instead have to
+   -- communicate via IORefs, because..
+   client :: Bool -> UnAcked tx -> SubmissionThreadStats
+          -- The () return type is forced by Ouroboros.Network.NodeToNode.connectTo
+          -> ClientStIdle (TxId (GenTx block)) (GenTx block) m ()
+   client done unAcked stats = ClientStIdle
+    { recvMsgRequestTxIds = \blocking (protoToAck -> ack) (protoToReq -> req)
+       -> do
+        traceWith tr $ reqIdsTrace ack req blocking
+
+        (exhausted, unReqd) <-
+          if done then pure $ (True, UnReqd [])
+          else consumeTxs sub req
+
+        r' <- decideAnnouncement blocking ack unReqd unAcked
+        (ann@(ToAnnce annNow), newUnacked@(UnAcked outs), Acked acked)
+          <- case r' of
+            Left e -> traceWith bmtr (TraceBenchTxSubError e)
+                      >> fail (T.unpack e)
+            Right x -> pure x
+
+        traceWith tr $ idListTrace ann blocking
+        traceWith bmtr $ TraceBenchTxSubServAnn  (txId <$> annNow)
+        traceWith bmtr $ TraceBenchTxSubServAck  (txId <$> acked)
+        traceWith bmtr $ TraceBenchTxSubServOuts (txId <$> outs)
+
+        let newStats = stats & over #stsAcked (+ ack)
+
+        case (NE.nonEmpty annNow, blocking) of
+          (Nothing, TokBlocking) -> do
+            traceWith tr EndOfProtocol
+            SendMsgDone <$> (submitThreadReport newStats
+                             -- The () return type is forced by
+                             --   Ouroboros.Network.NodeToNode.connectTo
+                             >> pure ())
+
+          (Just neAnnNow, TokBlocking) ->
+            pure $ SendMsgReplyTxIds
+                     (BlockingReply $ txToIdSizify <$> neAnnNow)
+                     (client exhausted newUnacked newStats)
+
+          (_, TokNonBlocking) -> do
+            pure $ SendMsgReplyTxIds
+                     (NonBlockingReply $ txToIdSizify <$> annNow)
+                     (client exhausted newUnacked newStats)
+
+    , recvMsgRequestTxs = \reqTxids -> do
+        traceWith tr $ ReqTxs (length reqTxids)
+        let UnAcked ua = unAcked
+            uaIds = txId <$> ua
+            (toSend, _retained) = L.partition ((`L.elem` reqTxids) . txId) ua
+            missIds = reqTxids L.\\ uaIds
+
+        traceWith tr $ TxList (length toSend)
+        traceWith bmtr $ TraceBenchTxSubServReq reqTxids
+        traceWith bmtr $ TraceBenchTxSubServOuts (txId <$> ua)
+        unless (L.null missIds) $
+          traceWith bmtr $ TraceBenchTxSubServUnav missIds
+        pure $ SendMsgReplyTxs toSend
+          (client done unAcked $
+            stats & over #stsSent        (+ (Sent $ length toSend))
+                  & over #stsUnavailable (+ (Unav $ length missIds)))
+    , recvMsgKThxBye = do
+        traceWith tr KThxBye
+        void $ submitThreadReport stats
+        pure ()
     }
+
+   submitThreadReport :: SubmissionThreadStats -> m SubmissionThreadReport
+   submitThreadReport strStats = do
+     strEndOfProtocol <- liftIO Clock.getCurrentTime
+     let strThreadIndex = threadIx
+         report = SubmissionThreadReport{..}
+     liftIO . STM.atomically $ STM.putTMVar (sReportsRefs L.!! fromIntegral threadIx) report
+     pure report
+
+   txToIdSizify :: tx -> (TxId tx, TxSizeInBytes)
+   txToIdSizify = txId &&& txInBlockSize
+
+   protoToAck :: Word16 -> Ack
+   protoToAck = Ack . fromIntegral
+
+   protoToReq :: Word16 -> Req
+   protoToReq = Req . fromIntegral
+
+   tokIsBlocking :: TokBlockingStyle a -> Bool
+   tokIsBlocking = \case
+     TokBlocking    -> True
+     TokNonBlocking -> False
+
+   reqIdsTrace :: Ack -> Req -> TokBlockingStyle a -> NodeToNodeSubmissionTrace
+   reqIdsTrace ack req = \case
+      TokBlocking    -> ReqIdsBlocking ack req
+      TokNonBlocking -> ReqIdsPrompt   ack req
+
+   idListTrace :: ToAnnce tx -> TokBlockingStyle a -> NodeToNodeSubmissionTrace
+   idListTrace (ToAnnce (length -> toAnn)) = \case
+      TokBlocking    -> IdsListBlocking toAnn
+      TokNonBlocking -> IdsListPrompt   toAnn

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -55,7 +55,7 @@ txSpendGenesisUTxOByronPBFT gc sk genAddr outs =
   where
     tx = UnsafeTx (pure txIn) outs txattrs
 
-    wit = signTxId (configProtocolMagicId gc) sk (Crypto.hash tx)
+    wit = signTxId (configProtocolMagicId gc) sk (Crypto.serializeCborHash tx)
 
     txIn :: UTxO.TxIn
     txIn  = genesisUTxOTxIn gc (Crypto.toVerification sk) genAddr

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Util.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Util.hs
@@ -1,0 +1,12 @@
+module Cardano.Benchmarking.Util
+  ( putStrLnStderr
+  ) where
+
+import           Cardano.Prelude
+
+import System.IO (stderr)
+
+-- | Unbuffered variant of 'putStrLn', that prints to stderr.
+--   Useful for debugging IO-related issues.
+putStrLnStderr :: Text -> IO ()
+putStrLnStderr = hPutStrLn stderr

--- a/default.nix
+++ b/default.nix
@@ -30,7 +30,7 @@ let
 
     # Grab the executable component of our package.
     inherit (haskellPackages.cardano-tx-generator.components.exes)
-      cardano-tx-generator-byron;
+      cardano-tx-generator;
     inherit (haskellPackages.cardano-rt-view.components.exes)
       cardano-rt-view-service;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohKNix = import sources.iohk-nix {};
+  iohkNix = import sources.iohk-nix {};
   haskellNix = import sources."haskell.nix";
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
@@ -16,16 +16,17 @@ let
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
     else (builtins.trace "Using IOHK default nixpkgs"
-      iohKNix.nixpkgs);
+      iohkNix.nixpkgs);
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohKNix.overlays.haskell-nix-extra
+    ++ iohkNix.overlays.haskell-nix-extra
+    ++ iohkNix.overlays.crypto
     # iohkNix: nix utilities and niv:
-    ++ iohKNix.overlays.iohkNix
+    ++ iohkNix.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; rec {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -9,19 +9,61 @@
 # GHC attribute name
 , compiler ? config.haskellNix.compiler or "ghc865"
 # Enable profiling
-, profiling ? config.haskellNix.profiling or true
+, profiling ? config.haskellNix.profiling or false
+# Version info, to be passed when not building from a git work tree
+, gitrev ? null
 }:
 let
 
-  # This creates the Haskell package set.
-  # https://input-output-hk.github.io/haskell.nix/user-guide/projects/
-  pkgSet = haskell-nix.cabalProject {
-    src = haskell-nix.haskellLib.cleanGit {
-      name = "cardano-benchmarking";
-      src = ../.;
-    };
+  src = haskell-nix.haskellLib.cleanGit {
+    name = __trace "haskell.nix profiling: ${if profiling then "true" else "false"}"
+           "cardano-benchmarking";
+    src = ../.;
+  };
+
+  projectPackages = lib.attrNames (haskell-nix.haskellLib.selectProjectPackages
+    (haskell-nix.cabalProject { inherit src; }));
+
+  pkgSet = haskell-nix.cabalProject  (lib.optionalAttrs stdenv.hostPlatform.isWindows {
+    # FIXME: without this deprecated attribute, db-converter fails to compile directory with:
+    # Encountered missing dependencies: unix >=2.5.1 && <2.9
     ghc = buildPackages.haskell-nix.compiler.${compiler};
+  } // {
+    inherit src;
+    #ghc = buildPackages.haskell-nix.compiler.${compiler};
+    pkg-def-extras = lib.optional stdenv.hostPlatform.isLinux (hackage: {
+      packages = {
+        "systemd" = (((hackage.systemd)."2.2.0").revisions).default;
+      };
+    });
     modules = [
+      { compiler.nix-name = compiler; }
+      # Allow reinstallation of Win32
+      { nonReinstallablePkgs =
+        [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+          "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+          # ghcjs custom packages
+          "ghcjs-prim" "ghcjs-th"
+          "ghc-boot"
+          "ghc" "array" "binary" "bytestring" "containers"
+          "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+          # "ghci" "haskeline"
+          "hpc"
+          "mtl" "parsec" "text" "transformers"
+          "xhtml"
+          # "stm" "terminfo"
+        ];
+
+        # Needed for the CLI tests.
+        # Coreutils because we need 'paste'.
+        packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
+          lib.mkForce [buildPackages.bc buildPackages.jq buildPackages.coreutils buildPackages.shellcheck];
+
+        # Stamp executables with the git revision
+        packages.cardano-tx-generator.components.exes.cardano-tx-generator.postInstall = setGitRev;
+        # Work around Haskell.nix issue when setting postInstall on components
+        packages.cardano-tx-generator.components.all.postInstall = lib.mkForce setGitRev;
+      }
       {
         # Packages we wish to ignore version bounds of.
         # This is similar to jailbreakCabal, however it
@@ -30,23 +72,83 @@ let
 
         # split data output for ekg to reduce closure size
         packages.ekg.components.library.enableSeparateDataOutput = true;
-        # TODO: Enable -Werror:
-        packages.cardano-tx-generator.configureFlags = [
+      }
+      # TODO: Compile all local packages with -Werror:
+      { packages.cardano-tx-generator.configureFlags = [
           "--ghc-option=-Wall"
+          "--ghc-option=-fprof-auto-top"
+          "--ghc-option=-fprof-auto-calls"
+          "--ghc-option=-fprof-cafs"
           #"--ghc-option=-Werror"
+        ] ++ lib.optionals profiling [
+          "--ghc-option=-fprof-auto-top"
+          "--ghc-option=-fprof-auto-calls"
+          "--ghc-option=-fprof-cafs"
         ];
         packages.cardano-rt-view.configureFlags = [
           "--ghc-option=-Wall"
           #"--ghc-option=-Werror"
         ];
-        enableLibraryProfiling = profiling;
       }
+      #{
+      #  packages = lib.genAttrs projectPackages
+      #    (name: { configureFlags = [ "--ghc-option=-Werror" ]; });
+      #}
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
-        packages.tx-generator.components.exes.tx-generator.enableExecutableProfiling = true;
-        profilingDetail = "default";
+        packages.cardano-tx-generator.components.exes.cardano-tx-generator.enableExecutableProfiling = true;
+      })
+      (lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        # systemd can't be statically linked
+        packages.cardano-tx-generator.flags.systemd = !stdenv.hostPlatform.isMusl;
+      })
+      # Musl libc fully static build
+      (lib.optionalAttrs stdenv.hostPlatform.isMusl (let
+        # Module options which adds GHC flags and libraries for a fully static build
+        fullyStaticOptions = {
+          enableShared = false;
+          enableStatic = true;
+        };
+      in
+        {
+          packages = lib.genAttrs projectPackages (name: fullyStaticOptions);
+
+          # Haddock not working and not needed for cross builds
+          doHaddock = false;
+        }
+      ))
+
+      (lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+        # Make sure we use a buildPackages version of happy
+        packages.pretty-show.components.library.build-tools = [ buildPackages.haskell-nix.haskellPackages.happy ];
+
+        # Remove hsc2hs build-tool dependencies (suitable version will be available as part of the ghc derivation)
+        packages.Win32.components.library.build-tools = lib.mkForce [];
+        packages.terminal-size.components.library.build-tools = lib.mkForce [];
+        packages.network.components.library.build-tools = lib.mkForce [];
+
+        # Disable cabal-doctest tests by turning off custom setups
+        packages.comonad.package.buildType = lib.mkForce "Simple";
+        packages.distributive.package.buildType = lib.mkForce "Simple";
+        packages.lens.package.buildType = lib.mkForce "Simple";
+        packages.nonempty-vector.package.buildType = lib.mkForce "Simple";
+        packages.semigroupoids.package.buildType = lib.mkForce "Simple";
       })
     ];
-  };
+    # TODO add flags to packages (like cs-ledger) so we can turn off tests that will
+    # not build for windows on a per package bases (rather than using --disable-tests).
+    # configureArgs = lib.optionalString stdenv.hostPlatform.isWindows "--disable-tests";
+  });
+
+  # setGitRev is a postInstall script to stamp executables with
+  # version info. It uses the "gitrev" argument, if set. Otherwise,
+  # the revision is sourced from the local git work tree.
+  setGitRev = ''
+    ${haskellBuildUtils}/bin/set-git-rev "${gitrev'}" $out/bin/* || true
+  '';
+  gitrev' = if (gitrev == null)
+    then buildPackages.commonLib.commitIdFromGitRepoOrZero ../.git
+    else gitrev;
+  haskellBuildUtils = buildPackages.haskellBuildUtils.package;
 in
   pkgSet

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -17,7 +17,7 @@
                 or pkgs.cardano-tx-generator;
               ## TODO:  that's actually a bit ugly and could be improved.
       ## This exe has to be available in the selected package.
-      exeName = "cardano-tx-generator-byron";
+      exeName = "cardano-tx-generator";
 
       extraOptionDecls = {
         ## TODO: the defaults should be externalised to a file.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-node": {
-        "branch": "master",
+        "branch": "cad-1131-utxo-size-trace",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "46f296f8a9f3f497d9bd41e20c8398d2b5730c86",
-        "sha256": "05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl",
+        "rev": "f8a2da1edc2d1c5389c41d069ae9e2d8e848958a",
+        "sha256": "05nv40b6p1mwfvfxpas7b5d470dniym4vpslnxqpj3i0w7qcicpb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/46f296f8a9f3f497d9bd41e20c8398d2b5730c86.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/f8a2da1edc2d1c5389c41d069ae9e2d8e848958a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-sl": {
@@ -41,10 +41,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c474dcec4a435698cd7978ef25e6fea25ff6795b",
-        "sha256": "149n40p56njpzibbkxlqj7rv8f2yvgfqni9m6xr8rvl5yry1lxd0",
+        "rev": "36836c1f580a021e99e7ad3ad23f4257e7ffda2b",
+        "sha256": "0jsg3lairnfn9i74dj6r88n53y5ca724wv9lvak67cbhmxgj35df",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/c474dcec4a435698cd7978ef25e6fea25ff6795b.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/36836c1f580a021e99e7ad3ad23f4257e7ffda2b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "8b1d65ba294708b12d7b15103ac35431d9b60819",
-        "sha256": "1z23lw28s3wa5bf5yr89i61m413ad299lyhv02i9r36p28wjl94g",
+        "rev": "8e469d915634f3bff21cb6fd6b7ee381bcffe1a0",
+        "sha256": "0xb5j2yqw8q32pb9b146333rbfyzsdb9dllda72i98cqmb2ma02a",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/8b1d65ba294708b12d7b15103ac35431d9b60819.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/8e469d915634f3bff21cb6fd6b7ee381bcffe1a0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -60,8 +60,8 @@ let
     native = mapTestOn (__trace (__toJSON (packagePlatforms project)) (packagePlatforms project));
   } // (mkRequiredJob (
       [
-        jobs.native.cardano-tx-generator-byron.x86_64-darwin
-        jobs.native.cardano-tx-generator-byron.x86_64-linux
+        jobs.native.cardano-tx-generator.x86_64-darwin
+        jobs.native.cardano-tx-generator.x86_64-linux
         jobs.native.cardano-rt-view-service.x86_64-darwin
         jobs.native.cardano-rt-view-service.x86_64-linux
       ]));

--- a/stack.yaml
+++ b/stack.yaml
@@ -99,7 +99,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: 46f296f8a9f3f497d9bd41e20c8398d2b5730c86
+    commit: f8a2da1edc2d1c5389c41d069ae9e2d8e848958a
     subdirs:
       - cardano-api
       - cardano-config
@@ -196,7 +196,7 @@ extra-deps:
 
     # Includes updated pretty printing function
   - git: https://github.com/well-typed/cborg.git
-    commit: 6886be5f7ca98fa44750ed5d44be6b84227aae67
+    commit: 42a83192749774268337258f4f94c97584b80ca6
     subdirs:
         - cborg
         - serialise


### PR DESCRIPTION
Summary of the changes in the generator:

1. Implement global TPS limitation.
1. Implement submission from a shared Tx pool.
1. Reimplement the submission protocol in a simpler, more clear way.
1. Improve tracing.
1. End-of-run report, including per-thread submission TPS.
1. Make the generator actually exit at the end of submission.
1. More type safety.
1. Factor submission into local/node-to-node modules.
1. Support Shelley, except for the metadata-based extra Tx payload.
1. Update to the latest node.
1. Drop the explorer-API-based submission.