### PR TITLE
Restore customConfig arg required by ci sync bench scripts.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,10 @@
 #   iohk-nix = ../iohk-nix;
 # }'
 , sourcesOverride ? {}
+# override scripts with custom configuration
+, customConfig ? {}
 # pinned version of nixpkgs augmented with overlays (iohk-nix and our packages).
-, pkgs ? import ./nix { inherit system crossSystem config sourcesOverride; }
+, pkgs ? import ./nix { inherit system crossSystem config sourcesOverride customConfig; }
 , gitrev ? pkgs.iohkNix.commitIdFromGitRepoOrZero ./.git
 }:
 with pkgs; with commonLib;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,6 +2,8 @@
 , crossSystem ? null
 , config ? {}
 , sourcesOverride ? {}
+# override scripts with custom configuration
+, customConfig ? {}
 }:
 let
   sources = import ./sources.nix { inherit pkgs; }
@@ -37,7 +39,7 @@ let
         svcLib = import ./svclib.nix { inherit pkgs; };
 
         cardanoNode = import sources.cardano-node {
-          inherit system crossSystem config sourcesOverride;
+          inherit system crossSystem config sourcesOverride customConfig;
         };
         cardanoDbSync = import sources.cardano-db-sync {
           inherit system crossSystem config sourcesOverride;


### PR DESCRIPTION
`customConfig` arg was removed in df2c7d99a5b9fff238dbb7fc47f3eadbcbc23e86 but it is still required by the `ci-full-sync.sh` and `ci.sh` nightly benchmark scripts.