### PR TITLE
Change names of executables

### DIFF
--- a/benchmarks/cluster3nodes/start.sh
+++ b/benchmarks/cluster3nodes/start.sh
@@ -13,8 +13,8 @@ set -e
 BASEDIR="$(realpath "$(dirname "$0")")"
 . "$(realpath "${BASEDIR}"/../../scripts/common.sh)"
 
-prebuild 'cardano-tx-generator' || exit 1
-prebuild 'cardano-rt-view' || exit 1
+prebuild 'cardano-tx-generator-byron' || exit 1
+prebuild 'cardano-rt-view-service' || exit 1
 prebuild 'cardano-node' || exit 1
 #prebuild 'cardano-db-sync' || exit 1
 prebuild 'cardano-cli' || exit 1


### PR DESCRIPTION
Previously it was impossible to run `start.sh` script, because of names error:

```
$ ./benchmarks/cluster3nodes/start.sh 
--( cabal mode, because /home/denis/Code/cardano-benchmarking/dist-newstyle exists.
cabal: Unknown target 'cardano-tx-generator:exe:cardano-tx-generator'.
The package cardano-tx-generator has no executable component
'cardano-tx-generator'.
Perhaps you meant the executable component 'lib:cardano-tx-generator'?
```

Now the names of executables are fixed, and cluster can be launched.