### PR TITLE
Fixes for `tx-generator-shelley` build

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -64,6 +64,8 @@ let
         jobs.native.cardano-tx-generator.x86_64-linux
         jobs.native.cardano-rt-view-service.x86_64-darwin
         jobs.native.cardano-rt-view-service.x86_64-linux
+        jobs.native.tx-generator-shelley.x86_64-darwin
+        jobs.native.tx-generator-shelley.x86_64-linux
       ]));
 
 in jobs

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ let
     packages = ps: with ps; [
       cardano-rt-view
       cardano-tx-generator
+      tx-generator-shelley
     ];
 
     # These programs will be available inside the nix-shell.


### PR DESCRIPTION
1. add `tx-generator-shelley`'s dependencies into the shell
1. add it as a required job as well