### PR TITLE
Remove old Cardano.Api

### DIFF
--- a/tx-generator-shelley/README.md
+++ b/tx-generator-shelley/README.md
@@ -9,8 +9,8 @@ Usage: tx-generator-shelley (--mainnet | --testnet-magic NATURAL)
                             --target-node (HOST,PORT) --num-of-txs INT
                             --tx-fee INT --tps FLOAT [--init-cooldown INT] 
                             [--add-tx-size INT] [--submit-to-api URL]
-                            --fund-value LOVELACE --fund-skey FILE
-                            --fund-utxo ARG --fund-addr ARG
+                            --fund-value LOVELACE --signing-key-file FILE
+                            --tx-in TX-IN --fund-addr FILE
 
 Available options:
   --mainnet                Use the mainnet magic id.
@@ -27,32 +27,10 @@ Available options:
   --add-tx-size INT        Additional size of transaction, in bytes.
   --submit-to-api URL      Explorer's API endpoint to submit transaction.
   --fund-value LOVELACE    Lovelace value of the initial fund
-  --fund-skey FILE         signingkey for spending the initial fund
-  --fund-utxo ARG          utxo of the initial fund
-  --fund-addr ARG          address uses for transactions
+  --signing-key-file FILE  Input filepath of the signing key
+  --tx-in TX-IN            The input transaction as TxId#TxIx where TxId is the
+                           transaction hash and TxIx is the index.
+  --fund-addr FILE         address used for transactions
   -h,--help                Show this help text
 ```
 
-### TODO
-
-* `--add-tx-size INT` is not implemented.
-* `--num-of-txs INT` is per target node (not the total number).
-
-## Example
-
-```
-tx-generator-shelley\
-  --testnet-magic 42\
-  --config /work/shelley3pools/node-config.json\
-  --socket-path /work/shelley3pools/logs/sockets/1\
-  --num-of-txs 6000\
-  --tx-fee 10000\
-  --tps 0.7\
-  --target-node '("127.0.0.1",3000)'\
-  --target-node '("127.0.0.1",3001)'\
-  --target-node '("127.0.0.1",3002)'\
-  --fund-utxo '355fae08a93b5920eca47ffb60ba13401d3d579cccfed1b69b766941452eb715#0'\
-  --fund-value 33333333334\
-  --fund-skey /work/shelley3pools/tmp-exgenesis/payer.skey\
-  --fund-addr 60734487ec861e69fa5509866a10d9eec7fba99051c366ce5e490cc2d298ad7579
-```

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Run.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/CLI/Run.hs
@@ -26,11 +26,8 @@ import           Ouroboros.Network.NodeToClient
                     , withIOManager
                     )
 
-import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Node.Logging
                     ( createLoggingLayer )
-import           Cardano.Node.Protocol.Shelley
-                       ( ShelleyProtocolInstantiationError(..))
 
 import           Cardano.Node.Types
                     ( ConfigYamlFilePath(..)
@@ -39,6 +36,7 @@ import           Cardano.Node.Types
 import           Cardano.Config.Types
                     ( DbFile(..), ConfigError(..)
                     , ProtocolFilepaths(..)
+                    , SocketPath (..)
                     , NodeProtocolMode(..)
                     , TopologyFile(..))
 
@@ -65,7 +63,7 @@ runCommand args =
                , configFile = ConfigYamlFilePath $ P.logConfig args
                , topologyFile = TopologyFile "" -- Tx generator doesn't use topology
                , databaseFile = DbFile ""       -- Tx generator doesn't use database
-               , socketFile = Just $ P.socketPath args
+               , socketFile = Just $ SocketPath $ P.socketPath args
                , protocolFiles = ProtocolFilepaths {
                     byronCertFile = Just ""
                   , byronKeyFile = Just ""
@@ -85,7 +83,6 @@ runCommand args =
 
     firstExceptT GenesisBenchmarkRunnerError $
       genesisBenchmarkRunner args loggingLayer iocp
-
 
 ----------------------------------------------------------------------------
 

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Phase1.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Phase1.hs
@@ -5,7 +5,6 @@ where
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as Text
 
 import qualified Cardano.Benchmarking.TxGenerator.CLI.Parsers as P
 import           Cardano.Benchmarking.TxGenerator.Error (TxGenError (..))
@@ -13,13 +12,11 @@ import           Cardano.Benchmarking.TxGenerator.Producer as Producer
 import           Cardano.Benchmarking.TxGenerator.Types as T
 
 import           Cardano.Api.Typed as Api
-import qualified Cardano.Api       as UApi
 import           Cardano.Api.TxSubmit as Api
 
 runPhase1 :: P.GenerateTxs -> NE.NonEmpty a0 -> ExceptT TxGenError IO [Producer]
 runPhase1 args remoteAddresses = do
   key    <- readKey keyFile
-  utxoIn  <- withExceptT UTxOParseError $ hoistEither $ UApi.parseTxIn $ Text.pack utxo
   srcAddr <- readAddr addressFile
   let initialFund = Producer.Producer
          { Producer.network = thisNetwork
@@ -30,24 +27,26 @@ runPhase1 args remoteAddresses = do
                               (PaymentCredentialByKey $ verificationKeyHash srcAddr)
                               NoStakeAddress
          , Producer.skey = key
-         , Producer.src  = castTxIn utxoIn
+         , Producer.src  = utxo
          , Producer.fund = Lovelace $ fromIntegral value
          }
   (tx,p) <- withExceptT Phase1SplitError $ hoistEither $ Producer.split splitList initialFund
   newExceptT $ fmap mapSubmitError $ Api.submitTx connectInfo $ TxForShelleyMode tx
   return p
   where
-    thisNetwork = P.network args
-    connectInfo = error "connectInfo"
     (P.InitialFund value keyFile utxo addressFile) = P.initialFund args
+    thisNetwork = P.network args
+    connectInfo = LocalNodeConnectInfo
+      { localNodeSocketPath    = P.socketPath args
+      , localNodeNetworkId     = thisNetwork
+      , localNodeConsensusMode = ShelleyMode
+      }
+
     txCount = NE.length remoteAddresses
     splitVal = Lovelace $ fromIntegral (value - (T.unFeePerTx $ P.fee args) )
                                            `div` fromIntegral txCount
     splitList :: [Lovelace]
     splitList = replicate txCount splitVal
-          
-    castTxIn :: UApi.TxIn -> TxIn
-    castTxIn = error "castTxIn"
 
 readKey :: FilePath -> ExceptT TxGenError IO (SigningKey PaymentKey)
 readKey keyFile

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Submission.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Submission.hs
@@ -26,41 +26,22 @@ import           Prelude (error, id)
 import           Cardano.Prelude hiding (ByteString, atomically, retry, threadDelay)
 
 import           Control.Exception (assert)
-import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM, TMVar, TVar,
                    atomically, newEmptyTMVarM, putTMVar, readTVar, retry,
                    takeTMVar, tryTakeTMVar)
-import qualified Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime (MonadTime(..), Time, addTime,
                    diffTime, getMonotonicTime)
-import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
-import           Control.Monad.Class.MonadThrow (MonadThrow)
-
-import           Data.ByteString.Lazy (ByteString)
+import           Control.Monad.Class.MonadTimer (threadDelay)
 import           Data.List.NonEmpty (fromList)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import           Data.Time.Clock (DiffTime)
-import           Data.Void (Void)
-
-import           Cardano.BM.Tracing
 import           Control.Tracer (Tracer, traceWith)
 
 import           Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool (GenTx)
 import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
-                   ( ApplyTxErr, GenTxId, HasTxId, txId, txInBlockSize)
-import           Ouroboros.Consensus.Network.NodeToClient
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                  (HasNetworkProtocolVersion (..), nodeToClientProtocolVersion, supportedNodeToClientVersions)
+                   ( GenTxId, HasTxId, txId, txInBlockSize)
 import           Ouroboros.Consensus.Node.Run (RunNode(..))
-
-import           Ouroboros.Network.Mux
-                   ( MuxMode(..), OuroborosApplication(..),
-                     MuxPeer(..), RunMiniProtocol(..) , RunOrStop)
-import           Ouroboros.Network.Driver (runPeer)
-import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as LocalTxSub
-import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult(..))
-import           Ouroboros.Network.Protocol.Handshake.Version (Versions)
 import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle(..),
                                                                  ClientStTxs(..),
                                                                  ClientStTxIds(..),
@@ -68,15 +49,6 @@ import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle(..
 import           Ouroboros.Network.Protocol.TxSubmission.Type (BlockingReplyList(..),
                                                                TokBlockingStyle(..),
                                                                TxSizeInBytes)
-import           Ouroboros.Network.NodeToClient (IOManager,
-                                                 NetworkConnectTracers(..),
-                                                 NodeToClientVersionData(..),
-                                                 foldMapVersions,
-                                                 versionedNodeToClientProtocols)
-import qualified Ouroboros.Network.NodeToClient as NodeToClient
-
-import           Cardano.Config.Types (SocketPath(..))
-
 import           Cardano.Benchmarking.TxGenerator.Types
 
 -- | Bulk submisson of transactions.

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
@@ -299,7 +299,7 @@ instance (MonadIO m) => Transformable Text m TraceLowLevelSubmit where
 
 type SendRecvTxSubmission blk = TraceSendRecv (TS.TxSubmission (GenTxId blk) (GenTx blk))
 
-instance (Show (TxId (GenTx blk)), Show (GenTx blk), ToJSON (TxId (GenTx blk)))
+instance (Show (TxId (GenTx blk)), Show (GenTx blk))
            => Transformable Text IO (SendRecvTxSubmission blk) where
   -- transform to JSON Object
   trTransformer verb tr = Tracer $ \arg -> do

--- a/tx-generator-shelley/tx-generator-shelley.cabal
+++ b/tx-generator-shelley/tx-generator-shelley.cabal
@@ -1,5 +1,5 @@
 name:                  tx-generator-shelley
-version:               0.1.0
+version:               0.2.0
 description:           The transaction generator for shelley
 author:                IOHK
 maintainer:            operations@iohk.io
@@ -29,10 +29,12 @@ library
 
   build-depends:       aeson
                      , async
+                     , attoparsec
                      , base >=4.12 && <5
                      , bytestring
                      , cardano-api
                      , cardano-binary
+                     , cardano-cli
                      , cardano-config
                      , cardano-crypto-class
                      , cardano-crypto-wrapper


### PR DESCRIPTION
This PR contains updates for the switch from `Cardano.Api` to `Cardano.Api.Typed` in `cardano-api`.
It adds some missing pieces that were skipped in #129.