### PR TITLE
CAD-1063 script 'mcount.sh' to count message per namespace x kind

### DIFF
--- a/scripts/mcount.sh
+++ b/scripts/mcount.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+ 
+SED=sed
+ARCH=$(uname)
+if [ $ARCH == "Darwin" ]; then
+  # check for GNU sed
+  T=$(which gsed && echo 1 || echo 0)
+  if [ "${T}" == "0" ]; then
+    echo "On Darwin we need GNU's version of sed"
+    echo "can be installed via 'brew install gnu-sed'"
+    exit 1
+  else
+    SED=gsed
+  fi
+fi
+
+$SED -ne 's/.*"kind":\(".*"\),"namespace":\(".*"\).*/\2 \1/p' - |
+  while true; do
+
+    read nmsp kind
+
+    if [ -z "$kind" ]; then break; fi
+
+    echo -n "$nmsp $kind "
+
+    if [ "${kind}" = '"no .data.kind"' ]; then
+      grep "\"ns\":.*${nmsp}" $* | wc -l
+    else
+      grep "\"ns\":.*${nmsp}.*\"kind\":${kind}" $* | wc -l
+    fi
+  done
+


### PR DESCRIPTION
example on log files in local benchmark:

`../../scripts/msgtypes.sh logs/node1-.json | ../../scripts/mcount.sh logs/node1-.json`


outputs:
```
"cardano.node.Forge" "LogMessage" 22780
"cardano.node-metrics" "LogValue" 12312
"cardano.node.BlockFetchDecision" "LogValue" 897
"cardano.node.ChainDB" "LogValue" 4
"cardano.node" "MeasureTxsTimeStop" 566
"cardano.node.ForgeTime" "OutcomeTraceForgeEvent" 576
"cardano.node.BlockFetchDecision" "PeersFetch" 2791
"cardano.node.ChainDB" "TraceAddBlockEvent.AddBlockValidation.InvalidBlock" 8
"cardano.node.ChainDB" "TraceAddBlockEvent.AddBlockValidation.ValidCandidate" 12
"cardano.node.ChainDB" "TraceAddBlockEvent.AddedToCurrentChain" 1240
"cardano.node.ChainDB" "TraceAddBlockEvent.SwitchedToAFork" 13
"cardano.node.ChainDB" "TraceAddBlockEvent.TrySwitchToAFork" 18
"cardano.node.Forge" "TraceAdoptedBlock" 566
"cardano.node.Forge" "TraceDidntAdoptBlock" 2
"cardano.node.Forge" "TraceForgedBlock" 576
"cardano.node.Forge" "TraceForgedInvalidBlock" 8
"cardano.node.ChainDB" "TraceLedgerEvent.TookSnapshot" 23
"cardano.node.Forge" "TraceNodeIsLeader" 576
"cardano.node.Forge" "TraceNodeNotLeader" 22204
"cardano.node.ChainDB" "TraceOpenEvent.ClosedDB" 1
"cardano.node.Forge" "TraceStartLeadershipCheck" 22780
"cardano.node.IpSubscription" "WithIPList SubscriptionTrace" 4
"cardano.node.BlockFetchDecision" "no .data.kind" 3690
"cardano.node.ForgeTime" "no .data.kind" 47289
```