### PR TITLE
CAD-1136: More detailed forged blocks info.

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -46,6 +46,7 @@ data ElementName
   | ElSlot
   | ElBlocksNumber
   | ElBlocksForgedNumber
+  | ElNodeCannotLead
   | ElChainDensity
   | ElNodeIsLeaderNumber
   | ElSlotsMissedNumber

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -37,6 +37,7 @@ mkNodeWidget = do
   elSlot                    <- string "0"
   elBlocksNumber            <- string "0"
   elBlocksForgedNumber      <- string "0"
+  elNodeCannotLead          <- string "0"
   elChainDensity            <- string "0"
   elNodeIsLeaderNumber      <- string "0"
   elSlotsMissedNumber       <- string "0"
@@ -315,6 +316,7 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [string "Forged blocks number:"]
                      , UI.div #. "" #+ [string "Chain density:"]
                      , UI.div #. "" #+ [string "Slot leader, number:"]
+                     , UI.div #. "" #+ [string "Cannot lead, number:"]
                      , UI.div #. "" #+ [string "Missed slots number:"]
                      , UI.div #. "" #+ [string "Created forks number:"]
                      ]
@@ -333,6 +335,7 @@ mkNodeWidget = do
                          , UI.span #. "density-percent" #+ [string "%"]
                          ]
                      , UI.div #. "" #+ [element elNodeIsLeaderNumber]
+                     , UI.div #. "" #+ [element elNodeCannotLead]
                      , UI.div #. "" #+ [element elSlotsMissedNumber]
                      , UI.div #. "" #+ [element elForksCreatedNumber]
                      ]
@@ -629,6 +632,7 @@ mkNodeWidget = do
           , (ElSlot,                    elSlot)
           , (ElBlocksNumber,            elBlocksNumber)
           , (ElBlocksForgedNumber,      elBlocksForgedNumber)
+          , (ElNodeCannotLead,          elNodeCannotLead)
           , (ElChainDensity,            elChainDensity)
           , (ElNodeIsLeaderNumber,      elNodeIsLeaderNumber)
           , (ElSlotsMissedNumber,       elSlotsMissedNumber)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -75,6 +75,7 @@ updateGUI nodesState params acceptors nodesStateElems =
     void $ updateElementValue (ElementInteger $ niSlot ni)                    $ elements ! ElSlot
     void $ updateElementValue (ElementInteger $ niBlocksNumber ni)            $ elements ! ElBlocksNumber
     void $ updateElementValue (ElementInteger $ niBlocksForgedNumber ni)      $ elements ! ElBlocksForgedNumber
+    void $ updateElementValue (ElementInteger $ niNodeCannotLead ni)          $ elements ! ElNodeCannotLead
     void $ updateElementValue (ElementDouble  $ niChainDensity ni)            $ elements ! ElChainDensity
     void $ updateElementValue (ElementInteger $ niNodeIsLeaderNum ni)         $ elements ! ElNodeIsLeaderNumber
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)       $ elements ! ElSlotsMissedNumber
@@ -278,7 +279,9 @@ markOutdatedElements params ni nm els = do
                                                       [els ! ElSlotOutdateWarning]
   markValueW now (niBlocksNumberLastUpdate ni) bcLife [els ! ElBlocksNumber]
                                                       [els ! ElBlocksNumberOutdateWarning]
-  markValueW now (niBlocksForgedNumberLastUpdate ni) bcLife [els ! ElBlocksForgedNumber]
+  markValueW now (niBlocksForgedNumberLastUpdate ni) bcLife [ els ! ElBlocksForgedNumber
+                                                            , els ! ElNodeCannotLead
+                                                            ]
                                                             [els ! ElBlocksForgedNumberOutdateWarning]
   markValueW now (niChainDensityLastUpdate ni) bcLife [els ! ElChainDensity]
                                                       [els ! ElChainDensityOutdateWarning]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -79,6 +79,7 @@ data NodeInfo = NodeInfo
   , niBlocksNumberLastUpdate        :: !Word64
   , niBlocksForgedNumber            :: !Integer
   , niBlocksForgedNumberLastUpdate  :: !Word64
+  , niNodeCannotLead                :: !Integer
   , niChainDensity                  :: !Double
   , niChainDensityLastUpdate        :: !Word64
   , niForksCreated                  :: !Integer
@@ -190,6 +191,7 @@ defaultNodeInfo = NodeInfo
   , niBlocksNumberLastUpdate        = 0
   , niBlocksForgedNumber            = 0
   , niBlocksForgedNumberLastUpdate  = 0
+  , niNodeCannotLead                = 0
   , niChainDensity                  = 0.0
   , niChainDensityLastUpdate        = 0
   , niForksCreated                  = 0

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
@@ -17,8 +17,6 @@ module Cardano.Benchmarking.RTView.NodeState.Updater
     ) where
 
 import           Cardano.Prelude hiding ( modifyMVar_ )
-import           Prelude
-                   ( String )
 
 import           Control.Concurrent.MVar.Strict
                    ( MVar
@@ -151,6 +149,8 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
                 nodesStateWith $ updateTxsProcessed ns processedTxsNum
               LogValue "blocksForgedNum" (PureI forgedBlocksNum) ->
                 nodesStateWith $ updateBlocksForged ns forgedBlocksNum now
+              LogValue "nodeCannotLead" (PureI cannotLead) ->
+                nodesStateWith $ updateNodeCannotLead ns cannotLead
               LogValue "nodeIsLeaderNum" (PureI leaderNum) ->
                 nodesStateWith $ updateNodeIsLeader ns leaderNum now
               LogValue "slotsMissedNum" (PureI missedSlotsNum) ->
@@ -510,6 +510,15 @@ updateBlocksForged ns blocksForged now = ns { nsInfo = newNi }
     currentNi
       { niBlocksForgedNumber = blocksForged
       , niBlocksForgedNumberLastUpdate = now
+      }
+  currentNi = nsInfo ns
+
+updateNodeCannotLead :: NodeState -> Integer -> NodeState
+updateNodeCannotLead ns cannotLead = ns { nsInfo = newNi }
+ where
+  newNi =
+    currentNi
+      { niNodeCannotLead = cannotLead
       }
   currentNi = nsInfo ns
 


### PR DESCRIPTION
More detailed information about forged blocks number: not only the total number of forged blocks, but the number of attempts to forge invalid block (`NodeCannotLead`).

Corresponding changes in `cardano-node`: https://github.com/input-output-hk/cardano-node/pull/1202