### PR TITLE
CAD-XXX:  fixes for benchmarks/shelley3pools/analyse.sh & report compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ analysis
 /logs
 /profile
 
+*.csv
 benchmark-results.log
 launch_node
 result*
 state-*
+timeline-*

--- a/benchmarks/shelley3pools/analyse.sh
+++ b/benchmarks/shelley3pools/analyse.sh
@@ -5,7 +5,7 @@ BASEDIR=$(realpath $(dirname "$0"))
 
 set -e
 
-prebuild 'bm-timeline' || exit 1
+prebuild 'bmtimeline' || exit 1
 
 TSTAMP=$(TZ=UTC date --iso-8601=seconds)
 
@@ -47,10 +47,14 @@ for N in $(seq 0 $((NNODES - 1))); do
   # parameters in genesis.json
   GENESIS=$(find ${LOGPATH}/.. -name "genesis.json" | head -1)
   if [ -e $GENESIS ]; then
-    jq '[ "activeSlotsCoeff", .activeSlotsCoeff, "slotLength", .slotLength, "securityParam", .securityParam, "epochLength", .epochLength, "decentralisationParam", .protocolParams.decentralisationParam ] | @csv' ${GENESIS} > ${OUTDIR}/genesis_parameters.csv
+    jq '[ "activeSlotsCoeff", .activeSlotsCoeff, "slotLength", .slotLength, "securityParam", .securityParam, "epochLength", .epochLength, "decentralisationParam", .protocolParams.decentralisationParam ] | @csv' --raw-output ${GENESIS} > ${OUTDIR}/genesis_parameters.csv
   fi
 done
 
-run reconstruct-timeline ${NNODES} ${OUTDIR} | tee -a ${OUTDIR}/timeline.txt
+run bmtimeline 'stub' ${NNODES} ${OUTDIR} | tee -a ${OUTDIR}/timeline.txt
 cp timeline.csv ${OUTDIR}/
 
+if test -n "$(command -v libreoffice)" &&
+   test -n "$(command -v ssconvert)"
+then ./report.sh "${OUTDIR}"
+fi

--- a/benchmarks/shelley3pools/report.sh
+++ b/benchmarks/shelley3pools/report.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+OUTDIR=$1
+
+set -e
+
+pushd ${OUTDIR}
+
+## Described in:
+## https://wiki.openoffice.org/wiki/Documentation/DevGuide/Spreadsheets/Filter_Options
+declare -A conversion_options
+conversion_options=(
+        ['addtochain']=':44,34,0,1,1/1/2/1/3/5/4/2'
+        ['adopted']=':44,34,0,1,1/1/2/1/3/5/4/2/5/1/6/1'
+        ['cpu']=':44,34,0,1,1/5/2/2/3/1'
+        ['genesis_parameters']=':44,34,0,1,1/1/2/1/3/1/4/1/5/1/6/1/7/1/8/1/9/1/10/1'
+        ['leader']=':44,34,0,1,1/1/2/1/3/5/4/2'
+        ['mem']=':44,34,0,1,1/5/2/2/3/1'
+        ['outcome']=':44,34,0,1,1/1/2/1/3/5/4/2/5/1/6/1/7/1'
+        ['switchedtoafork']=':44,34,0,1,1//2//3/'
+        ['timeline']=':44,34,0,1,1/1/2/1/3/1/4/2/5/1/6/1/7/1'
+        ['tryswitchtoafork']=':44,34,0,1,1//2//3/'
+        ['txadopted']=':44,34,0,1,1/1/2/1/3/5/4/2'
+        ['txmempool']=':44,34,0,1,1/1/2/2/3/5/4/2'
+        ['txrejected']=':44,34,0,1,1/1/2/2/3/5/4/2'
+        ['utxosize']=':44,34,0,1,1/1/2/1/3/5/4/1/5/2'
+)
+
+rm -f -- *.ods
+for csv in *.csv
+do key=$(echo $csv | sed 's_[\.-].*$__g')
+   file_options=${conversion_options[${key}]}
+   if test -z "$file_options"
+   then echo "ERROR:  no converssion_options entry for CSV file $csv (key $key)" >&2
+        exit 1
+   else echo "key $key options $file_options file $csv"
+   fi
+   libreoffice --infilter="csv${file_options}" \
+       --convert-to ods \
+       --outdir . \
+       "$csv" 2>&1 |
+   grep -v 'Theme parsing error: gtk.css\|^$'
+done
+
+report_name=report #$(basename "$OUTDIR")
+rm -f                ${report_name}.ods
+set -x
+ssconvert --merge-to ${report_name}.ods *.ods
+

--- a/scripts/libconfig.sh
+++ b/scripts/libconfig.sh
@@ -16,7 +16,7 @@ CABALPKG_TO_HASKELLNIX_PKGSET=(
         [cardano-db-sync]='cardanoDbSyncHaskellPackages'
         [cardano-rt-view]='cardanoBenchmarkingHaskellPackages'
         [cardano-tx-generator]='cardanoBenchmarkingHaskellPackages'
-        [bm-timeline]='cardanoBenchmarkingHaskellPackages'
+        [bmtimeline]='cardanoBenchmarkingHaskellPackages'
 )
 
 declare -A CABALEXE_TO_CABALPKG
@@ -29,8 +29,7 @@ CABALEXE_TO_CABALPKG=(
         [cardano-rt-view-service]='cardano-rt-view'
         [cardano-tx-generator]='cardano-tx-generator'
         [cardano-tx-generator-byron]='cardano-tx-generator'
-        [bm-timeline]='bm-timeline'
-        [reconstruct-timeline]='bm-timeline'
+        [bmtimeline]='bm-timeline'
 )
 
 declare -A CABALEXE_TO_LIBOPTS

--- a/shell.nix
+++ b/shell.nix
@@ -29,7 +29,9 @@ let
       cabal-install
       stack
       ghcid
+      gnumeric
       hlint
+      libreoffice
       weeder
       nix
       niv


### PR DESCRIPTION
1. make `bmtimeline` runnable & fix `analyse.sh`
1. `report.sh`:  compile a single ODS report file from the CSV bundle