### PR TITLE
Import tx-generator-shelley

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,7 @@ index-state: 2020-04-01T00:00:00Z
 packages:
     cardano-rt-view
     cardano-tx-generator
+    tx-generator-shelley
     bm-timeline
     --ext/cardano-node.git/cardano-api
     --ext/cardano-node.git/cardano-cli

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ compiler: ghc-8.6.5
 packages:
   - cardano-rt-view
   - cardano-tx-generator
+  - tx-generator-shelley
   - bm-timeline
 
   # references to git submodules only in development

--- a/tx-generator-shelley/LICENSE
+++ b/tx-generator-shelley/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tx-generator-shelley/NOTICE
+++ b/tx-generator-shelley/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/tx-generator-shelley/README.md
+++ b/tx-generator-shelley/README.md
@@ -1,0 +1,1 @@
+# Transaction Generator

--- a/tx-generator-shelley/app/cardano-tx-generator-shelley.hs
+++ b/tx-generator-shelley/app/cardano-tx-generator-shelley.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Control.Monad.Trans.Except.Extra
+                   ( runExceptT )
+import           Options.Applicative
+                   ( ParserInfo
+                   , customExecParser, fullDesc, header
+                   , helper, info, prefs, showHelpOnEmpty
+                   , (<**>)
+                   )
+import           System.Exit
+                   (exitFailure)
+
+import           Cardano.Benchmarking.TxGenerator.CLI.Parsers
+                   ( GenerateTxs
+                   , parseCommand
+                   )
+import           Cardano.Benchmarking.TxGenerator.CLI.Run
+                   ( runCommand )
+
+main :: IO ()
+main = do
+  generateTxs <- customExecParser (prefs showHelpOnEmpty) txGenInfo
+  runExceptT (runCommand generateTxs) >>= \case
+    Right _  -> pure ()
+    Left err -> print err >> exitFailure
+ where
+  txGenInfo :: ParserInfo GenerateTxs
+  txGenInfo =
+    info (parseCommand <**> helper)
+         (fullDesc <> header "cardano-tx-generator-shelley - a transaction generator Shelley.")

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Benchmarking.TxGenerator
+  ( TxGenError
+  , genesisBenchmarkRunner
+  )
+where
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async
+import qualified Control.Concurrent.STM as STM
+import           Control.Monad (forM, mapM, when, void)
+import qualified Control.Monad.Class.MonadSTM as MSTM
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra
+import qualified Data.List.NonEmpty as NE
+import           Network.Socket (AddrInfo)
+
+import           Cardano.Config.Logging (LoggingLayer (..))
+
+import           Cardano.Benchmarking.TxGenerator.Error (TxGenError (..))
+import           Cardano.Benchmarking.TxGenerator.NodeToNode (BenchmarkTxSubmitTracers (..),
+                     benchmarkConnectTxSubmit)
+
+import           Control.Tracer (Tracer, traceWith)
+
+import           Ouroboros.Consensus.Shelley.Node as Ouroboros (protocolClientInfoShelley)
+import           Ouroboros.Network.NodeToClient (IOManager)
+import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool (GenTxId)
+import           Ouroboros.Consensus.Shelley.Ledger.Mempool (GenTx, mkShelleyTx)
+import           Cardano.Api as Api
+
+import qualified Cardano.Benchmarking.TxGenerator.CLI.Parsers as P
+import           Cardano.Benchmarking.TxGenerator.Producer as Producer
+import           Cardano.Benchmarking.TxGenerator.Phase1
+import           Cardano.Benchmarking.TxGenerator.Submission
+import           Cardano.Benchmarking.TxGenerator.Types as T
+import           Cardano.Benchmarking.TxGenerator.Utils
+
+-----------------------------------------------------------------------------------------
+-- | Genesis benchmark runner (we call it in 'Run.runNode').
+--
+--   Using a _richman_ (from genesis block) to supply some initial
+--   amount of funds for disbursment.
+-----------------------------------------------------------------------------------------
+genesisBenchmarkRunner
+  :: P.GenerateTxs
+  -> LoggingLayer
+  -> IOManager
+  -> ExceptT TxGenError IO ()
+genesisBenchmarkRunner args loggingLayer iocp = do
+  do
+    let tps = unTPSRate $ P.tps args
+    when (tps < 0.05) $ left $ TooSmallTPSRate $ tps
+
+  let ( benchTracer , connectTracer , submitMuxTracer , _lowLevelSubmitTracer , submitTracer )
+          = createTracers loggingLayer
+
+  let traceIO = traceWith benchTracer . TraceBenchTxSubDebug
+      trace = liftIO . traceIO
+  trace "******* Tx generator, tracers are ready *******"
+
+  liftIO . traceWith benchTracer . TraceBenchTxSubDebug
+    $ "******* Tx generator, signing keys are ready *******"
+
+  trace "******* Tx generator, phase 1: make enough available UTxO entries *******"
+
+  remoteAddresses <- liftIO $ mapM resolveRemoteAddr $ P.nodeAdresses args
+
+  producers <- runPhase1 args remoteAddresses
+
+  do let coolDown = unInitCoolDown $ P.coolDownDelay args
+     trace $ "******* Tx generator: waiting " ++ show coolDown ++ "s *******"
+     liftIO $ threadDelay (coolDown * 1000 * 1000)
+
+  trace "******* Tx generator, phase 2: pay to recipients *******"
+  let benchmarkTracers :: BenchmarkTxSubmitTracers IO Block
+      benchmarkTracers = BenchmarkTracers
+                           { trSendRecvConnect      = connectTracer
+                           , trSendRecvTxSubmission = submitMuxTracer
+                           }
+
+
+  let updROEnv
+        :: ROEnv (Mempool.GenTxId Block) (GenTx Block)
+        -> ROEnv (Mempool.GenTxId Block) (GenTx Block)
+      updROEnv defaultROEnv =
+        ROEnv { targetBacklog     = targetBacklog defaultROEnv
+              , txNumServiceTime  = Just $ minimalTPSRate $ P.tps args
+              , txSizeServiceTime = Nothing
+              }
+
+  let
+    mkNodeTxList addr p = (addr, txs)
+      where
+           -- todo : divide by number of nodes
+       (Right (txSigned,_,_)) = payWithChangeSeq (replicate (unNumberOfTxs $ P.txCount args) $ Lovelace 111) p
+
+       txs = map (\(TxSignedShelley x) -> mkShelleyTx x) txSigned
+    targetNodesAddrsAndTxsLists = zipWith mkNodeTxList (NE.toList remoteAddresses) producers
+
+  txSubmissionTerm <- liftIO $ STM.newTVarIO False
+  case P.explorerAPI args of
+    Nothing ->
+      -- There's no Explorer's API endpoint specified, submit transactions
+      -- to the target nodes via 'ouroboros-network'.
+      liftIO $ do
+        traceIO $ "******* Tx generator, launching Tx peers:  "
+                ++ show (length targetNodesAddrsAndTxsLists) ++ " of them"
+        allAsyncs <- forM targetNodesAddrsAndTxsLists $ \(remoteAddr, txsList) -> do
+          txsListGeneral :: STM.TMVar [GenTx Block] <- liftIO $ STM.newTMVarIO txsList
+
+          r <- launchTxPeer benchTracer
+                       benchmarkTracers
+                       submitTracer
+                       iocp
+                       (P.network args)
+                       txSubmissionTerm
+                       Nothing
+                       remoteAddr
+                       updROEnv
+                       txsListGeneral
+          traceIO $ "******* Tx generator, launched a submission peer for " <> show remoteAddr
+          pure r
+        traceIO $ "******* Tx generator, all "
+                  ++ show (length targetNodesAddrsAndTxsLists) ++ " peers started"
+        let allAsyncs' = concat [[c, s] | (c, s) <- allAsyncs]
+        -- Just wait for all threads to complete.
+        mapM_ (void . wait) allAsyncs'
+    Just (ExplorerAPIEnpoint _endpoint) ->
+      -- Explorer's API endpoint is specified, submit transactions
+      -- to that endpoint using POST-request.
+{-      liftIO $ do
+        initialRequest <- parseRequest endpoint
+        txsList <- concat <$> mapM (STM.atomically . STM.takeTMVar) txsLists
+        submitTxsToExplorer benchTracer initialRequest txsList tpsRate"
+-}
+      error "Just (ExplorerAPIEnpoint endpoint)"
+
+---------------------------------------------------------------------------------------------------
+-- Txs for submission.
+---------------------------------------------------------------------------------------------------
+
+-- | To get higher performance we need to hide latency of getting and
+-- forwarding (in sufficient numbers) transactions.
+--
+-- TODO: transform comments into haddocks.
+--
+launchTxPeer
+  :: forall block txid tx.
+     ( RunNode block
+     , txid ~ Mempool.GenTxId block
+     , tx ~ GenTx block
+     , block ~ Block
+     )
+  => Tracer IO (TraceBenchTxSubmit txid)
+  -- Tracer carrying the benchmarking events
+  -> BenchmarkTxSubmitTracers IO block
+  -- tracer for lower level connection and details of
+  -- protocol interactisn, intended for debugging
+  -- associated issues.
+  -> Tracer IO NodeToNodeSubmissionTrace
+  -> IOManager
+  -- ^ associate a file descriptor with IO completion port
+  -> Network
+  -- ^ network magic
+  -> MSTM.TVar IO Bool
+  -- a "global" stop variable, set to True to force shutdown
+  -> Maybe Network.Socket.AddrInfo
+  -- local address binding (if wanted)
+  -> Network.Socket.AddrInfo
+  -- Remote address
+  -> (ROEnv txid tx -> ROEnv txid tx)
+  -- modifications to the submission engine enviroment to
+  -- control rate etc
+  -> MSTM.TMVar IO [tx]
+  -- give this peer 1 or more transactions, empty list
+  -- signifies stop this peer
+  -> IO (Async (), Async ())
+launchTxPeer tr1 tr2 tr3 iocp network termTM localAddr remoteAddr updROEnv txInChan = do
+  tmv <- MSTM.newEmptyTMVarM
+  (,) <$> (async $ benchmarkConnectTxSubmit
+                     iocp
+                     tr2
+                     Ouroboros.protocolClientInfoShelley
+                     network
+                     localAddr
+                     remoteAddr
+                     (txSubmissionClient tr3 tmv))
+      <*> (async $ bulkSubmission updROEnv tr1 termTM txInChan tmv)

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Parsers.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Parsers.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Cardano.Benchmarking.TxGenerator.CLI.Parsers
+  ( GenerateTxs (..)
+  , InitialFund (..)
+  , parseCommand
+  ) where
+
+import           Cardano.Prelude hiding (option)
+import qualified Data.List.NonEmpty as NE
+import           Prelude (String)
+import           Options.Applicative as Opt
+                    ( Parser
+                    , bashCompleter, completer,flag', help, long, metavar
+                    , auto, option, strOption
+                    )
+import qualified Control.Arrow as Arr
+import           Network.Socket (PortNumber)
+
+import           Cardano.Config.Types
+                    ( SocketPath(..)
+                    , NodeAddress(..)
+                    , NodeHostAddress(..)
+                    )
+
+import           Cardano.Benchmarking.TxGenerator.Types
+import           Cardano.Api
+
+data GenerateTxs = GenerateTxs
+  { network       :: Network
+  , logConfig     :: FilePath
+  , socketPath    :: SocketPath
+  , nodeAdresses  :: (NonEmpty NodeAddress)
+  , txCount       :: NumberOfTxs
+--  , txinputs      :: NumberOfInputsPerTx
+--  , txoutputs     :: NumberOfOutputsPerTx
+  , fee           :: FeePerTx
+  , tps           :: TPSRate
+  , coolDownDelay :: InitCoolDown
+  , extraPayload  :: (Maybe TxAdditionalSize)
+  , explorerAPI   :: (Maybe ExplorerAPIEnpoint)
+  , initialFund   :: InitialFund
+  }
+
+parseCommand :: Parser GenerateTxs
+parseCommand =
+  GenerateTxs
+    <$> pNetwork
+    <*> parseConfigFile
+          "config"
+          "a cardano-node config file (for logging config)"
+    <*> parseSocketPath
+          "socket-path"
+          "Path to a cardano-node socket"
+    <*> (NE.fromList <$> some (
+            parseTargetNodeAddress
+              "target-node"
+              "host and port of the node transactions will be sent to."
+          )
+        )
+    <*> parseNumberOfTxs
+          "num-of-txs"
+          "Number of transactions generator will create."
+{-
+    <*> parseNumberOfInputsPerTx
+          "inputs-per-tx"
+          "Number of inputs in each of transactions."
+    <*> parseNumberOfOutputsPerTx
+          "outputs-per-tx"
+          "Number of outputs in each of transactions."
+-}
+  <*> parseFeePerTx
+          "tx-fee"
+          "Fee per transaction, in Lovelaces."
+    <*> parseTPSRate
+          "tps"
+          "TPS (transaction per second) rate."
+    <*> fmap (fromMaybe defaultInitCooldown)
+          (optional $ parseInitCooldown
+             "init-cooldown"
+             "Delay between init and main submission phases.")
+    <*> optional (
+          parseTxAdditionalSize
+            "add-tx-size"
+            "Additional size of transaction, in bytes."
+        )
+    <*> optional (
+          parseExplorerAPIEndpoint
+            "submit-to-api"
+            "Explorer's API endpoint to submit transaction."
+        )
+    <*>  parseInitialFund
+
+defaultInitCooldown :: InitCoolDown
+defaultInitCooldown = InitCoolDown 100
+
+----------------------------------------------------------------
+
+parseTargetNodeAddress :: String -> String -> Parser NodeAddress
+parseTargetNodeAddress optname desc =
+  option
+    ( uncurry NodeAddress
+      . Arr.first parseHostAddress
+      . Arr.second parsePort
+      <$> auto
+    )
+    $ long optname
+      <> metavar "(HOST,PORT)"
+      <> help desc
+
+parseHostAddress :: String -> NodeHostAddress
+parseHostAddress = NodeHostAddress . Just .
+  maybe (panic "Bad host of target node") identity . readMaybe
+
+parsePort :: Word16 -> PortNumber
+parsePort = fromIntegral
+
+parseNumberOfTxs :: String -> String -> Parser NumberOfTxs
+parseNumberOfTxs opt desc = NumberOfTxs <$> parseIntegral opt desc
+
+parseNumberOfInputsPerTx :: String -> String -> Parser NumberOfInputsPerTx
+parseNumberOfInputsPerTx opt desc = NumberOfInputsPerTx <$> parseIntegral opt desc
+
+parseNumberOfOutputsPerTx :: String -> String -> Parser NumberOfOutputsPerTx
+parseNumberOfOutputsPerTx opt desc = NumberOfOutputsPerTx <$> parseIntegral opt desc
+
+parseFeePerTx :: String -> String -> Parser FeePerTx
+parseFeePerTx opt desc = FeePerTx <$> parseIntegral opt desc
+
+parseTPSRate :: String -> String -> Parser TPSRate
+parseTPSRate opt desc = TPSRate <$> parseFloat opt desc
+
+parseInitCooldown :: String -> String -> Parser InitCoolDown
+parseInitCooldown opt desc = InitCoolDown <$> parseIntegral opt desc
+
+parseTxAdditionalSize :: String -> String -> Parser TxAdditionalSize
+parseTxAdditionalSize opt desc = TxAdditionalSize <$> parseIntegral opt desc
+
+parseExplorerAPIEndpoint :: String -> String -> Parser ExplorerAPIEnpoint
+parseExplorerAPIEndpoint opt desc = ExplorerAPIEnpoint <$> parseUrl opt desc
+
+------------------------------------------------------------------
+
+parseIntegral :: Integral a => String -> String -> Parser a
+parseIntegral optname desc = option (fromInteger <$> auto)
+  $ long optname <> metavar "INT" <> help desc
+
+parseFloat :: String -> String -> Parser Float
+parseFloat optname desc = option (auto)
+  $ long optname <> metavar "FLOAT" <> help desc
+
+parseUrl :: String -> String -> Parser String
+parseUrl optname desc =
+  strOption $ long optname <> metavar "URL" <> help desc
+
+parseFilePath :: String -> String -> Parser FilePath
+parseFilePath optname desc =
+  strOption
+    $ long optname
+        <> metavar "FILEPATH"
+        <> help desc
+        <> completer (bashCompleter "file")
+
+parseSocketPath :: String -> String -> Parser SocketPath
+parseSocketPath optname desc =
+  SocketPath <$> parseFilePath optname desc
+
+parseConfigFile :: String -> String -> Parser FilePath
+parseConfigFile = parseFilePath
+
+
+data InitialFund = InitialFund
+  { value         :: Word64
+  , keyFile       :: FilePath
+  , utxo          :: String
+  , address       :: String
+  } deriving Show
+
+parseInitialFund :: Parser InitialFund
+parseInitialFund
+  = InitialFund
+      <$> (option auto $ long "fund-value"
+           <> help "Lovelace value of the initial fund"
+           <> metavar "LOVELACE"
+          )
+      <*> (strOption   $ long "fund-skey"
+           <> help "signingkey for spending the initial fund"
+           <> metavar "FILE"
+           <> Opt.completer (Opt.bashCompleter "file")
+          )
+      <*> (strOption   $ long "fund-utxo"  <> help "utxo of the initial fund")
+      <*> (strOption   $ long "fund-addr"  <> help "address uses for transactions")
+
+pNetwork :: Parser Network
+pNetwork =
+  pMainnet <|> fmap Testnet pTestnetMagic
+
+pMainnet :: Parser Network
+pMainnet =
+  Opt.flag' Mainnet
+    (  Opt.long "mainnet"
+    <> Opt.help "Use the mainnet magic id."
+    )
+
+pTestnetMagic :: Parser NetworkMagic
+pTestnetMagic =
+  NetworkMagic <$>
+    Opt.option Opt.auto
+      (  Opt.long "testnet-magic"
+      <> Opt.metavar "NATURAL"
+      <> Opt.help "Specify a testnet magic id."
+      )

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Run.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Run.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Benchmarking.TxGenerator.CLI.Run
+  ( runCommand
+  ) where
+
+import qualified Prelude ()
+import           Data.Version
+                    ( showVersion )
+import           Data.Text
+                    ( pack )
+-- todo: fix
+--import           Paths_tx_generator_shelley
+--                    ( version )
+
+import           Cardano.Prelude hiding (option)
+import           Control.Monad.Trans.Except.Extra
+                    ( firstExceptT )
+
+import           Ouroboros.Network.Block (MaxSlotNo (..))
+import           Ouroboros.Network.NodeToClient
+                    ( IOManager
+                    , withIOManager
+                    )
+
+import qualified Cardano.Chain.Genesis as Genesis
+import           Cardano.Config.Logging
+                    ( createLoggingFeature )
+import           Cardano.Node.Protocol.Shelley
+                       ( ShelleyProtocolInstantiationError(..))
+
+import           Cardano.Config.Types
+                    ( DbFile(..), ConfigError(..), ConfigYamlFilePath(..)
+                    , CardanoEnvironment(..)
+                    , ProtocolFilepaths(..), NodeCLI(..)
+                    , NodeProtocolMode(..), Protocol
+                    , TopologyFile(..)
+                    )
+
+import           Cardano.Benchmarking.TxGenerator.Error
+                    ( TxGenError )
+import qualified Cardano.Benchmarking.TxGenerator.CLI.Parsers as P
+                    ( GenerateTxs (..) )
+import           Cardano.Benchmarking.TxGenerator
+                    ( genesisBenchmarkRunner )
+
+data RealPBFTError =
+    IncorrectProtocolSpecified !Protocol
+  | FromProtocolError !ShelleyProtocolInstantiationError
+  | GenesisBenchmarkRunnerError !TxGenError
+  deriving Show
+
+data CliError =
+    GenesisReadError !FilePath !Genesis.GenesisDataError
+  | GenerateTxsError !RealPBFTError
+  | FileNotFoundError !FilePath
+  deriving Show
+
+------------------------------------------------------------------------------------------------
+
+runCommand :: P.GenerateTxs -> ExceptT CliError IO ()
+runCommand args =
+  withIOManagerE $ \iocp -> do
+    let ncli = NodeCLI
+               { nodeMode = RealProtocolMode
+               , nodeAddr = Nothing
+               , configFile = ConfigYamlFilePath $ P.logConfig args
+               , topologyFile = TopologyFile "" -- Tx generator doesn't use topology
+               , databaseFile = DbFile ""       -- Tx generator doesn't use database
+               , socketFile = Just $ P.socketPath args
+               , protocolFiles = ProtocolFilepaths {
+                    byronCertFile = Just ""
+                  , byronKeyFile = Just ""
+                  , shelleyKESFile = Nothing
+                  , shelleyVRFFile = Nothing
+                  , shelleyCertFile = Nothing
+                  }
+               , validateDB = False
+               , shutdownIPC = Nothing
+               , shutdownOnSlotSynced = NoMaxSlotNo
+               }
+
+    (loggingLayer, _) <- firstExceptT (\(ConfigErrorFileNotFound fp) -> FileNotFoundError fp) $
+                             createLoggingFeature
+                                 (pack $ "todo: undefined Version" )--showVersion version)
+                                 NoEnvironment
+                                 ncli
+
+    firstExceptT GenerateTxsError $
+        firstExceptT GenesisBenchmarkRunnerError $
+            genesisBenchmarkRunner args loggingLayer iocp
+
+
+----------------------------------------------------------------------------
+
+withIOManagerE :: (IOManager -> ExceptT e IO a) -> ExceptT e IO a
+withIOManagerE k = ExceptT $ withIOManager (runExceptT . k)

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Error.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Error.hs
@@ -1,0 +1,27 @@
+module Cardano.Benchmarking.TxGenerator.Error
+  ( TxGenError (..)
+  ) where
+
+import           Prelude
+import           Cardano.Api (ApiError)
+import           Cardano.Binary (DecoderError)
+import           Cardano.Benchmarking.TxGenerator.Producer
+
+data TxGenError =
+    CurrentlyCannotSendTxToRelayNode !FilePath
+  -- ^ Relay nodes cannot currently be transaction recipients.
+  | InsufficientFundsForRecipientTx
+  -- ^ Error occurred while creating the target node address.
+  | NeedMinimumThreeSigningKeyFiles ![FilePath]
+  -- ^ Need at least 3 signing key files.
+  | TooSmallTPSRate !Float
+  -- ^ TPS is less than lower limit.
+--  | SecretKeyDeserialiseError !Text
+--  | SecretKeyReadError !Text
+  | UTxOParseError !String
+  | AddrParseError !DecoderError
+  | CardanoApiError !ApiError
+  | TxSubmitError !String
+  | Phase1SplitError !PError
+  -- ^ error from Cardana.Api.Error
+  deriving Show

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/NodeToNode.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/NodeToNode.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans -Wno-unticked-promoted-constructors #-}
+
+module Cardano.Benchmarking.TxGenerator.NodeToNode
+  ( BenchmarkTxSubmitTracers (..)
+  , SendRecvConnect
+  , SendRecvTxSubmission
+  , benchmarkConnectTxSubmit
+  ) where
+
+import           Prelude
+import           Cardano.Prelude (Void, forever)
+
+import qualified Codec.CBOR.Term as CBOR
+import           Codec.Serialise (DeserialiseFailure)
+import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
+import           Data.ByteString.Lazy (ByteString)
+import           Data.Proxy (Proxy (..))
+import           Network.Mux (MuxMode(InitiatorMode), WithMuxBearer (..))
+import           Network.Socket (AddrInfo (..), SockAddr)
+
+import           Control.Tracer (Tracer (..), nullTracer)
+import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo, pClientInfoCodecConfig)
+import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Network.NodeToNode (Codecs(..), defaultCodecs)
+import           Ouroboros.Network.Driver (TraceSendRecv (..))
+import           Ouroboros.Network.Mux
+                   (OuroborosApplication(..), MuxPeer(..), RunMiniProtocol(..))
+import           Ouroboros.Network.NodeToNode (NetworkConnectTracers (..))
+import qualified Ouroboros.Network.NodeToNode as NtN
+import           Ouroboros.Network.NodeToClient (IOManager, chainSyncPeerNull)
+import           Ouroboros.Network.Protocol.BlockFetch.Client (BlockFetchClient(..), blockFetchClientPeer)
+import           Ouroboros.Network.Protocol.Handshake.Type (Handshake)
+import           Ouroboros.Network.Protocol.Handshake.Version (Versions, simpleSingletonVersions)
+import           Ouroboros.Network.Protocol.TxSubmission.Client (TxSubmissionClient, txSubmissionClientPeer)
+import           Ouroboros.Network.Snocket (socketSnocket)
+
+import           Cardano.Api (Network, toNetworkMagic)
+
+import           Cardano.Benchmarking.TxGenerator.Types
+
+type SendRecvConnect = WithMuxBearer
+                         NtN.RemoteConnectionId
+                         (TraceSendRecv (Handshake
+                                           NtN.NodeToNodeVersion
+                                           CBOR.Term))
+
+data BenchmarkTxSubmitTracers m blk = BenchmarkTracers
+  { trSendRecvConnect      :: Tracer m SendRecvConnect
+  , trSendRecvTxSubmission :: Tracer m (SendRecvTxSubmission blk)
+  }
+
+benchmarkConnectTxSubmit
+  :: forall m blk . (RunNode blk, m ~ IO)
+  => IOManager
+  -> BenchmarkTxSubmitTracers m blk
+  -- ^ For tracing the send/receive actions
+  -> ProtocolClientInfo blk
+  -- ^ The particular block protocol
+  -> Network
+  -- ^ Network(Magic)
+  -> Maybe AddrInfo
+  -- ^ local address information (typically local interface/port to use)
+  -> AddrInfo
+  -- ^ remote address information
+  -> TxSubmissionClient (GenTxId blk) (GenTx blk) m ()
+  -- ^ the particular txSubmission peer
+  -> m ()
+benchmarkConnectTxSubmit iocp trs cfg network localAddr remoteAddr myTxSubClient =
+  NtN.connectTo
+    (socketSnocket iocp)
+    NetworkConnectTracers {
+        nctMuxTracer       = nullTracer,
+        nctHandshakeTracer = trSendRecvConnect trs
+      }
+    peerMultiplex
+    (addrAddress <$> localAddr)
+    (addrAddress remoteAddr)
+ where
+  myCodecs :: Codecs blk DeserialiseFailure m
+                ByteString ByteString ByteString ByteString ByteString
+  myCodecs  = defaultCodecs (pClientInfoCodecConfig cfg) (mostRecentSupportedNodeToNode (Proxy @blk))
+  peerMultiplex :: Versions NtN.NodeToNodeVersion NtN.DictVersion
+                     (OuroborosApplication InitiatorMode SockAddr ByteString IO () Void)
+  peerMultiplex =
+    simpleSingletonVersions
+      NtN.NodeToNodeV_1
+      (NtN.NodeToNodeVersionData { NtN.networkMagic = toNetworkMagic network})
+      (NtN.DictVersion NtN.nodeToNodeCodecCBORTerm) $
+      NtN.nodeToNodeProtocols NtN.defaultMiniProtocolParameters $ \_ _->
+        NtN.NodeToNodeProtocols
+          { NtN.chainSyncProtocol = InitiatorProtocolOnly $
+                                      MuxPeer
+                                        nullTracer
+                                        (cChainSyncCodec myCodecs)
+                                        chainSyncPeerNull
+          , NtN.blockFetchProtocol = InitiatorProtocolOnly $
+                                       MuxPeer
+                                         nullTracer
+                                         (cBlockFetchCodec myCodecs)
+                                         (blockFetchClientPeer blockFetchClientNull)
+          , NtN.txSubmissionProtocol = InitiatorProtocolOnly $
+                                         MuxPeer
+                                           (trSendRecvTxSubmission trs)
+                                           (cTxSubmissionCodec myCodecs)
+                                           (txSubmissionClientPeer myTxSubClient)
+          }
+
+-- the null block fetch client
+blockFetchClientNull
+  :: forall block m a.  MonadTimer m
+  => BlockFetchClient block m a
+blockFetchClientNull
+  = BlockFetchClient $ forever $ threadDelay (24 * 60 * 60) {- one day in seconds -}

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Phase1.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Phase1.hs
@@ -1,0 +1,45 @@
+{-# Language LambdaCase #-}
+module Cardano.Benchmarking.TxGenerator.Phase1
+where
+
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Except.Extra
+import           Control.Monad.IO.Class
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as Text
+
+import qualified Cardano.Benchmarking.TxGenerator.CLI.Parsers as P
+import           Cardano.Benchmarking.TxGenerator.Error (TxGenError (..))
+import           Cardano.Benchmarking.TxGenerator.Producer as Producer
+import           Cardano.Benchmarking.TxGenerator.Submission
+import           Cardano.Benchmarking.TxGenerator.Types as T
+
+import           Cardano.Api as Api
+
+runPhase1 :: P.GenerateTxs -> NE.NonEmpty a0 -> ExceptT TxGenError IO [Producer]
+runPhase1 args remoteAddresses = do
+  skey    <- withExceptT CardanoApiError $ newExceptT $ readSigningKey keyFile
+  utxoIn  <- withExceptT UTxOParseError $ hoistEither $ parseTxIn $ Text.pack utxo
+  srcAddr <- withExceptT AddrParseError $ hoistEither $ addressFromHex $ Text.pack address
+  let initialFund = Producer.Producer
+         { Producer.network = network
+         , Producer.ttl  = SlotNo 10000000
+         , Producer.fee  = Lovelace $ fromIntegral $ T.unFeePerTx $ P.fee args
+         , Producer.addr = srcAddr
+         , Producer.skey = skey
+         , Producer.src  = utxoIn
+         , Producer.fund = Lovelace $ fromIntegral value
+         }
+  (tx,p) <- withExceptT Phase1SplitError $ hoistEither $ Producer.split splitList initialFund
+  newExceptT $ fmap mapSubmitError $ Api.submitTx network (P.socketPath args) tx
+  return p
+  where
+    (P.InitialFund value keyFile utxo address) = P.initialFund args
+    txCount = NE.length remoteAddresses
+    splitVal = Lovelace $ fromIntegral (value - (T.unFeePerTx $ P.fee args) ) `div` fromIntegral txCount
+    splitList :: [Lovelace]
+    splitList = replicate txCount splitVal
+    network = P.network args
+    mapSubmitError e = case e of
+      TxSubmitSuccess -> Right ()
+      err             -> Left $ TxSubmitError $ show err

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Producer.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Producer.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+module Cardano.Benchmarking.TxGenerator.Producer
+where
+
+import           Prelude
+import qualified Data.Map as Map
+
+import           Cardano.Api
+import           Shelley.Spec.Ledger.TxData as Shelley (Wdrl(..))
+
+deriving instance Num Lovelace
+deriving instance Ord Lovelace
+
+{-
+It may be possible to use a fancy co-monad here.
+-}
+data Producer = Producer
+  { network :: !Network
+  , ttl     :: !SlotNo
+  , fee     :: !Lovelace
+  , addr    :: !Address
+  , skey    :: !SigningKey
+  , src     :: !TxIn
+  , fund    :: !Lovelace
+  } deriving (Show)
+
+data PError = UnsufficientFunds
+  deriving (Show,Eq)
+
+extract :: Producer -> (TxIn, Lovelace)
+extract (Producer {src, fund}) = (src, fund)
+
+setFunds :: Producer -> TxIn -> Lovelace -> Producer
+setFunds p txIn ada = p { src = txIn, fund = ada}
+
+fullTransfer :: Producer -> Either PError (TxSigned, Producer)
+fullTransfer p@(Producer {..})
+  = if fee > fund
+    then Left UnsufficientFunds
+    else Right (txSigned, setFunds p newSrc newVal)
+  where
+    newVal = fund - fee
+    tx = buildTX
+      [ src ]
+      [ TxOut addr newVal ]
+      ttl
+      fee
+    newSrc = TxIn (getTransactionId tx) 0
+    txSigned = signTransaction tx network [skey]
+
+payWithChange :: Lovelace -> Producer -> Either PError (TxSigned, Producer, Producer)
+payWithChange payment p@(Producer {..})
+  = if fund < payment + fee
+      then Left UnsufficientFunds
+      else Right (txSigned, p0, p1)
+  where
+    change = fund - payment - fee
+    tx = buildTX
+      [ src ]
+      [ TxOut addr payment , TxOut addr change ]
+      ttl
+      fee
+    txSigned = signTransaction tx network [skey]
+    txId = getTransactionId tx
+    p0 = setFunds p (TxIn txId 0) payment
+    p1 = setFunds p (TxIn txId 1) change
+
+payWithChangeSeq :: [Lovelace] -> Producer -> Either PError ([TxSigned], [Producer], Producer)
+payWithChangeSeq []  p = Right ([], [], p)
+payWithChangeSeq (ada:l) p = do
+  (tx, out, rest ) <- payWithChange ada p
+  (txs, outs, change) <- payWithChangeSeq l rest
+  return (tx:txs, out:outs, change)
+
+split :: [Lovelace] -> Producer -> Either PError (TxSigned, [Producer] )
+split outValues p@(Producer {..})
+  = if fund < fee + sum outValues
+      then Left UnsufficientFunds
+      else Right (txSigned, outs)
+  where
+    tx = buildTX
+      [ src ]
+      (map (\l -> TxOut addr l) outValues)
+      ttl
+      fee
+    txSigned = signTransaction tx network [skey]
+    txId = getTransactionId tx
+    outs = map (\(ada, ix) -> setFunds p (TxIn txId ix) ada)
+               $ zip outValues [0..]
+
+buildTX :: [TxIn] -> [TxOut] -> SlotNo -> Lovelace -> TxUnsigned
+buildTX src dest ttl fee
+  = buildShelleyTransaction src dest ttl fee [] emptyWithdrawl Nothing Nothing
+  where
+    emptyWithdrawl = WithdrawalsShelley $ Shelley.Wdrl Map.empty
+

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Submission.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Submission.hs
@@ -1,0 +1,522 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+{-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Benchmarking.TxGenerator.Submission
+  ( ROEnv(..)
+  , RPCTxSubmission(..)
+  , TraceBenchTxSubmit(..)
+  , TraceLowLevelSubmit (..)
+  , bulkSubmission
+  , submitTx
+  , NodeToNodeSubmissionTrace(..)
+  , txSubmissionClient
+  ) where
+
+import           Prelude (error, id)
+import           Cardano.Prelude hiding (ByteString, atomically, retry, threadDelay)
+
+import           Control.Exception (assert)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadSTM (MonadSTM, TMVar, TVar,
+                   atomically, newEmptyTMVarM, putTMVar, readTVar, retry,
+                   takeTMVar, tryTakeTMVar)
+import qualified Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime (MonadTime(..), Time, addTime,
+                   diffTime, getMonotonicTime)
+import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
+
+import           Data.ByteString.Lazy (ByteString)
+import           Data.List.NonEmpty (fromList)
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+import           Data.Time.Clock (DiffTime)
+import           Data.Void (Void)
+
+import           Cardano.BM.Tracing
+import           Control.Tracer (Tracer, traceWith)
+
+import           Ouroboros.Consensus.Block.Abstract (getCodecConfig)
+import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
+import           Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool (GenTx)
+import           Ouroboros.Consensus.Config (TopLevelConfig(..))
+import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
+                   ( ApplyTxErr, GenTxId, HasTxId, txId, txInBlockSize)
+import           Ouroboros.Consensus.Network.NodeToClient
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                  (HasNetworkProtocolVersion (..), nodeToClientProtocolVersion, supportedNodeToClientVersions)
+import           Ouroboros.Consensus.Node.Run (RunNode(..))
+
+import           Ouroboros.Network.Mux
+                   ( MuxMode(..), OuroborosApplication(..),
+                     MuxPeer(..), RunMiniProtocol(..) , RunOrStop)
+import           Ouroboros.Network.Driver (runPeer)
+import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as LocalTxSub
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult(..))
+import           Ouroboros.Network.Protocol.Handshake.Version (Versions)
+import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle(..),
+                                                                 ClientStTxs(..),
+                                                                 ClientStTxIds(..),
+                                                                 TxSubmissionClient(..))
+import           Ouroboros.Network.Protocol.TxSubmission.Type (BlockingReplyList(..),
+                                                               TokBlockingStyle(..),
+                                                               TxSizeInBytes)
+import           Ouroboros.Network.NodeToClient (IOManager,
+                                                 NetworkConnectTracers(..),
+                                                 NodeToClientVersionData(..),
+                                                 foldMapVersions,
+                                                 versionedNodeToClientProtocols)
+import qualified Ouroboros.Network.NodeToClient as NodeToClient
+
+import           Cardano.Config.Types (SocketPath(..))
+
+import           Cardano.Benchmarking.TxGenerator.Types
+
+-- | Bulk submisson of transactions.
+--
+--   This is intended to be used as a seperate process that interfaces
+--   between some form of transaction generation mechanism
+--   (e.g. benchmarking) and the local Ouroboros protocol peer. It has
+--   configurable latency hiding (number of transactions to try to
+--   keep ahead of actual submission) and has tracing that both
+--   reports observables related to transaction submission and whether
+--   the tx generation is able to keep up the pace.
+--
+--   For the details of the protocol description see
+--   `TxSubmission` and its associated instances
+--   (e.g. `Message`).
+bulkSubmission
+  :: forall blk txid tx .
+     ( Ord txid
+     , Mempool.HasTxId tx
+     , RunNode blk
+     , tx ~ Mempool.GenTx blk, txid ~ Mempool.GenTxId blk)
+  => (ROEnv txid tx -> ROEnv txid tx)
+  -- changes to default settings
+  -> Tracer IO (TraceBenchTxSubmit txid)
+  -> TVar IO Bool
+  -- Set to True to indicate subsystem should terminate
+  -> TMVar IO [tx]
+  -- non-empty list of transactions to be forwarded,
+  -- empty list indicates terminating
+  -> TMVar IO (RPCTxSubmission IO txid tx)
+  -- the RPC variable shared with
+  -- `TxSubmission` local peer
+  -> IO ()
+bulkSubmission updEnv tr termVar txIn rpcIn =
+  -- liftIO $ putStrLn "bulkSubmission__0"
+  defaultRWEnv >>= evalStateT (go $ updEnv defaultROEnv)
+ where
+  go :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
+  go env = do
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, env: " ++ show env
+    shutdown <- gets (\RWEnv{terminating, inFlight, notYetSent} ->
+                       terminating &&
+                       Seq.null inFlight &&
+                       Seq.null notYetSent)
+    if shutdown
+    then do -- terminating normally, inform local peer
+      -- check if remote peer is waiting on us
+      -- lift . traceWith tr . TraceBenchTxSubDebug $ "TERMINATING normally"
+      (opP, op) <- maybe (False, error "internal error")
+                         (\x -> (True,snd x)) <$> gets availableOp
+--        liftIO $ putStrLn $ "TERMINATING normally, opP: " ++ show opP
+      lift . atomically $
+        if opP
+        then putTMVar op Nothing
+        else do
+          reqTxIds <- takeTMVar rpcIn -- no other message should occur as nothing is in flight
+          case reqTxIds of
+            RPCRequestTxIds _ resp -> putTMVar resp Nothing
+            _ -> return ()
+    else  -- process next interaction
+      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, process next interaction"
+      go1 env
+
+  go1 :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
+  go1 env = do
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, env: " ++ show env
+    terminating' <- gets terminating
+    notYetSent'  <- gets notYetSent
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, terminating': " ++ show terminating'
+
+    -- perform the blocking inquiry
+    (nowTerminating, newTxs, rpc) <- lift . atomically $ do
+      -- just looking for the transition to terminating here
+      term' <- if terminating'
+               then pure False
+               else readTVar termVar
+      -- try get more txs if our target backlog permits
+      txs' <- if Seq.length notYetSent' < targetBacklog env &&
+                 not terminating'
+              then tryTakeTMVar txIn
+              else pure Nothing
+      -- always willing to interact with local peer
+      rpc' <- tryTakeTMVar rpcIn
+      -- check there was some change to process
+      unless (term' || isJust txs' || isJust rpc') retry
+      -- treat empty input transaction list as equiv to
+      -- terminating
+      let (term,txs) =
+            case txs' of
+              Just x | null x
+                       -> (True, Nothing)
+              _        -> (term', txs')
+      pure (term || terminating', txs, rpc')
+
+    -- Update terminating, if needed
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, update terminating, if needed"
+    when (nowTerminating && not terminating') $
+      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, update terminating: True"
+      modify (\x -> x {terminating = True})
+
+    -- incorporate new transactions from the generator into
+    -- NotYetSent
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, incorporate new transactions from the generator into NotYetSent"
+    flip (maybe (pure ())) newTxs $ \xs -> do
+      let newTxs' = map (\x -> (getTxId x, x, getTxSize x)) xs
+      -- lift . traceWith tr . TraceBenchTxSubDebug $ "go1, newTxs' size: " ++ show (length newTxs')
+      lift . traceWith tr . TraceBenchTxSubRecv $ map (\(a,_,_) -> a) newTxs'
+      modify (\x -> x {notYetSent = notYetSent x Seq.>< Seq.fromList newTxs'})
+
+    -- if remote peer is waiting on us and there is something to be
+    -- sent: reply to the outstanding operation.
+    opP <- isJust <$> gets availableOp
+    haveStuffP <- (not . Seq.null) <$> gets notYetSent
+    when (opP && haveStuffP) $ processOp env
+
+    -- process any interaction with the local peer
+    flip (maybe (pure ())) rpc $ processRPC env
+
+    -- and recurse
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "go, recurse"
+    go env
+
+  getTxId :: tx -> txid
+  getTxId = Mempool.txId
+
+  getTxSize :: tx -> TxSizeInBytes
+  getTxSize = txInBlockSize
+
+  processOp :: ROEnv txid tx -> StateT (RWEnv IO txid tx) IO ()
+  processOp env = do
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, env: " ++ show env
+    (window, op) <- (maybe (error "internal error")) id <$> gets availableOp
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, window: " ++ show window
+    (send,store) <- Seq.splitAt window <$> gets notYetSent
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, send size: " ++ show (length send)
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, store size: " ++ show (length store)
+    let send' = toList send
+    checkRateLimiter
+    lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
+    lift . atomically $ putTMVar op (Just $ [(a,c) | (a,_,c) <-  send'])
+    setRateLimiter env [ c | (_,_,c) <- send']
+    modify (\x -> x { availableOp = Nothing
+                    , inFlight    = inFlight x Seq.>< send
+                    , notYetSent  = store })
+    -- lift . traceWith tr . TraceBenchTxSubDebug $ "processOp, done."
+
+  processRPC :: ROEnv txid tx -> RPCTxSubmission IO txid tx -> StateT (RWEnv IO txid tx) IO ()
+  processRPC env =
+    \case
+      RPCRequestTxs  txids resp -> do
+        -- lift . traceWith tr . TraceBenchTxSubDebug $ "processRPC, RPCRequestTxs"
+        lift . traceWith tr $ TraceBenchTxSubServReq txids
+        let txset = Set.fromList txids
+        result <- Seq.filter (\(x,_,_) -> Set.member x txset) <$> gets inFlight
+        lift . atomically $ putTMVar resp [b |(_,b,_) <- toList result]
+
+      -- if blocking (deferred response) then the window has to be
+      -- greater than zero, otherwise you can never respond (as the
+      -- list has to be non empty)
+      RPCRequestTxIds (acked, window) resp -> assert (window > 0) $ do
+      -- prompt reply NOT expected (blocking)
+        -- lift . traceWith tr . TraceBenchTxSubDebug $ "processRPC, RPCRequestTxIds"
+        haveWork <- (not . Seq.null) <$> gets notYetSent
+        if haveWork
+        then do
+          checkRateLimiter
+          (send,store) <- Seq.splitAt (fromIntegral window) <$> gets notYetSent
+          let send' = toList send
+          lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
+          lift . atomically $ putTMVar resp (Just $ [(a,c) | (a,_,c) <-  send'])
+          setRateLimiter env [ c | (_,_,c) <- send']
+          modify (\x -> x { inFlight    = inFlight x Seq.>< send
+                            , notYetSent  = store })
+          noteBusy
+        else do
+          noteIdle
+          modify (\x -> x { availableOp = Just (fromIntegral window, resp)})
+
+        -- deal with acked txs
+        processAcks acked
+
+      RPCRequestTxIdsPromptly (acked, window) resp -> do
+      -- prompt reply expected
+        haveWork <- (not . Seq.null) <$> gets notYetSent
+        if haveWork
+        then do
+          checkRateLimiter
+          (send,store) <- Seq.splitAt (fromIntegral window) <$> gets notYetSent
+          let send' = toList send
+          lift . traceWith tr . TraceBenchTxSubStart $ [a | (a,_,_) <- send']
+          lift . atomically $ putTMVar resp [(a,c) | (a,_,c) <-  send']
+          setRateLimiter env [ c | (_,_,c) <- send']
+          modify (\x -> x { inFlight    = inFlight x Seq.>< send
+                          , notYetSent  = store })
+          noteBusy
+        else do
+          noteIdle
+          lift . atomically $ putTMVar resp []
+          modify (\x -> x { availableOp = Nothing })
+
+        -- deal with acked txs
+        processAcks acked
+
+  checkRateLimiter :: StateT (RWEnv IO txid tx) IO ()
+  checkRateLimiter = do
+    waitUntil <- gets proceedAfter
+    sleepFor <- (\x -> waitUntil `diffTime` x) <$> lift getMonotonicTime
+    when (sleepFor > 0) . lift $ do
+      traceWith tr $ TraceBenchTxSubRateLimit sleepFor
+      threadDelay sleepFor
+
+  setRateLimiter
+    :: ROEnv txid tx
+    -> [TxSizeInBytes]
+    -> StateT (RWEnv IO txid tx) IO ()
+  setRateLimiter env tls = do
+    let txLimit   = (* fromIntegral (length tls)) <$> txNumServiceTime  env
+        sizeLimit = (* fromIntegral (sum    tls)) <$> txSizeServiceTime env
+        limit     = max txLimit sizeLimit
+    flip (maybe (pure ())) limit $ \d -> do
+      liftIO . traceWith tr . TraceBenchTxSubDebug
+        $ "******* sleeping for " ++ show d
+      waitUntil <- (addTime d) <$> lift getMonotonicTime
+      modify (\x -> x { proceedAfter = waitUntil })
+
+  processAcks :: Word16 -> StateT (RWEnv IO txid tx) IO ()
+  processAcks acked  =  when (acked > 0) $ do
+    (done, left) <- (Seq.splitAt (fromIntegral acked)) <$> gets inFlight
+    lift . traceWith tr $ TraceBenchTxSubServAck [a | (a,_,_) <- toList done]
+    modify (\x -> x {inFlight = left})
+
+  noteIdle :: StateT (RWEnv IO txid tx) IO ()
+  noteIdle = do
+--      liftIO $ putStrLn $ "noteIdle"
+    wasBusy <- (== Busy) <$> gets activityState
+    when wasBusy $ do
+      lift . traceWith tr $ TraceBenchTxSubIdle
+--        liftIO $ putStrLn $ "noteIdle, Idle!"
+      modify (\x -> x { activityState = Idle})
+
+  noteBusy :: StateT (RWEnv IO txid tx) IO ()
+  noteBusy = do -- just can't get those memory write cycles out of my head
+--      liftIO $ putStrLn $ "noteBusy"
+    wasIdle <- (== Idle) <$> gets activityState
+    when wasIdle $
+--        liftIO $ putStrLn $ "noteBusy, Busy!"
+      modify (\x -> x { activityState = Busy})
+
+data ActivityState = Idle | Busy deriving (Eq)
+
+-- | The readonly environment
+data ROEnv txid tx = ROEnv
+  { targetBacklog     :: Int -- ^ how many to try to keep in back pocket, >0
+  , txNumServiceTime  :: Maybe DiffTime -- ^ seconds per tx
+  , txSizeServiceTime :: Maybe DiffTime -- ^ seconds per tx octet
+  } deriving Show
+
+defaultROEnv :: ROEnv txid tx
+defaultROEnv = ROEnv
+  { targetBacklog     = 1
+  , txNumServiceTime  = Nothing
+  , txSizeServiceTime = Nothing
+  }
+
+data RWEnv m txid tx = RWEnv
+  { terminating     :: Bool
+  , activityState   :: ActivityState
+  , proceedAfter    :: Time
+  , availableOp     :: Maybe (Int, TMVar m (Maybe [(txid, TxSizeInBytes)]))
+  -- ^ the window and the response action
+  , inFlight
+  , notYetSent      :: Seq (txid, tx,  TxSizeInBytes)
+  }
+
+defaultRWEnv :: MonadTime m => m (RWEnv m txid tx)
+defaultRWEnv = do
+  now <- getMonotonicTime
+  pure $ RWEnv
+    { terminating     = False
+    , activityState   = Idle
+    , proceedAfter    = now
+    , availableOp     = Nothing
+    , inFlight        = mempty
+    , notYetSent      = mempty
+    }
+
+
+{-------------------------------------------------------------------------------
+  Main logic
+-------------------------------------------------------------------------------}
+
+submitTx :: ( RunNode blk
+            , Show (ApplyTxErr blk)
+            )
+         => IOManager
+         -> SocketPath
+         -> TopLevelConfig blk
+         -> GenTx blk
+         -> Tracer IO TraceLowLevelSubmit
+         -> IO ()
+submitTx iocp sockpath cfg tx tracer =
+    let path = unSocketPath sockpath
+    in NodeToClient.connectTo
+         (NodeToClient.localSnocket iocp path)
+         NetworkConnectTracers {
+             nctMuxTracer       = nullTracer,
+             nctHandshakeTracer = nullTracer
+           }
+         (localInitiatorNetworkApplication tracer cfg tx)
+         path
+
+
+localInitiatorNetworkApplication
+  :: forall blk m .
+     ( RunNode blk
+     , MonadST m
+     , MonadThrow m
+     , MonadTimer m
+     , Show (ApplyTxErr blk)
+     )
+  => Tracer m TraceLowLevelSubmit
+  -> TopLevelConfig blk
+  -> GenTx blk
+  -> Versions NodeToClient.NodeToClientVersion NodeToClient.DictVersion
+              (OuroborosApplication InitiatorMode NodeToClient.LocalAddress ByteString m () Void)
+
+localInitiatorNetworkApplication tracer cfg tx =
+  foldMapVersions
+    (\v ->
+      versionedNodeToClientProtocols
+        (nodeToClientProtocolVersion proxy v)
+        versionData
+        (protocols v))
+    (supportedNodeToClientVersions proxy)
+ where
+    proxy :: Proxy blk
+    proxy = Proxy
+
+    versionData = NodeToClientVersionData $ getNetworkMagic $ configBlock cfg
+
+    protocols :: BlockNodeToClientVersion blk
+              -> NodeToClient.ConnectionId NodeToClient.LocalAddress
+              -> Control.Monad.Class.MonadSTM.STM m RunOrStop
+              -> NodeToClient.NodeToClientProtocols InitiatorMode ByteString m () Void
+    protocols byronClientVersion _ _ =
+        NodeToClient.NodeToClientProtocols {
+          NodeToClient.localChainSyncProtocol =
+            InitiatorProtocolOnly $
+              MuxPeer
+                nullTracer
+                cChainSyncCodec
+                NodeToClient.chainSyncPeerNull
+
+        , NodeToClient.localTxSubmissionProtocol =
+            InitiatorProtocolOnly $
+              MuxPeerRaw $ \channel -> do
+                traceWith tracer TraceLowLevelSubmitting
+                (result, maybs) <- runPeer
+                            nullTracer -- (contramap show tracer)
+                            cTxSubmissionCodec
+                            channel
+                            (LocalTxSub.localTxSubmissionClientPeer
+                               (txSubmissionClientSingle tx))
+                case result of
+                  SubmitSuccess -> traceWith tracer TraceLowLevelAccepted
+                  SubmitFail msg -> traceWith tracer (TraceLowLevelRejected $ show msg)
+                return ((), maybs)
+
+        , NodeToClient.localStateQueryProtocol =
+            InitiatorProtocolOnly $
+              MuxPeer
+                nullTracer
+                cStateQueryCodec
+                NodeToClient.localStateQueryPeerNull
+        }
+     where
+      Codecs { cChainSyncCodec
+             , cTxSubmissionCodec
+             , cStateQueryCodec
+             } = defaultCodecs (getCodecConfig $ configBlock cfg) byronClientVersion
+
+
+-- | A 'LocalTxSubmissionClient' that submits exactly one transaction, and then
+-- disconnects, returning the confirmation or rejection.
+--
+txSubmissionClientSingle
+  :: forall tx reject m.
+     Applicative m
+  => tx
+  -> LocalTxSub.LocalTxSubmissionClient tx reject m (LocalTxSub.SubmitResult reject)
+txSubmissionClientSingle tx = LocalTxSub.LocalTxSubmissionClient $
+    pure $ LocalTxSub.SendMsgSubmitTx tx $ \mreject ->
+      pure (LocalTxSub.SendMsgDone mreject)
+
+txSubmissionClient
+  :: forall m block txid tx .
+     ( MonadSTM m
+     , txid ~ Mempool.GenTxId block
+     , tx ~ GenTx block)
+  => Tracer m NodeToNodeSubmissionTrace
+  -> TMVar m (RPCTxSubmission m txid tx)
+  -> TxSubmissionClient txid tx m ()
+txSubmissionClient tr tmvReq =
+  TxSubmissionClient $ pure client
+ where
+  client = ClientStIdle
+    { recvMsgRequestTxIds = \blocking acked window ->
+        case blocking of
+          TokBlocking -> do -- prompt reply not required
+            traceWith tr $ ReqIdsBlocking acked window
+            resp' <- newEmptyTMVarM
+            atomically . putTMVar tmvReq $
+              RPCRequestTxIds (acked, window) resp'
+            -- might be some delay at this point
+            r <- atomically $ takeTMVar resp'
+            case r of
+              Nothing  -> do
+                traceWith tr $ EndOfProtocol
+                pure $ SendMsgDone ()
+              Just txs -> do
+                traceWith tr $ IdsListPrompt (length txs)
+                pure $ SendMsgReplyTxIds (BlockingReply $ fromList txs) client
+          TokNonBlocking -> do -- prompt reply required
+            traceWith tr $ ReqIdsPrompt acked window
+            resp' <- newEmptyTMVarM
+            atomically . putTMVar tmvReq $
+              RPCRequestTxIdsPromptly (acked, window) resp'
+            txs <- atomically $ takeTMVar resp'
+            traceWith tr $ IdsListBlocking (length txs)
+            pure $ SendMsgReplyTxIds (NonBlockingReply txs) client
+    , recvMsgRequestTxs = \txids -> do
+        traceWith tr $ ReqTxs (length txids)
+        resp' <- newEmptyTMVarM
+        atomically $ putTMVar tmvReq $ RPCRequestTxs txids resp'
+        r <- atomically $ takeTMVar resp'
+        traceWith tr $ TxList (length r)
+        pure $ SendMsgReplyTxs r client
+    , recvMsgKThxBye = return ()
+    }

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
@@ -1,0 +1,318 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Benchmarking.TxGenerator.Types
+where
+
+import           Control.Monad.IO.Class
+import           Data.Aeson (ToJSON (..), (.=))
+import qualified Data.Aeson as A
+import           Data.ByteString (ByteString)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import           Data.Text (Text)
+import           Data.Time.Clock (DiffTime, getCurrentTime)
+import           Data.Word
+
+import           Cardano.BM.Tracing
+import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Tracer (emptyObject, mkObject, trStructured)
+
+import           Cardano.TracingOrphanInstances.Byron ()
+import           Cardano.TracingOrphanInstances.Common ()
+import           Cardano.TracingOrphanInstances.Consensus ()
+import           Cardano.TracingOrphanInstances.Mock ()
+import           Cardano.TracingOrphanInstances.Shelley ()
+import           Cardano.TracingOrphanInstances.Network ()
+
+import qualified Cardano.Chain.UTxO as CC.UTxO
+
+import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool (GenTx)
+import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
+                   ( GenTxId, TxId)
+import           Ouroboros.Network.Driver (TraceSendRecv (..))
+import qualified Ouroboros.Network.Protocol.TxSubmission.Type as TS
+
+import           Control.Monad.Class.MonadSTM (TMVar)
+
+type              Block = ShelleyBlock  TPraosStandardCrypto
+type              Transaction = CC.UTxO.ATxAux ByteString
+
+newtype NumberOfTxs = NumberOfTxs {unNumberOfTxs :: Int}
+  deriving (Eq, Ord, Show)
+
+newtype NumberOfInputsPerTx =
+  NumberOfInputsPerTx Int
+  deriving (Eq, Ord, Show)
+
+newtype NumberOfOutputsPerTx =
+  NumberOfOutputsPerTx Int
+  deriving (Eq, Ord, Show)
+
+newtype FeePerTx = FeePerTx {unFeePerTx :: Word64}
+  deriving (Eq, Ord, Show)
+
+newtype TPSRate = TPSRate {unTPSRate :: Float}
+  deriving (Eq, Ord, Show)
+
+-- | How long wait before starting the main submission phase,
+--   after the init Tx batch was submitted.
+newtype InitCoolDown = InitCoolDown {unInitCoolDown :: Int}
+  deriving (Eq, Ord, Show)
+
+-- | This parameter specifies additional size (in bytes) of transaction.
+--   Since 1 transaction is ([input] + [output] + attributes), its size
+--   is defined by its inputs and outputs. We want to have an ability to
+--   increase transaction's size without increasing the number of inputs/
+--   outputs. Such a big transaction will give us more real-world results
+--   of benchmarking.
+--   Technically this parameter specifies the size of attribute we'll
+--   add to transaction (by default attributes are empty, so if this
+--   parameter is skipped, attributes will remain empty).
+newtype TxAdditionalSize =
+  TxAdditionalSize Int
+  deriving (Eq, Ord, Show)
+
+-- | This parameter specifies Explorer's API endpoint we use to submit
+--   transaction. This parameter is an optional one, and if it's defined -
+--   generator won't submit transactions to 'ouroboros-network', instead it
+--   will submit transactions to that endpoint, using POST-request.
+newtype ExplorerAPIEnpoint =
+  ExplorerAPIEnpoint String
+  deriving (Eq, Ord, Show)
+
+-- | Tracer
+data TraceBenchTxSubmit txid
+  = TraceBenchTxSubRecv [txid]
+  -- ^ Received from generator.
+  | TraceBenchTxSubStart [txid]
+  -- ^ The @txid@ has been submitted to `TxSubmission`
+  --   protocol peer.
+  | TraceBenchTxSubServAnn [txid]
+  -- ^ Announcing txids in response for server's request.
+  | TraceBenchTxSubServReq [txid]
+  -- ^ Request for @tx@ recieved from `TxSubmission` protocol
+  --   peer.
+  | TraceBenchTxSubServAck [txid]
+  -- ^ An ack (window moved over) received for these transactions.
+  | TraceBenchTxSubServDrop [txid]
+  -- ^ Transactions the server implicitly dropped.
+  | TraceBenchTxSubServOuts [txid]
+  -- ^ Transactions outstanding.
+  | TraceBenchTxSubIdle
+  -- ^ Remote peer requested new transasctions but none were
+  --   available, generator not keeping up?
+  | TraceBenchTxSubRateLimit DiffTime
+  -- ^ Rate limiter bit, this much delay inserted to keep within
+  --   configured rate.
+  | TraceBenchTxSubDebug String
+  | TraceBenchTxSubError Text
+  deriving (Show)
+
+-- | RPC interaction with `TxSubmission`
+data RPCTxSubmission m txid tx
+  = RPCRequestTxIdsPromptly (Word16, Word16) (TMVar m [(txid, TS.TxSizeInBytes)])
+  -- ^ Request contains the acknowledged number and the size of the
+  --   open window. Response contains the list of transactions (that
+  --   can be empty - see the `TxSubmission` description of
+  --   `StBlockingStyle` for more details). A prompt response
+  --   is expected.
+  |  RPCRequestTxIds (Word16, Word16) (TMVar m (Maybe [(txid, TS.TxSizeInBytes)]))
+  -- ^ Request contains the acknowledged number and the size of the
+  --   open window. Response contains the list of transactions (that
+  --   can not be empty - see the `TxSubmission` description
+  --   of `StBlockingStyle` for more details); `Nothing`
+  --   indicates no more transaction submissions and a clean
+  --   shutdown. A prompt response is not expected.
+  | RPCRequestTxs [txid] (TMVar m [tx])
+  -- ^ Request contains the list of transaction identifiers which are
+  --   returned in the response.
+
+-- | Low-tevel tracer
+data TraceLowLevelSubmit
+  = TraceLowLevelSubmitting
+  -- ^ Submitting transaction.
+  | TraceLowLevelAccepted
+  -- ^ The transaction has been accepted.
+  | TraceLowLevelRejected String
+  -- ^ The transaction has been rejected, with corresponding error message.
+  deriving (Show)
+
+data NodeToNodeSubmissionTrace
+  = ReqIdsBlocking  Word16 Word16
+  | IdsListBlocking Int
+
+  | ReqIdsPrompt    Word16 Word16
+  | IdsListPrompt   Int
+
+  | ReqTxs          Int
+  | TxList          Int
+
+  | EndOfProtocol
+
+instance ToObject NodeToNodeSubmissionTrace where
+  toObject MinimalVerbosity = const emptyObject -- do not log
+  toObject _ = \case
+    ReqIdsBlocking  ack req -> mkObject [ "kind" .= A.String "ReqIdsBlocking"
+                                        , "ack"  .= A.toJSON ack
+                                        , "req"  .= A.toJSON req ]
+    IdsListBlocking sent    -> mkObject [ "kind" .= A.String "IdsListBlocking"
+                                        , "sent" .= A.toJSON sent ]
+    ReqIdsPrompt    ack req -> mkObject [ "kind" .= A.String "ReqIdsPrompt"
+                                        , "ack"  .= A.toJSON ack
+                                        , "req"  .= A.toJSON req ]
+    IdsListPrompt   sent    -> mkObject [ "kind" .= A.String "IdsListPrompt"
+                                        , "sent" .= A.toJSON sent ]
+    EndOfProtocol           -> mkObject [ "kind" .= A.String "EndOfProtocol" ]
+    ReqTxs          req     -> mkObject [ "kind" .= A.String "ReqTxs"
+                                        , "req"  .= A.toJSON req ]
+    TxList          sent    -> mkObject [ "kind" .= A.String "TxList"
+                                        , "sent" .= A.toJSON sent ]
+
+instance HasSeverityAnnotation NodeToNodeSubmissionTrace
+instance HasPrivacyAnnotation  NodeToNodeSubmissionTrace
+instance Transformable Text IO NodeToNodeSubmissionTrace where
+  trTransformer = trStructured
+
+{-instance {-# OVERLAPS #-} Show (GenTxId blk)
+ => ToJSON (Mempool.GenTxId blk) where
+  toJSON txid = A.String (T.pack $ show txid)
+-}
+
+instance ToObject (TraceBenchTxSubmit (Mempool.GenTxId Block)) where
+  toObject MinimalVerbosity _ = emptyObject -- do not log
+  toObject NormalVerbosity t =
+    case t of
+      TraceBenchTxSubRecv _      -> mkObject ["kind" .= A.String "TraceBenchTxSubRecv"]
+      TraceBenchTxSubStart _     -> mkObject ["kind" .= A.String "TraceBenchTxSubStart"]
+      TraceBenchTxSubServAnn _   -> mkObject ["kind" .= A.String "TraceBenchTxSubServAnn"]
+      TraceBenchTxSubServReq _   -> mkObject ["kind" .= A.String "TraceBenchTxSubServReq"]
+      TraceBenchTxSubServAck _   -> mkObject ["kind" .= A.String "TraceBenchTxSubServAck"]
+      TraceBenchTxSubServDrop _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServDrop"]
+      TraceBenchTxSubServOuts _  -> mkObject ["kind" .= A.String "TraceBenchTxSubServOuts"]
+      TraceBenchTxSubIdle        -> mkObject ["kind" .= A.String "TraceBenchTxSubIdle"]
+      TraceBenchTxSubRateLimit _ -> mkObject ["kind" .= A.String "TraceBenchTxSubRateLimit"]
+      TraceBenchTxSubDebug _     -> mkObject ["kind" .= A.String "TraceBenchTxSubDebug"]
+      TraceBenchTxSubError _     -> mkObject ["kind" .= A.String "TraceBenchTxSubError"]
+  toObject MaximalVerbosity t =
+    case t of
+      TraceBenchTxSubRecv txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubRecv"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubStart txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubStart"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServAnn txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServAnn"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServReq txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServReq"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServAck txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServAck"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServDrop txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServDrop"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubServOuts txIds ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubServOuts"
+                 , "txIds" .= toJSON txIds
+                 ]
+      TraceBenchTxSubIdle ->
+        mkObject [ "kind" .= A.String "TraceBenchTxSubIdle"
+                 ]
+      TraceBenchTxSubRateLimit limit ->
+        mkObject [ "kind"  .= A.String "TraceBenchTxSubRateLimit"
+                 , "limit" .= toJSON limit
+                 ]
+      TraceBenchTxSubDebug s ->
+        mkObject [ "kind" .= A.String "TraceBenchTxSubDebug"
+                 , "msg"  .= A.String (T.pack s)
+                 ]
+      TraceBenchTxSubError s ->
+        mkObject [ "kind" .= A.String "TraceBenchTxSubError"
+                 , "msg"  .= A.String s
+                 ]
+
+instance ToObject (Mempool.GenTxId Block) where
+  toObject MinimalVerbosity _    = emptyObject -- do not log
+  toObject NormalVerbosity _     = mkObject [ "kind" .= A.String "GenTxId"]
+  toObject MaximalVerbosity txid = mkObject [ "kind" .= A.String "GenTxId"
+                                            , "txId" .= toJSON txid
+                                            ]
+
+instance HasSeverityAnnotation (Mempool.GenTxId Block)
+
+instance HasPrivacyAnnotation (Mempool.GenTxId Block)
+
+instance Transformable Text IO (Mempool.GenTxId Block) where
+  trTransformer = trStructured
+
+instance HasSeverityAnnotation (TraceBenchTxSubmit (Mempool.GenTxId Block))
+
+instance HasPrivacyAnnotation (TraceBenchTxSubmit (Mempool.GenTxId Block))
+
+instance Transformable Text IO (TraceBenchTxSubmit (Mempool.GenTxId Block)) where
+  -- transform to JSON Object
+  trTransformer = trStructured
+
+instance ToObject TraceLowLevelSubmit where
+  toObject MinimalVerbosity _ = emptyObject -- do not log
+  toObject NormalVerbosity t =
+    case t of
+      TraceLowLevelSubmitting -> mkObject ["kind" .= A.String "TraceLowLevelSubmitting"]
+      TraceLowLevelAccepted   -> mkObject ["kind" .= A.String "TraceLowLevelAccepted"]
+      TraceLowLevelRejected m -> mkObject [ "kind" .= A.String "TraceLowLevelRejected"
+                                          , "message" .= A.String (T.pack m)
+                                          ]
+  toObject MaximalVerbosity t =
+    case t of
+      TraceLowLevelSubmitting ->
+        mkObject [ "kind" .= A.String "TraceLowLevelSubmitting"
+                 ]
+      TraceLowLevelAccepted ->
+        mkObject [ "kind" .= A.String "TraceLowLevelAccepted"
+                 ]
+      TraceLowLevelRejected errMsg ->
+        mkObject [ "kind"   .= A.String "TraceLowLevelRejected"
+                 , "errMsg" .= A.String (T.pack errMsg)
+                 ]
+
+instance HasSeverityAnnotation TraceLowLevelSubmit
+
+instance HasPrivacyAnnotation TraceLowLevelSubmit
+
+instance (MonadIO m) => Transformable Text m TraceLowLevelSubmit where
+  -- transform to JSON Object
+  trTransformer = trStructured
+
+type SendRecvTxSubmission blk = TraceSendRecv (TS.TxSubmission (GenTxId blk) (GenTx blk))
+
+instance (Show (TxId (GenTx blk)), Show (GenTx blk), ToJSON (TxId (GenTx blk)))
+           => Transformable Text IO (SendRecvTxSubmission blk) where
+  -- transform to JSON Object
+  trTransformer verb tr = Tracer $ \arg -> do
+    currentTime <- getCurrentTime
+    let
+      obj = toObject verb arg
+      updatedObj =
+        if obj == emptyObject
+          then obj
+          else
+            -- Add a timestamp in 'ToObject'-representation.
+            HM.insert "time" (A.String (T.pack . show $ currentTime)) obj
+      tracer = if obj == emptyObject then nullTracer else tr
+    meta <- mkLOMeta (getSeverityAnnotation arg) (getPrivacyAnnotation arg)
+    traceWith tracer (mempty, LogObject mempty meta (LogStructured updatedObj))
+

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Utils.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Utils.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Cardano.Benchmarking.TxGenerator.Utils
+where
+
+import qualified Data.IP as IP
+import           Data.Text (Text)
+import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
+import           Network.Socket (AddrInfo (..),
+                     AddrInfoFlag (..), Family (..), SocketType (Stream),
+                     addrFamily,addrFlags, addrSocketType, defaultHints,
+                     getAddrInfo)
+
+import           Cardano.BM.Data.Tracer (ToLogObject (..))
+import           Cardano.BM.Trace (appendName)
+import           Cardano.Config.Logging (LoggingLayer (..), Trace)
+import           Cardano.Config.Types (NodeAddress (..), NodeHostAddress(..))
+
+import           Control.Tracer (Tracer)
+
+import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
+                   ( GenTxId )
+
+import           Cardano.Benchmarking.TxGenerator.Types
+import           Cardano.Benchmarking.TxGenerator.NodeToNode (SendRecvConnect)
+
+createTracers
+  :: LoggingLayer
+  -> ( Tracer IO (TraceBenchTxSubmit (Mempool.GenTxId Block))
+     , Tracer IO SendRecvConnect
+     , Tracer IO (SendRecvTxSubmission Block)
+     , Tracer IO TraceLowLevelSubmit
+     , Tracer IO NodeToNodeSubmissionTrace
+     )
+createTracers loggingLayer =
+  (benchTracer, connectTracer, submitTracer, lowLevelSubmitTracer, n2nSubmitTracer)
+ where
+  basicTr :: Trace IO Text
+  basicTr = llBasicTrace loggingLayer
+
+  tr :: Trace IO Text
+  tr = llAppendName loggingLayer "cli" basicTr
+
+  tr' :: Trace IO Text
+  tr' = appendName "generate-txs" tr
+
+  benchTracer :: Tracer IO (TraceBenchTxSubmit (Mempool.GenTxId Block))
+  benchTracer = toLogObjectVerbose (appendName "benchmark" tr')
+
+  connectTracer :: Tracer IO SendRecvConnect
+  connectTracer = toLogObjectVerbose (appendName "connect" tr')
+
+  submitTracer :: Tracer IO (SendRecvTxSubmission Block)
+  submitTracer = toLogObjectVerbose (appendName "submit" tr')
+
+  lowLevelSubmitTracer :: Tracer IO TraceLowLevelSubmit
+  lowLevelSubmitTracer = toLogObjectVerbose (appendName "llSubmit" tr')
+
+  n2nSubmitTracer :: Tracer IO NodeToNodeSubmissionTrace
+  n2nSubmitTracer = toLogObjectVerbose (appendName "submit2" tr')
+
+-- | It represents the earliest time at which another tx will be sent.
+minimalTPSRate :: TPSRate -> DiffTime
+minimalTPSRate (TPSRate tps) = picosecondsToDiffTime timeInPicoSecs
+ where
+  -- Since tps cannot be less than 0.05, timeInPicoSecs
+  -- will definitely be integer number after round.
+  timeInPicoSecs = round $ picosecondsIn1Sec / tps
+  picosecondsIn1Sec = 1000000000000 :: Float
+
+resolveRemoteAddr :: NodeAddress -> IO AddrInfo
+resolveRemoteAddr name = do
+  addrs <-getAddrInfo (Just hints) (Just targetNodeHost) (Just targetNodePort)
+  case addrs of
+    [] -> Prelude.error $ "getRemoteAddr : unknown: " ++ show name
+    h:_ -> return h
+  where
+    (anAddrFamily, targetNodeHost) = case unNodeHostAddress $ naHostAddress name of
+              Just (IP.IPv4 ipv4) -> (AF_INET,  show ipv4)
+              Just (IP.IPv6 ipv6) -> (AF_INET6, show ipv6)
+              _ -> error "Target node's IP-address is undefined!"
+
+    targetNodePort = show $ naPort name
+
+    hints :: AddrInfo
+    hints = defaultHints
+          { addrFlags      = [AI_PASSIVE]
+          , addrFamily     = anAddrFamily
+          , addrSocketType = Stream
+          , addrCanonName  = Nothing
+          }

--- a/tx-generator-shelley/test/Spec.hs
+++ b/tx-generator-shelley/test/Spec.hs
@@ -1,0 +1,4 @@
+import Cardano.Prelude
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"

--- a/tx-generator-shelley/tx-generator-shelley.cabal
+++ b/tx-generator-shelley/tx-generator-shelley.cabal
@@ -1,0 +1,111 @@
+name:                  tx-generator-shelley
+version:               0.1.0
+description:           The transaction generator for shelley
+author:                IOHK
+maintainer:            operations@iohk.io
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+build-type:            Simple
+cabal-version:         >= 1.10
+extra-source-files:    README.md
+library
+
+  hs-source-dirs:      src
+
+  exposed-modules:     Cardano.Benchmarking.TxGenerator
+                       Cardano.Benchmarking.TxGenerator.CLI.Parsers
+                       Cardano.Benchmarking.TxGenerator.CLI.Run
+                       Cardano.Benchmarking.TxGenerator.Error
+                       Cardano.Benchmarking.TxGenerator.NodeToNode
+                       Cardano.Benchmarking.TxGenerator.Phase1
+                       Cardano.Benchmarking.TxGenerator.Producer
+                       Cardano.Benchmarking.TxGenerator.Submission
+                       Cardano.Benchmarking.TxGenerator.Types
+                       Cardano.Benchmarking.TxGenerator.Utils
+
+  other-modules:       Paths_tx_generator_shelley
+
+  build-depends:       aeson
+                     , async
+                     , base >=4.12 && <5
+                     , bytestring
+                     , cardano-api
+                     , cardano-binary
+                     , cardano-config
+                     , cardano-crypto-class
+                     , cardano-crypto-wrapper
+                     , cardano-ledger
+                     , cardano-node
+                     , cardano-prelude
+                     , cborg >= 0.2.2 && < 0.3
+                     , containers
+                     , contra-tracer
+                     , directory
+                     , filepath
+                     , io-sim-classes
+                     , iohk-monitoring
+                     , iproute
+                     , network
+                     , network-mux
+                     , optparse-applicative
+                     , ouroboros-consensus
+                     , ouroboros-consensus-byron
+                     , ouroboros-consensus-shelley
+                     , ouroboros-consensus-cardano
+                     , ouroboros-network
+                     , ouroboros-network-framework
+                     , shelley-spec-ledger
+                     , serialise
+                     , stm
+                     , text
+                     , time
+                     , tracer-transformers
+                     , transformers
+                     , transformers-except
+                     , unordered-containers
+
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+  ghc-options:         -Wall
+                       -fno-warn-safe
+                       -fno-warn-unsafe
+                       -fno-warn-missing-import-lists
+                       -Wno-unticked-promoted-constructors
+                       -Wincomplete-record-updates
+                       -Wincomplete-uni-patterns
+                       -Wredundant-constraints
+                       -Wpartial-fields
+                       -Wcompat
+
+executable tx-generator-shelley
+  hs-source-dirs:      app
+  main-is:             cardano-tx-generator-shelley.hs
+  default-language:    Haskell2010
+  ghc-options:         -threaded
+                       -Wall
+                       -rtsopts
+  build-depends:       base >=4.12 && <5
+                     , cardano-prelude
+                     , tx-generator-shelley
+                     , optparse-applicative
+                     , transformers-except
+
+test-suite tx-generator-test
+  hs-source-dirs:       test
+  main-is:              Spec.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        base >=4.12 && <5
+                      , cardano-prelude
+
+  default-language:     Haskell2010
+  default-extensions:   NoImplicitPrelude
+
+  ghc-options:          -Wall
+                        -fno-warn-missing-import-lists
+                        -fno-warn-safe
+                        -fno-warn-unsafe
+                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T


### PR DESCRIPTION
This PR adds `tx-genertor-shelley` a fork of `cardano-tx-generator`.
It is trying to reduce technical debts and clean up the existing code.
Compared to `cardano-tx-generator` it has much less code
(ca  2100 LOC vs 3000 LOC / 68kB vs 114kB).
The largest Haskell module `GeneratorTx.hs` from `cardano-tx-generator` (1300 LOC/ 50kB),
has been split up to `TxGenerator.hs` with 200 LOC and 8 kB.

`tx-generator` does not parse a genesis-config at runtime but instead takes the inital funds from an regular UTxO.