### PR TITLE
CAD-1349: RTView AppImage fixed.

### DIFF
--- a/cardano-rt-view/AppImage.md
+++ b/cardano-rt-view/AppImage.md
@@ -28,7 +28,27 @@ To be able to run `AppImage`s, you need `appimage-run` program as well, install 
 $ nix-env -iA nixos.appimage-run
 ```
 
-## Create AppImage using [appimagetool](https://github.com/AppImage/AppImageKit)
+## NixOS: Static Compilation
+
+By default, `cardano-rt-view-service` executable is built with dynamic dependencies
+(you can check it using `ldd` command). To simplify distribution of `AppImage`, it is
+highly recommended to compile `cardano-rt-view-service` with static linking. In this case
+all dependencies will be a part of executable, so `ldd` command returns nothing.
+
+Use this command:
+
+```
+$ cd path/to/cardano-benchmarking/
+$ nix build -L -f static.nix cardano-rt-view.components.exes.cardano-rt-view-service
+```
+
+Then copy executable in `bin` directory:
+
+```
+$ cp result/bin/cardano-rt-view-service bin/
+```
+
+## Recommended: Create AppImage using [appimagetool](https://github.com/AppImage/AppImageKit)
 
 First, download `appimatetool` from this [AppImageKit/Releases](https://github.com/AppImage/AppImageKit/releases).
 For example, `appimagetool-x86_64.AppImage` file.
@@ -51,7 +71,7 @@ As a result, you'll see a directory like `appdir-2020-07-01T16_01_43`. Correspon
 in `/tmp` directory, for example:
 
 ```
-$ ls -al /tmp/Cardano_RTview-x86_64.AppImage 
+$ ls -al /tmp/Cardano_RTview-x86_64.AppImage
 -rwxr-xr-x 1 denis users 7356392 Jul  1 21:13 /tmp/Cardano_RTview-x86_64.AppImage
 ```
 

--- a/cardano-rt-view/mkapp.sh
+++ b/cardano-rt-view/mkapp.sh
@@ -29,26 +29,8 @@ mkdir ${OUTDIR}
 
 cd ${OUTDIR}
 
-# copy libraries to local lib folder
-if [ -d lib ]; then
-  rm -ivr lib
-fi
-mkdir lib
-
-LIBS=$(ldd ${EXE}  | sed -ne 's/.* => \([^ ]\+\) .*/\1/p')
-
-for L in $LIBS; do
-  cp -iv ${L} ./lib/
-done
-
-# hack hack
-export LD_LIBRARY_PATH="$(pwd)/lib":$LD_LIBRARY_PATH
-
-# copy binary and change library search path
+# copy binary
 cp -iv ${EXE} .
-
-patchelf --remove-rpath ${PROGNAME}
-patchelf --set-rpath lib/ ${PROGNAME}
 
 # copy resources
 cp ../resources/cardano-rt-view.desktop .

--- a/cardano-rt-view/resources/AppRun
+++ b/cardano-rt-view/resources/AppRun
@@ -73,10 +73,9 @@ if [ "${CONN}" = "P" ]; then
   echo "nodes will need to write to the pipes created in: ${PIPELOC}"
 fi
 
-
 ## prepare configuration
 
-sed -e '/##ACCEPTORS##/q' rt-view.yaml0 > rt-view.yaml
+sed -e '/##ACCEPTORS##/q' ${APPDIR}/rt-view.yaml0 > /tmp/rt-view.yaml
 
 {
   echo
@@ -98,7 +97,7 @@ sed -e '/##ACCEPTORS##/q' rt-view.yaml0 > rt-view.yaml
       fi
       echo
   done
-} >> rt-view.yaml
+} >> /tmp/rt-view.yaml
 
 
 ## start service
@@ -106,7 +105,7 @@ sed -e '/##ACCEPTORS##/q' rt-view.yaml0 > rt-view.yaml
 echo
 echo "Starting RTview on http://localhost:${WEBPORT}"
 
-exec ./cardano-rt-view-service --port ${WEBPORT} \
-  --config rt-view.yaml \
-  --static static
+exec ${APPDIR}/cardano-rt-view-service --port ${WEBPORT} \
+  --config /tmp/rt-view.yaml \
+  --static ${APPDIR}/static
 

--- a/static.nix
+++ b/static.nix
@@ -1,0 +1,21 @@
+let
+  # Fetch the latest haskell.nix and import its default.nix
+  haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/a2bc3db.tar.gz) {};
+  # haskell.nix provides access to the nixpkgs pins which are used by our CI, hence
+  # you will be more likely to get cache hits when using these.
+  # But you can also just use your own, e.g. '<nixpkgs>'
+  nixpkgsSrc = haskellNix.sources.nixpkgs-2003;
+  # haskell.nix provides some arguments to be passed to nixpkgs, including some patches
+  # and also the haskell.nix functionality itself as an overlay.
+  nixpkgsArgs = haskellNix.nixpkgsArgs;
+in
+{ nativePkgs ? import nixpkgsSrc nixpkgsArgs
+, haskellCompiler ? "ghc865"
+, cardano-benchmarking-src ? ./.
+}:
+nativePkgs.pkgsCross.musl64.pkgs.haskell-nix.cabalProject {
+  src = cardano-benchmarking-src;
+  modules = [
+    { packages.cardano-config.flags.systemd = false; }
+  ];
+}


### PR DESCRIPTION
1. `cardano-rt-view-service` can be compiled statically (without dynamic dependencies), it simplifies distribution.
2. Correct `AppImage`: created on NixOS, works on Ubuntu.

Thanks to @angerman for help!