### PR TITLE
CAD-998 adapt tx gen to API changes in Release-1.12

### DIFF
--- a/benchmarks/cluster3nodes/run-3node-cluster.sh
+++ b/benchmarks/cluster3nodes/run-3node-cluster.sh
@@ -27,6 +27,7 @@ fi
 SUBCONFIG=
 if [ $1 == "rt-view" ]; then
   SUBCONFIG="-rt-view"
+  REDIRSTDERR="2>/dev/null"
 fi
 
 # start a tmux session:
@@ -88,7 +89,7 @@ do tmux select-pane -t ${i}
       . ${__COMMON_SRCROOT}/scripts/lib-cli.sh;
       . ${__COMMON_SRCROOT}/scripts/lib-node.sh;
 
-      run cardano-node run $(nodeargs $i)" \
+      run cardano-node run $(nodeargs $i)" ${REDIRSTDERR} \
      C-m
 done
 tmux select-pane -t 0

--- a/benchmarks/cluster3nodes/run-second-3node-cluster.sh
+++ b/benchmarks/cluster3nodes/run-second-3node-cluster.sh
@@ -27,6 +27,7 @@ fi
 SUBCONFIG=
 if [ $1 == "rt-view" ]; then
   SUBCONFIG="-rt-view"
+  REDIRSTDERR="2>/dev/null"
 fi
 
 # start a tmux session:
@@ -88,7 +89,7 @@ do tmux select-pane -t $((i-3))
       . ${__COMMON_SRCROOT}/scripts/lib-cli.sh;
       . ${__COMMON_SRCROOT}/scripts/lib-node.sh;
 
-      run cardano-node run $(nodeargs $i)" \
+      run cardano-node run $(nodeargs $i)" ${REDIRSTDERR} \
      C-m
 done
 tmux select-pane -t 0

--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,7 @@ index-state: 2020-04-01T00:00:00Z
 packages:
     cardano-rt-view
     cardano-tx-generator
+    -- bm-timeline
     --ext/cardano-node.git/cardano-api
     --ext/cardano-node.git/cardano-cli
     --ext/cardano-node.git/cardano-node
@@ -14,29 +15,29 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 66f0e6d4066930bcebd34fd280a8bc1f6fab8706
-  --sha256: 0il6nhlswxa8wnc1nr2360bzfd0n41qhlqb8fq30x3k9vf34yvg6
+  tag: f7c56548c05b7a3b544acb2c30f28803ff7524b2
+  --sha256: 1nlz2n5yyv38rqmw54rcvyy9nxqp3vrqx1alqdlypi4r19015ppb
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 66f0e6d4066930bcebd34fd280a8bc1f6fab8706
-  --sha256: 0il6nhlswxa8wnc1nr2360bzfd0n41qhlqb8fq30x3k9vf34yvg6
+  tag: f7c56548c05b7a3b544acb2c30f28803ff7524b2
+  --sha256: 1nlz2n5yyv38rqmw54rcvyy9nxqp3vrqx1alqdlypi4r19015ppb
   subdir: cardano-cli
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 66f0e6d4066930bcebd34fd280a8bc1f6fab8706
-  --sha256: 0il6nhlswxa8wnc1nr2360bzfd0n41qhlqb8fq30x3k9vf34yvg6
+  tag: f7c56548c05b7a3b544acb2c30f28803ff7524b2
+  --sha256: 1nlz2n5yyv38rqmw54rcvyy9nxqp3vrqx1alqdlypi4r19015ppb
   subdir: cardano-config
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 66f0e6d4066930bcebd34fd280a8bc1f6fab8706
-  --sha256: 0il6nhlswxa8wnc1nr2360bzfd0n41qhlqb8fq30x3k9vf34yvg6
+  tag: f7c56548c05b7a3b544acb2c30f28803ff7524b2
+  --sha256: 1nlz2n5yyv38rqmw54rcvyy9nxqp3vrqx1alqdlypi4r19015ppb
   subdir: cardano-node
 
 source-repository-package
@@ -56,29 +57,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: slotting
 
 source-repository-package
@@ -90,71 +91,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
+  tag: 317879efb23d119245dc900f3af8e9c3f4b4e066
+  --sha256: 1isnxralcnnniwlmh93jd4wivd7fixagldzv27dpil6crk38s79c
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
+  tag: 317879efb23d119245dc900f3af8e9c3f4b4e066
+  --sha256: 1isnxralcnnniwlmh93jd4wivd7fixagldzv27dpil6crk38s79c
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
+  tag: 317879efb23d119245dc900f3af8e9c3f4b4e066
+  --sha256: 1isnxralcnnniwlmh93jd4wivd7fixagldzv27dpil6crk38s79c
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
+  tag: 317879efb23d119245dc900f3af8e9c3f4b4e066
+  --sha256: 1isnxralcnnniwlmh93jd4wivd7fixagldzv27dpil6crk38s79c
   subdir: crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
@@ -255,99 +256,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 776d76c24fb96ef4fb64f427f3989f1004ba2907
-  --sha256: 1g8qa7qpgdf21ff9wls7s48dy3klzm7ysja6rxbvgdi9fkz6ml8l
+  tag: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
+  --sha256: 0dz8sq4vzhh2asi0h7l1y7578rzkcss9z6gf7njrbajg7ymh5qrz
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -710,11 +710,10 @@ runBenchmark benchTracer
 
   remoteAddresses <- forM targetNodeAddresses $ \targetNodeAddress -> do
     let (anAddrFamily, targetNodeHost) =
-          case naHostAddress targetNodeAddress of
-            Just na -> case unNodeHostAddress na of
-                         IP.IPv4 ipv4 -> (AF_INET,  show ipv4)
-                         IP.IPv6 ipv6 -> (AF_INET6, show ipv6)
-            Nothing -> panic "Target node's IP-address is undefined!"
+          case unNodeHostAddress $ naHostAddress targetNodeAddress of
+              Just (IP.IPv4 ipv4) -> (AF_INET,  show ipv4)
+              Just (IP.IPv6 ipv6) -> (AF_INET6, show ipv6)
+              _ -> panic "Target node's IP-address is undefined!"
 
     let targetNodePort = show $ naPort targetNodeAddress
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
@@ -111,8 +111,8 @@ parseTargetNodeAddress optname desc =
       <> metavar "(HOST,PORT)"
       <> help desc
 
-parseHostAddress :: String -> Maybe NodeHostAddress
-parseHostAddress = Just . NodeHostAddress .
+parseHostAddress :: String -> NodeHostAddress
+parseHostAddress = NodeHostAddress . Just .
   maybe (panic "Bad host of target node") identity . readMaybe
 
 parsePort :: Word16 -> PortNumber
@@ -169,7 +169,7 @@ parseFilePath optname desc =
 
 parseSocketPath :: String -> String -> Parser SocketPath
 parseSocketPath optname desc =
-  SocketFile <$> parseFilePath optname desc
+  SocketPath <$> parseFilePath optname desc
 
 parseConfigFile :: String -> String -> Parser FilePath
 parseConfigFile = parseFilePath

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -41,7 +41,7 @@ import           Ouroboros.Consensus.Mempool.API (GenTxId, GenTx)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run (RunNode, nodeNetworkMagic)
 import           Ouroboros.Consensus.Network.NodeToNode (Codecs(..), defaultCodecs)
-import           Ouroboros.Consensus.Config (TopLevelConfig(..))
+import           Ouroboros.Consensus.Config (TopLevelConfig(..), configCodec)
 
 import           Ouroboros.Network.Codec (AnyMessage (..))
 import           Ouroboros.Network.Driver (TraceSendRecv (..))
@@ -212,9 +212,7 @@ benchmarkConnectTxSubmit iocp trs cfg localAddr remoteAddr myTxSubClient =
  where
   myCodecs :: Codecs blk DeserialiseFailure m
                 ByteString ByteString ByteString ByteString ByteString
-  --               ByteString ByteString ByteString
-  -- myCodecs :: _
-  myCodecs  = defaultCodecs (configBlock cfg) (mostRecentNodeToNodeVersion (Proxy @blk))
+  myCodecs  = defaultCodecs (configCodec cfg) (mostRecentNodeToNodeVersion (Proxy @blk))
 
   peerMultiplex :: Versions NtN.NodeToNodeVersion NtN.DictVersion
                             (NtN.ConnectionId SockAddr ->
@@ -222,7 +220,7 @@ benchmarkConnectTxSubmit iocp trs cfg localAddr remoteAddr myTxSubClient =
   peerMultiplex =
     simpleSingletonVersions
       NtN.NodeToNodeV_1
-      (NtN.NodeToNodeVersionData { NtN.networkMagic = nodeNetworkMagic (Proxy @blk) cfg})
+      (NtN.NodeToNodeVersionData { NtN.networkMagic = nodeNetworkMagic cfg})
       (NtN.DictVersion NtN.nodeToNodeCodecCBORTerm) $ \_ ->
       NtN.nodeToNodeProtocols NtN.defaultMiniProtocolParameters $
         NtN.NodeToNodeProtocols

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ compiler: ghc-8.6.5
 packages:
   - cardano-rt-view
   - cardano-tx-generator
+    #- bm-timeline
   - ext/cardano-node.git/cardano-api
   - ext/cardano-node.git/cardano-cli
   - ext/cardano-node.git/cardano-node
@@ -61,6 +62,9 @@ extra-deps:
   - Win32-2.8.5.0
   - word-wrap-0.4.1
 
+  - git: https://github.com/erebe/systemd
+    commit: dba4b563dac99ff52328db916d99d928bc4a80fb
+
   - git: https://github.com/input-output-hk/cardano-prelude
     commit: bd7eb69d27bfaee46d435bc1d2720520b1446426
     subdirs:
@@ -68,7 +72,7 @@ extra-deps:
       - test
 
 #  - git: https://github.com/input-output-hk/cardano-node
-#    commit: 66f0e6d4066930bcebd34fd280a8bc1f6fab8706
+#    commit: f7c56548c05b7a3b544acb2c30f28803ff7524b2
 #    subdirs:
 #      - cardano-api
 #      - cardano-config
@@ -82,7 +86,7 @@ extra-deps:
       - cardano-db-sync
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: c845509c307af9df956ef203ac8ad67fe4d5d065
+    commit: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
     subdirs:
       - binary
       - binary/test
@@ -98,13 +102,13 @@ extra-deps:
       - cardano-shell
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+    commit: 317879efb23d119245dc900f3af8e9c3f4b4e066
     subdirs:
       - cardano-ledger
       - crypto
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
+    commit: 25354e11ed43d59485c404f491a118efe0bd8e70
     subdirs:
       # small-steps
       - semantics/executable-spec
@@ -121,7 +125,7 @@ extra-deps:
     commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 776d76c24fb96ef4fb64f427f3989f1004ba2907
+    commit: 65a7abfd704c58091dd7b862b5e9f78cf334f8dc
     subdirs:
         - io-sim
         - io-sim-classes


### PR DESCRIPTION
a lot of API changes in ouroboros-network and cardano-config

tested in cluster3nodes:

30,"2020-05-19 17:51:36.00","TraceAdoptedBlock","a1b006b7ac56f8cc",0
31,"2020-05-19 17:51:56.00","TraceAdoptedBlock","7d0459c0dce6ef1f",0
32,"2020-05-19 17:52:16.04","TraceAdoptedBlock","a139032ae996a362",118
33,"2020-05-19 17:52:36.04","TraceAdoptedBlock","e3539f577832e21c",199
34,"2020-05-19 17:52:56.06","TraceAdoptedBlock","a6d58b224c804c4c",199
35,"2020-05-19 17:53:16.06","TraceAdoptedBlock","85ad3acc2445be0d",199
36,"2020-05-19 17:53:36.04","TraceAdoptedBlock","5a1131bfa7d1eaae",200
37,"2020-05-19 17:53:56.03","TraceAdoptedBlock","bf15992fd0a3880f",85
38,"2020-05-19 17:54:16.00","TraceAdoptedBlock","a5936e26df8ffa2a",0

keeps around 10 TPS, targeted all six nodes.