### PR TITLE
CAD-1340 shelley3pools:  more funds!

### DIFF
--- a/benchmarks/shelley3pools/configuration/parameters
+++ b/benchmarks/shelley3pools/configuration/parameters
@@ -13,7 +13,7 @@ GEN_DECENTRALISATIONPARAM="0.5"
 MAGIC=42
 
 # total supply of Lovelaces in genesis (divisible by $NNODES)
-SUPPLY=100000000002
+SUPPLY=1000000000002
 
 # how many nodes to start
 NNODES=3


### PR DESCRIPTION
1, Fix lack of funds in `shelley3pools` -- the generator, otherwise, fails with:

```
[cardano.cli.generate-txs.benchmark:Debug:4] [2020-07-03 21:36:49.35 UTC] fromList [("kind",String "TraceBenchTxSubDebug"),("msg",String "******* Tx generator: waiting 5s *******")]
GenerateTxsError (GenesisBenchmarkRunnerError InsufficientFundsForRecipientTx)
```