### PR TITLE
CAD-1230: cleanups

### DIFF
--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -15,4 +15,5 @@ data TxGenError =
   -- ^ TPS is less than lower limit.
   | SecretKeyDeserialiseError !Text
   | SecretKeyReadError !Text
+  | SplittingSubmissionError !Text
   deriving Show


### PR DESCRIPTION
1. Fix local submission error propagation.
1. Properly generalise `txGenerator` over `blk` and eliminate `AvailableFunds`.