### PR TITLE
CAD-1134: No space leaks, strict MVar and structures.

### DIFF
--- a/cardano-rt-view/cardano-rt-view.cabal
+++ b/cardano-rt-view/cardano-rt-view.cabal
@@ -41,11 +41,13 @@ library
                      , cardano-prelude
                      , containers
                      , contra-tracer
+                     , deepseq
                      , formatting
                      , iohk-monitoring
                      , lobemo-backend-trace-acceptor
                      , network
                      , optparse-applicative
+                     , strict-concurrency
                      , text
                      , time
                      , threepenny-gui

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
@@ -5,11 +5,11 @@ module Cardano.Benchmarking.RTView
     ( runCardanoRTView
     ) where
 
-import           Cardano.Prelude
+import           Cardano.Prelude hiding ( newMVar )
 
 import           Control.Concurrent.Async
                    ( async, waitAnyCancel )
-import           Control.Concurrent.MVar
+import           Control.Concurrent.MVar.Strict
                    ( MVar
                    , newMVar
                    )

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Benchmarking.RTView.GUI.Elements
@@ -10,6 +12,8 @@ module Cardano.Benchmarking.RTView.GUI.Elements
 import           Cardano.Prelude
 import           Prelude
                    ( String )
+import           Control.DeepSeq
+                   ( NFData (..) )
 import           Data.Map.Strict
                    ( Map )
 
@@ -113,10 +117,11 @@ data ElementName
   | ElNetworkOutProgressBox
   | ElRTSMemoryProgress
   | ElRTSMemoryProgressBox
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Generic, NFData, Ord, Show)
 
 data ElementValue
-  = ElementInteger Integer
-  | ElementWord64  Word64
-  | ElementDouble  Double
-  | ElementString  String
+  = ElementInteger !Integer
+  | ElementWord64  !Word64
+  | ElementDouble  !Double
+  | ElementString  !String
+  deriving (Generic, NFData)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -7,26 +7,33 @@ module Cardano.Benchmarking.RTView.GUI.Elements
     , NodeStateElements
     , ElementName (..)
     , ElementValue (..)
+    , PeerInfoItem (..)
+    , PeerInfoElements (..)
     ) where
 
 import           Cardano.Prelude
 import           Prelude
                    ( String )
 import           Control.DeepSeq
-                   ( NFData (..) )
+                   ( NFData (..)
+                   , rwhnf
+                   )
 import           Data.Map.Strict
                    ( Map )
 
 import           Graphics.UI.Threepenny.Core
                    ( Element )
 
+instance NFData Element where
+  rnf = rwhnf
+
 -- | GUI elements containing current node state (info, metrics).
 --   These elements are continuously updating using |LogObject|s
 --   received by |TraceAcceptor|s.
 type NodeStateElements = Map ElementName Element
 
--- | GUI elements for all nodes, pairs from nodeName and its elements.
-type NodesStateElements = [(Text, NodeStateElements)]
+-- | GUI elements for all nodes, tuples from nodeName, its elements and prepared peers items.
+type NodesStateElements = [(Text, NodeStateElements, [PeerInfoItem])]
 
 data ElementName
   = ElNodeRelease
@@ -45,7 +52,6 @@ data ElementName
   | ElForksCreatedNumber
   | ElTxsProcessed
   | ElPeersNumber
-  | ElPeersList
   | ElTraceAcceptorHost
   | ElTraceAcceptorPort
   | ElNodeErrors
@@ -125,3 +131,19 @@ data ElementValue
   | ElementDouble  !Double
   | ElementString  !String
   deriving (Generic, NFData)
+
+-- | An item for each connected peer, contains a parent element
+--   and list of child elements.
+data PeerInfoItem = PeerInfoItem
+  { piItem      :: !Element
+  , piItemElems :: !PeerInfoElements
+  } deriving (Generic, NFData)
+
+data PeerInfoElements = PeerInfoElements
+  { pieEndpoint   :: !Element
+  , pieBytesInF   :: !Element
+  , pieReqsInF    :: !Element
+  , pieBlocksInF  :: !Element
+  , pieSlotNumber :: !Element
+  , pieStatus     :: !Element
+  } deriving (Generic, NFData)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Markup.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Markup.hs
@@ -19,7 +19,9 @@ import           Graphics.UI.Threepenny.Core
 import           Cardano.BM.Data.Configuration
                    ( RemoteAddrNamed (..) )
 import           Cardano.Benchmarking.RTView.GUI.Elements
-                   ( NodeStateElements, NodesStateElements )
+                   ( NodeStateElements, NodesStateElements
+                   , PeerInfoItem
+                   )
 import           Cardano.Benchmarking.RTView.GUI.NodeWidget
                    ( mkNodeWidget )
 
@@ -31,12 +33,12 @@ mkPageBody window acceptors = do
   -- Create widgets for each node (corresponding to acceptors).
   nodeWidgetsWithElems
     <- forM acceptors $ \(RemoteAddrNamed nameOfNode _) -> do
-         (widget, nodeStateElems) <- mkNodeWidget
-         return (nameOfNode, widget, nodeStateElems)
+         (widget, nodeStateElems, peerInfoItems) <- mkNodeWidget
+         return (nameOfNode, widget, nodeStateElems, peerInfoItems)
 
   -- Create widgets areas on the page.
   widgetsAreas
-    <- forM nodeWidgetsWithElems $ \(_, widget, _) ->
+    <- forM nodeWidgetsWithElems $ \(_, widget, _, _) ->
          return $ UI.div #. "w3-col l6 m12 s12" #+ [element widget]
 
   -- Register clickable selector for nodes (to be able to show only one or all of them).
@@ -70,8 +72,8 @@ mkPageBody window acceptors = do
          ]
 
   nodesStateElems
-    <- forM nodeWidgetsWithElems $ \(nameOfNode, _, nodeStateElems) ->
-         return (nameOfNode, nodeStateElems)
+    <- forM nodeWidgetsWithElems $ \(nameOfNode, _, nodeStateElems, peerInfoItems) ->
+         return (nameOfNode, nodeStateElems, peerInfoItems)
 
   return (body, nodesStateElems)
 
@@ -96,10 +98,10 @@ topNavigation nodesSelector = do
 --   to choose only one of them.
 showOnlyOneWidget
   :: Text
-  -> [(Text, Element, NodeStateElements)]
+  -> [(Text, Element, NodeStateElements, [PeerInfoItem])]
   -> UI ()
 showOnlyOneWidget nameOfNode nodeWidgetsWithElems =
-  forM_ nodeWidgetsWithElems $ \(aName, widget, _) ->
+  forM_ nodeWidgetsWithElems $ \(aName, widget, _, _) ->
     if aName == nameOfNode
       then void $ element widget # showIt
       else void $ element widget # hideIt
@@ -107,10 +109,10 @@ showOnlyOneWidget nameOfNode nodeWidgetsWithElems =
 -- | If user choosed one particular node, it's possible to
 --   show all nodes again without page reload.
 showAllWidgetsAgain
-  :: [(Text, Element, NodeStateElements)]
+  :: [(Text, Element, NodeStateElements, [PeerInfoItem])]
   -> UI ()
 showAllWidgetsAgain nodeWidgetsWithElems =
-  forM_ nodeWidgetsWithElems $ \(_, widget, _) -> do
+  forM_ nodeWidgetsWithElems $ \(_, widget, _, _) -> do
     void $ element widget # showIt
 
 showIt, hideIt :: UI Element -> UI Element

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -14,6 +16,8 @@ module Cardano.Benchmarking.RTView.NodeState.Types
 import           Cardano.Prelude
 import           Prelude
                    ( String )
+import           Control.DeepSeq
+                   ( NFData (..) )
 import qualified Data.Map.Strict as Map
 import           Data.Map.Strict
                    ( Map )
@@ -35,7 +39,7 @@ type NodesState = Map Text NodeState
 data NodeState = NodeState
   { nsInfo    :: !NodeInfo
   , nsMetrics :: !NodeMetrics
-  } deriving Show
+  } deriving (Generic, NFData, Show)
 
 data PeerInfo = PeerInfo
   { piEndpoint   :: !String
@@ -44,13 +48,16 @@ data PeerInfo = PeerInfo
   , piBlocksInF  :: !String
   , piSlotNumber :: !String
   , piStatus     :: !String
-  } deriving (Eq, Show)
+  } deriving (Eq, Generic, NFData, Show)
+
+-- Severity type already has Generic instance.
+instance NFData Severity
 
 data NodeError = NodeError
   { eTimestamp :: !UTCTime
   , eSeverity  :: !Severity
   , eMessage   :: !String
-  } deriving Show
+  } deriving (Generic, NFData, Show)
 
 data NodeInfo = NodeInfo
   { niNodeRelease                   :: !String
@@ -82,7 +89,7 @@ data NodeInfo = NodeInfo
   , niTraceAcceptorHost             :: !String
   , niTraceAcceptorPort             :: !String
   , niNodeErrors                    :: ![NodeError]
-  } deriving Show
+  } deriving (Generic, NFData, Show)
 
 data NodeMetrics = NodeMetrics
   { nmMempoolTxsNumber          :: !Word64
@@ -142,7 +149,7 @@ data NodeMetrics = NodeMetrics
   , nmRTSGcNumLastUpdate        :: !Word64
   , nmRTSGcMajorNum             :: !Integer
   , nmRTSGcMajorNumLastUpdate   :: !Word64
-  } deriving Show
+  } deriving (Generic, NFData, Show)
 
 defaultNodesState
   :: Configuration

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
@@ -5,10 +5,14 @@ module Cardano.Benchmarking.RTView.NodeState.Updater
     ( launchNodeStateUpdater
     ) where
 
-import           Cardano.Prelude
+import           Cardano.Prelude hiding ( modifyMVar_ )
 import           Prelude
                    ( String )
 
+import           Control.Concurrent.MVar.Strict
+                   ( MVar
+                   , modifyMVar_
+                   )
 import qualified Data.Aeson as A
 import           Data.List
                    ( (!!) )

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/Server.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/Server.hs
@@ -5,8 +5,12 @@ module Cardano.Benchmarking.RTView.Server
     ( launchServer
     ) where
 
-import           Cardano.Prelude
+import           Cardano.Prelude hiding ( readMVar )
 
+import           Control.Concurrent.MVar.Strict
+                   ( MVar
+                   , readMVar
+                   )
 import qualified Graphics.UI.Threepenny as UI
 import           Graphics.UI.Threepenny.Core
                    ( UI


### PR DESCRIPTION
1. Now strict `MVar` and strict structures (derived from `NFData`) are used, to prevent space leaks.
2. No dynamic DOM manipulation for peers list, to prevent space leaks.