### PR TITLE
CAD-1188: drop optics

### DIFF
--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -51,7 +51,6 @@ library
                      , iproute
                      , network
                      , network-mux
-                     , optics
                      , optparse-applicative
                      , ouroboros-consensus
                      , ouroboros-consensus-byron


### PR DESCRIPTION
1. Drop usage of `optics`.
1. Small strictness fix, suggested by @mrBliss.