### PR TITLE
CAD-1073: analysis updates

### DIFF
--- a/scripts/explorer.MsgBlock.sh
+++ b/scripts/explorer.MsgBlock.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+grep --no-filename -F 'MsgBlock' "$@" |
+jq 'def katip_timestamp_to_iso8601:
+      .[:-4] + "Z";
+    .
+    | map
+      ( (.at | katip_timestamp_to_iso8601)
+        as $date_iso
+      | { date_iso:    $date_iso
+        , timestamp:   $date_iso | fromdateiso8601
+        , blkid:       .data.msg."block hash"
+        , txs:         (.data.msg."tx ids" | length)
+        }
+      )
+    | sort_by (.timestamp)
+    | .[]
+    ' --slurp --compact-output

--- a/scripts/node.AddedBlockToQueue.sh
+++ b/scripts/node.AddedBlockToQueue.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+grep -Fh '"TraceAddBlockEvent.AddedBlockToQueue"' "$@" |
+jq '.
+   | { timestamp: .at
+     , host:      .host
+     , slot:      .data.block.slot
+     , kind:      .data.kind
+     }
+   ' --compact-output

--- a/scripts/node.AddedToCurrentChain.sh
+++ b/scripts/node.AddedToCurrentChain.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+grep -Fh '"TraceAddBlockEvent.AddedToCurrentChain"' "$@" |
+jq '.
+   | { timestamp: .at
+     , host:      .host
+     , slot:      .data.headers[0].slotNo
+     , kind:      .data.kind
+     }
+   ' --compact-output

--- a/scripts/node.TraceMempoolRejectedTx.sh.disabled
+++ b/scripts/node.TraceMempoolRejectedTx.sh.disabled
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+grep -Fh '"TraceMempoolRejectedTx"' "$@" |
+jq 'def katip_timestamp_to_iso8601:
+      .[:-4] + "Z";
+    .
+    | map
+      ( (.at | katip_timestamp_to_iso8601)
+        as $date_iso
+      | { date_iso:    $date_iso
+        , timestamp:   ($date_iso | fromdateiso8601)
+        , host:        .host
+        , txid:        .data.tx.txid[5:]
+        , err:         .data.err
+        })
+    | sort_by (.timestamp)
+    | .[]
+    ' --slurp --compact-output

--- a/scripts/tocsv.AddedBlockToQueue.sh
+++ b/scripts/tocsv.AddedBlockToQueue.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+jq '[ .timestamp, .kind, .slot | tostring ]
+   | @csv
+   ' --raw-output "$@" |
+sed -e 's/\([0-9-]\+\)T\([0-9:.]\+\)Z/\1 \2/; s_"__g'

--- a/scripts/tocsv.AddedToCurrentChain.sh
+++ b/scripts/tocsv.AddedToCurrentChain.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+jq '[ .timestamp, .kind, .slot | tostring ]
+   | @csv
+   ' --raw-output "$@" |
+sed -e 's/\([0-9-]\+\)T\([0-9:.]\+\)Z/\1 \2/; s_"__g'

--- a/scripts/tocsv.TraceMempoolRejectedTx.sh
+++ b/scripts/tocsv.TraceMempoolRejectedTx.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+jq 'def nodename_to_index:
+      .[5:];
+
+    [ .date_iso
+    , (.host | nodename_to_index)
+    , .txid
+    , .err
+    ]
+   | join(",")
+   ' --raw-output "$@" |
+sed -e 's/\([0-9-]\+\)T\([0-9:.]\+\)Z/\1 \2/; s_"__g'


### PR DESCRIPTION
1. Makes more analysis data available in JSON form, to enable more intermediate processing
    - this is done by splitting some of the CSV-emitting scripts into pairs of JSON-emitters and CSV-ifiers.
1. Simplifies the workflow of sharing analyses between `cardano-benchmarking` and `cardano-ops`
1. A prerequisite for more cluster log sanity checking
