### PR TITLE
CAD-1262: Remove 'Forks created' metric.

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -50,7 +50,6 @@ data ElementName
   | ElChainDensity
   | ElNodeIsLeaderNumber
   | ElSlotsMissedNumber
-  | ElForksCreatedNumber
   | ElTxsProcessed
   | ElPeersNumber
   | ElTraceAcceptorHost

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -41,7 +41,6 @@ mkNodeWidget = do
   elChainDensity            <- string "0"
   elNodeIsLeaderNumber      <- string "0"
   elSlotsMissedNumber       <- string "0"
-  elForksCreatedNumber      <- string "0"
   elTxsProcessed            <- string "0"
   elPeersNumber             <- string "0"
   elTraceAcceptorHost       <- string "0"
@@ -318,7 +317,6 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [string "Slot leader, number:"]
                      , UI.div #. "" #+ [string "Cannot lead, number:"]
                      , UI.div #. "" #+ [string "Missed slots number:"]
-                     , UI.div #. "" #+ [string "Created forks number:"]
                      ]
                  ]
              , UI.div #. "w3-third w3-theme" #+
@@ -337,7 +335,6 @@ mkNodeWidget = do
                      , UI.div #. "" #+ [element elNodeIsLeaderNumber]
                      , UI.div #. "" #+ [element elNodeCannotLead]
                      , UI.div #. "" #+ [element elSlotsMissedNumber]
-                     , UI.div #. "" #+ [element elForksCreatedNumber]
                      ]
                  ]
              , UI.div #. "w3-third w3-theme" #+
@@ -639,7 +636,6 @@ mkNodeWidget = do
           , (ElChainDensity,            elChainDensity)
           , (ElNodeIsLeaderNumber,      elNodeIsLeaderNumber)
           , (ElSlotsMissedNumber,       elSlotsMissedNumber)
-          , (ElForksCreatedNumber,      elForksCreatedNumber)
           , (ElTxsProcessed,            elTxsProcessed)
           , (ElPeersNumber,             elPeersNumber)
           , (ElTraceAcceptorHost,       elTraceAcceptorHost)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -79,7 +79,6 @@ updateGUI nodesState params acceptors nodesStateElems =
     void $ updateElementValue (ElementDouble  $ niChainDensity ni)            $ elements ! ElChainDensity
     void $ updateElementValue (ElementInteger $ niNodeIsLeaderNum ni)         $ elements ! ElNodeIsLeaderNumber
     void $ updateElementValue (ElementInteger $ niSlotsMissedNumber ni)       $ elements ! ElSlotsMissedNumber
-    void $ updateElementValue (ElementInteger $ niForksCreated ni)            $ elements ! ElForksCreatedNumber
     void $ updateElementValue (ElementInteger $ niTxsProcessed ni)            $ elements ! ElTxsProcessed
     void $ updateElementValue (ElementInteger $ niPeersNumber ni)             $ elements ! ElPeersNumber
     void $ updateElementValue (ElementString  acceptorHost)                   $ elements ! ElTraceAcceptorHost
@@ -290,8 +289,6 @@ markOutdatedElements params ni nm els = do
                                                            [els ! ElSlotsMissedNumberOutdateWarning]
   markValueW now (niNodeIsLeaderNumLastUpdate ni) bcLife [els ! ElNodeIsLeaderNumber]
                                                          [els ! ElNodeIsLeaderNumberOutdateWarning]
-  markValueW now (niForksCreatedLastUpdate ni) bcLife [els ! ElForksCreatedNumber]
-                                                      [els ! ElForksCreatedNumberOutdateWarning]
 
   markValueW now (nmRTSGcCpuLastUpdate nm)      rtsLife [els ! ElRTSGcCpu]
                                                         [els ! ElRTSGcCpuOutdateWarning]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -82,8 +82,6 @@ data NodeInfo = NodeInfo
   , niNodeCannotLead                :: !Integer
   , niChainDensity                  :: !Double
   , niChainDensityLastUpdate        :: !Word64
-  , niForksCreated                  :: !Integer
-  , niForksCreatedLastUpdate        :: !Word64
   , niTxsProcessed                  :: !Integer
   , niPeersNumber                   :: !Integer
   , niPeersInfo                     :: ![PeerInfo]
@@ -194,8 +192,6 @@ defaultNodeInfo = NodeInfo
   , niNodeCannotLead                = 0
   , niChainDensity                  = 0.0
   , niChainDensityLastUpdate        = 0
-  , niForksCreated                  = 0
-  , niForksCreatedLastUpdate        = 0
   , niTxsProcessed                  = 0
   , niPeersNumber                   = 0
   , niPeersInfo                     = []

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Updater.hs
@@ -187,8 +187,6 @@ updateNodesState nsMVar loggerName (LogObject aName aMeta aContent) = do
                 nodesStateWith $ updateNodeIsLeader ns leaderNum now
               LogValue "slotsMissedNum" (PureI missedSlotsNum) ->
                 nodesStateWith $ updateSlotsMissed ns missedSlotsNum now
-              LogValue "forksCreatedNum" (PureI createdForksNum) ->
-                nodesStateWith $ updateForksCreated ns createdForksNum now
               _ -> return currentNodesState
            | "cardano.node-metrics" `T.isInfixOf` aName ->
             case aContent of
@@ -568,16 +566,6 @@ updateSlotsMissed ns slotsMissed now = ns { nsInfo = newNi }
     currentNi
       { niSlotsMissedNumber = slotsMissed
       , niSlotsMissedNumberLastUpdate = now
-      }
-  currentNi = nsInfo ns
-
-updateForksCreated :: NodeState -> Integer -> Word64 -> NodeState
-updateForksCreated ns forksCreated now = ns { nsInfo = newNi }
- where
-  newNi =
-    currentNi
-      { niForksCreated = forksCreated
-      , niForksCreatedLastUpdate = now
       }
   currentNi = nsInfo ns
 


### PR DESCRIPTION
After a long discussion (initiated by https://github.com/input-output-hk/cardano-node/issues/1211), it's still unclear how to measure "forks events" properly and if this metric is needed in the RTView at all. So currently we remove `forks created:` metric from the RTView.

Corresponding changes in `cardano-node`: https://github.com/input-output-hk/cardano-node/pull/1315.