### PR TITLE
CAD-992 txgen: single threaded submission

### DIFF
--- a/benchmarks/cluster3nodes/run_tx_generator.sh
+++ b/benchmarks/cluster3nodes/run_tx_generator.sh
@@ -28,6 +28,7 @@ run 'cardano-tx-generator' \
   --outputs-per-tx $outputstx \
   --tx-fee $txfee \
   --tps $tps \
+  --single-threaded \
   --sig-key ${CONFIGDIR}/genesis/delegate-keys.000.key \
   --sig-key ${CONFIGDIR}/genesis/delegate-keys.001.key \
   --sig-key ${CONFIGDIR}/genesis/delegate-keys.002.key \

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -161,6 +161,7 @@ genesisBenchmarkRunner
   -> Maybe TxAdditionalSize
   -> Maybe ExplorerAPIEnpoint
   -> [FilePath]
+  -> Bool
   -> ExceptT TxGenError IO ()
 genesisBenchmarkRunner loggingLayer
                        iocp
@@ -175,7 +176,8 @@ genesisBenchmarkRunner loggingLayer
                        initCooldown
                        txAdditionalSize
                        explorerAPIEndpoint
-                       signingKeyFiles = do
+                       signingKeyFiles
+                       singleThreaded = do
   when (length signingKeyFiles < 3) $
     left $ NeedMinimumThreeSigningKeyFiles signingKeyFiles
 
@@ -243,7 +245,9 @@ genesisBenchmarkRunner loggingLayer
                  pInfoConfig
                  sourceKey
                  recipientAddress
-                 targetNodeAddresses
+                 (if singleThreaded
+                   then NE.fromList $ NE.take 1 targetNodeAddresses
+                   else targetNodeAddresses)
                  numOfTxs
                  numOfInsPerTx
                  numOfOutsPerTx

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
@@ -9,7 +9,7 @@ import           Prelude (String)
 import           Options.Applicative
                     ( Parser
                     , bashCompleter, completer, help, long, metavar
-                    , auto, option, strOption
+                    , auto, flag, option, strOption
                     )
 import qualified Control.Arrow as Arr
 import           Network.Socket (PortNumber)
@@ -40,6 +40,7 @@ data GenerateTxs =
               (Maybe TxAdditionalSize)
               (Maybe ExplorerAPIEnpoint)
               [SigningKeyFile]
+              Bool
 
 parseCommand :: Parser GenerateTxs
 parseCommand =
@@ -94,10 +95,21 @@ parseCommand =
           "sig-key"
           "Path to signing key file, for genesis UTxO using by generator."
 
+    <*> parseFlag
+          "single-threaded"
+          "Single-threaded submission."
+
 defaultInitCooldown :: InitCooldown
 defaultInitCooldown = InitCooldown 100
 
 ----------------------------------------------------------------
+
+parseFlag :: String -> String -> Parser Bool
+parseFlag = parseFlag' False True
+
+parseFlag' :: a -> a -> String -> String -> Parser a
+parseFlag' def active optname desc =
+  flag def active $ long optname <> help desc
 
 parseTargetNodeAddress :: String -> String -> Parser NodeAddress
 parseTargetNodeAddress optname desc =

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Run.hs
@@ -74,7 +74,8 @@ runCommand (GenerateTxs logConfigFp
                         initCooldown
                         txAdditionalSize
                         explorerAPIEndpoint
-                        sigKeysFiles) =
+                        sigKeysFiles
+                        singleThreaded) =
   withIOManagerE $ \iocp -> do
     let ncli = NodeCLI
                { nodeMode = RealProtocolMode
@@ -131,6 +132,7 @@ runCommand (GenerateTxs logConfigFp
                 txAdditionalSize
                 explorerAPIEndpoint
                 [fp | SigningKeyFile fp <- sigKeysFiles]
+                singleThreaded
 
 ----------------------------------------------------------------------------
 

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -29,6 +29,7 @@
         tx_fee          =  intOpt 10000000   "Tx fee, in Lovelace.";
         tps             =  intOpt 100        "Strength of generated load, in TPS.";
         init_cooldown   =  intOpt 100        "Delay between init and main submissions.";
+        single_threaded = boolOpt false      "Force submission via single thread.";
 
         nodeConfig      = attrOpt {}         "Node-style config, overrides the default.";
         keyGen          =  strOpt null       "Signing key: generator";
@@ -67,6 +68,8 @@
             "--signing-key"            keyGen
             "--delegation-certificate" delegCert
           ] ++
+          optional single_threaded
+            "--single-threaded" ++
           __attrValues
             (__mapAttrs (name: { ip, port }: "--target-node '(\"${ip}\",${toString port})'")
               targetNodes);

--- a/nix/svclib.nix
+++ b/nix/svclib.nix
@@ -67,6 +67,7 @@ let
   serviceDeclarationLib = with pkgs.lib; rec {
     opt = type: default: description:
               mkOption { inherit type default description; };
+    boolOpt = opt types.bool;
     intOpt  = opt types.int;
     pathOpt = opt (types.or types.path types.str);
     strOpt  = opt types.str;


### PR DESCRIPTION
1. txgen:  --single-threaded flag, for the needs of the distributed cluster
1. pass --single-threaded to cluster-3-nodes