### PR TITLE
CAD-1135: Adapt max mempool size.

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -60,8 +60,8 @@ data ElementName
   | ElMempoolTxsPercent
   | ElMempoolBytes
   | ElMempoolBytesPercent
-  | ElMempoolCapacity
-  | ElMempoolCapacityBytes
+  | ElMempoolMaxTxs
+  | ElMempoolMaxBytes
   | ElMemory
   | ElMemoryMax
   | ElMemoryMaxTotal

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -50,8 +50,8 @@ mkNodeWidget = do
   elMempoolTxsPercent       <- string "0"
   elMempoolBytes            <- string "0"
   elMempoolBytesPercent     <- string "0"
-  elMempoolCapacity         <- string "0"
-  elMempoolCapacityBytes    <- string "0"
+  elMempoolMaxTxs           <- string "0"
+  elMempoolMaxBytes         <- string "0"
   elMemory                  <- string "0"
   elMemoryMax               <- string "0"
   elMemoryMaxTotal          <- string "0"
@@ -384,8 +384,8 @@ mkNodeWidget = do
                        [ UI.div #. "w3-row" #+
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (Bytes)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
-                               [ element elMempoolCapacityBytes
-                               , infoMark "Capacity in bytes"
+                               [ element elMempoolMaxBytes
+                               , infoMark "Maximum in bytes"
                                ]
                            ]
                        , element elMempoolBytesProgressBox
@@ -394,8 +394,8 @@ mkNodeWidget = do
                        [ UI.div #. "w3-row" #+
                            [ UI.div #. "w3-half w3-theme" #+ [string "Mempool (TXs)"]
                            , UI.div #. "w3-half w3-theme w3-right-align" #+
-                               [ element elMempoolCapacity
-                               , infoMark "Capacity"
+                               [ element elMempoolMaxTxs
+                               , infoMark "Maximum in txs"
                                ]
                            ]
                        , element elMempoolTxsProgressBox
@@ -646,8 +646,8 @@ mkNodeWidget = do
           , (ElMempoolTxsPercent,       elMempoolTxsPercent)
           , (ElMempoolBytes,            elMempoolBytes)
           , (ElMempoolBytesPercent,     elMempoolBytesPercent)
-          , (ElMempoolCapacity,         elMempoolCapacity)
-          , (ElMempoolCapacityBytes,    elMempoolCapacityBytes)
+          , (ElMempoolMaxTxs,           elMempoolMaxTxs)
+          , (ElMempoolMaxBytes,         elMempoolMaxBytes)
           , (ElMemory,                  elMemory)
           , (ElMemoryMax,               elMemoryMax)
           , (ElMemoryMaxTotal,          elMemoryMaxTotal)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -89,8 +89,8 @@ updateGUI nodesState params acceptors nodesStateElems =
     void $ updateElementValue (ElementDouble  $ nmMempoolTxsPercent nm)       $ elements ! ElMempoolTxsPercent
     void $ updateElementValue (ElementWord64  $ nmMempoolBytes nm)            $ elements ! ElMempoolBytes
     void $ updateElementValue (ElementDouble  $ nmMempoolBytesPercent nm)     $ elements ! ElMempoolBytesPercent
-    void $ updateElementValue (ElementWord64  $ nmMempoolCapacity nm)         $ elements ! ElMempoolCapacity
-    void $ updateElementValue (ElementWord64  $ nmMempoolCapacityBytes nm)    $ elements ! ElMempoolCapacityBytes
+    void $ updateElementValue (ElementInteger $ nmMempoolMaxTxs nm)           $ elements ! ElMempoolMaxTxs
+    void $ updateElementValue (ElementInteger $ nmMempoolMaxBytes nm)         $ elements ! ElMempoolMaxBytes
     void $ updateElementValue (ElementDouble  $ nmMemory nm)                  $ elements ! ElMemory
     void $ updateElementValue (ElementDouble  $ nmMemoryMax nm)               $ elements ! ElMemoryMax
     void $ updateElementValue (ElementDouble  $ nmMemoryMaxTotal nm)          $ elements ! ElMemoryMaxTotal

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -97,8 +97,8 @@ data NodeMetrics = NodeMetrics
   , nmMempoolTxsPercent         :: !Double
   , nmMempoolBytes              :: !Word64
   , nmMempoolBytesPercent       :: !Double
-  , nmMempoolCapacity           :: !Word64
-  , nmMempoolCapacityBytes      :: !Word64
+  , nmMempoolMaxTxs             :: !Integer
+  , nmMempoolMaxBytes           :: !Integer
   , nmMemory                    :: !Double
   , nmMemoryMax                 :: !Double
   , nmMemoryMaxTotal            :: !Double
@@ -210,8 +210,8 @@ defaultNodeMetrics = NodeMetrics
   , nmMempoolTxsPercent         = 0.0
   , nmMempoolBytes              = 0
   , nmMempoolBytesPercent       = 0.0
-  , nmMempoolCapacity           = 200
-  , nmMempoolCapacityBytes      = 200 * maxBytesPerTx
+  , nmMempoolMaxTxs             = 0
+  , nmMempoolMaxBytes           = 0
   , nmMemory                    = 0.0
   , nmMemoryMax                 = 0.0
   , nmMemoryMaxTotal            = 200.0
@@ -264,5 +264,3 @@ defaultNodeMetrics = NodeMetrics
   , nmRTSGcMajorNum             = 0
   , nmRTSGcMajorNumLastUpdate   = 0
   }
- where
-  maxBytesPerTx = 4096 :: Word64

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
@@ -480,10 +480,12 @@ updateMempoolTxs ns txsInMempool = ns { nsMetrics = newNm }
     currentNm
       { nmMempoolTxsNumber  = fromIntegral txsInMempool
       , nmMempoolTxsPercent =   fromIntegral txsInMempool
-                              / fromIntegral (nmMempoolCapacity currentNm)
+                              / fromIntegral maxTxs
                               * 100.0
+      , nmMempoolMaxTxs = maxTxs
       }
   currentNm = nsMetrics ns
+  maxTxs = max txsInMempool (nmMempoolMaxTxs currentNm)
 
 updateMempoolBytes :: NodeState -> Integer -> NodeState
 updateMempoolBytes ns mempoolBytes = ns { nsMetrics = newNm }
@@ -492,10 +494,12 @@ updateMempoolBytes ns mempoolBytes = ns { nsMetrics = newNm }
     currentNm
       { nmMempoolBytes = fromIntegral mempoolBytes
       , nmMempoolBytesPercent =   fromIntegral mempoolBytes
-                                / fromIntegral (nmMempoolCapacityBytes currentNm)
+                                / fromIntegral maxBytes
                                 * 100.0
+      , nmMempoolMaxBytes = maxBytes
       }
   currentNm = nsMetrics ns
+  maxBytes = max mempoolBytes (nmMempoolMaxBytes currentNm)
 
 updateTxsProcessed :: NodeState -> Integer -> NodeState
 updateTxsProcessed ns txsProcessed = ns { nsInfo = newNi }


### PR DESCRIPTION
Now maximum value of mempool (both txs size + txs number) aren't fixed, but it's based on real maximum values received from tracers.

Corresponding changes in `cardano-node` are already merged: https://github.com/input-output-hk/cardano-node/pull/1223