### PR TITLE
CAD-1385: KES-info in RTView.

### DIFF
--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Elements.hs
@@ -55,6 +55,9 @@ data ElementName
   | ElTraceAcceptorHost
   | ElTraceAcceptorPort
   | ElTraceAcceptorEndpoint
+  | ElOpCertStartKESPeriod
+  | ElCurrentKESPeriod
+  | ElRemainingKESPeriods
   | ElNodeErrors
   | ElMempoolTxsNumber
   | ElMempoolTxsPercent
@@ -94,6 +97,9 @@ data ElementName
   | ElNodePlatformOutdateWarning
   | ElNodeCommitHrefOutdateWarning
   | ElUptimeOutdateWarning
+  | ElOpCertStartKESPeriodOutdateWarning
+  | ElCurrentKESPeriodOutdateWarning
+  | ElRemainingKESPeriodsOutdateWarning
   | ElSlotOutdateWarning
   | ElBlocksNumberOutdateWarning
   | ElBlocksForgedNumberOutdateWarning

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Grid.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Grid.hs
@@ -69,6 +69,9 @@ metricLabel ElNodePlatform          = "Node platform"
 metricLabel ElNodeCommitHref        = "Node commit"
 metricLabel ElPeersNumber           = "Peers number"
 metricLabel ElUptime                = "Node uptime"
+metricLabel ElOpCertStartKESPeriod  = "Start KES period"
+metricLabel ElCurrentKESPeriod      = "Current KES period"
+metricLabel ElRemainingKESPeriods   = "KES remaining periods"
 metricLabel ElMemoryUsageChart      = "Memory usage"
 metricLabel ElCPUUsageChart         = "CPU usage"
 metricLabel ElDiskUsageChart        = "Disk usage"
@@ -99,6 +102,9 @@ allMetricsNames =
   , ElNodeCommitHref
   , ElPeersNumber
   , ElUptime
+  , ElOpCertStartKESPeriod
+  , ElCurrentKESPeriod
+  , ElRemainingKESPeriods
   , ElMemoryUsageChart
   , ElCPUUsageChart
   , ElDiskUsageChart
@@ -163,6 +169,9 @@ mkNodeElements nameOfNode = do
                  #+ [string ""]
   elPeersNumber <- string "0"
   elUptime      <- string "00:00:00"
+  elOpCertStartKESPeriod <- string "-"
+  elCurrentKESPeriod     <- string "-"
+  elRemainingKESPeriods  <- string "-"
 
   elMemoryUsageChart
     <- UI.canvas ## ("grid-memoryUsageChart-" <> T.unpack nameOfNode)
@@ -206,6 +215,9 @@ mkNodeElements nameOfNode = do
       , (ElNodeCommitHref,        elNodeCommitHref)
       , (ElPeersNumber,           elPeersNumber)
       , (ElUptime,                elUptime)
+      , (ElOpCertStartKESPeriod,  elOpCertStartKESPeriod)
+      , (ElCurrentKESPeriod,      elCurrentKESPeriod)
+      , (ElRemainingKESPeriods,   elRemainingKESPeriods)
       , (ElMemoryUsageChart,      elMemoryUsageChart)
       , (ElCPUUsageChart,         elCPUUsageChart)
       , (ElDiskUsageChart,        elDiskUsageChart)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/NodeWidget.hs
@@ -47,6 +47,9 @@ mkNodeWidget nameOfNode = do
   elPeersNumber             <- string "0"
   elTraceAcceptorHost       <- string "0"
   elTraceAcceptorPort       <- string "0"
+  elOpCertStartKESPeriod    <- string "0"
+  elCurrentKESPeriod        <- string "0"
+  elRemainingKESPeriods     <- string "0"
   elMempoolTxsNumber        <- string "0"
   elMempoolTxsPercent       <- string "0"
   elMempoolBytes            <- string "0"
@@ -156,6 +159,10 @@ mkNodeWidget nameOfNode = do
   elNodePlatformOutdateWarning   <- infoMark "The value is outdated"
   elNodeCommitHrefOutdateWarning <- infoMark "The value is outdated"
   elUptimeOutdateWarning         <- infoMark "The value is outdated"
+  
+  elOpCertStartKESPeriodOutdateWarning <- infoMark "The value is outdated"
+  elCurrentKESPeriodOutdateWarning     <- infoMark "The value is outdated"
+  elRemainingKESPeriodsOutdateWarning  <- infoMark "The value is outdated"
 
   elSlotOutdateWarning               <- infoMark "The value is outdated"
   elBlocksNumberOutdateWarning       <- infoMark "The value is outdated"
@@ -182,6 +189,10 @@ mkNodeWidget nameOfNode = do
                  , vSpacer "node-info-v-spacer"
                  , UI.div #. "" #+ [string "Node uptime:"]
                  , vSpacer "node-info-v-spacer"
+                 , UI.div #. "" #+ [string "Start KES period:"]
+                 , UI.div #. "" #+ [string "KES period:"]
+                 , UI.div #. "" #+ [string "KES remaining:"]
+                 , vSpacer "node-info-v-spacer"
                  , UI.div #. "" #+ [string "TraceAcceptor endpoint:"]
                  ]
              , UI.div #. "w3-third" #+
@@ -192,6 +203,10 @@ mkNodeWidget nameOfNode = do
                      , UI.div #. "commit-link" #+ [element elNodeCommitHref]
                      , vSpacer "node-info-v-spacer"
                      , UI.div #. "" #+ [element elUptime]
+                     , vSpacer "node-info-v-spacer"
+                     , UI.div #. "" #+ [element elOpCertStartKESPeriod]
+                     , UI.div #. "" #+ [element elCurrentKESPeriod]
+                     , UI.div #. "" #+ [element elRemainingKESPeriods]
                      , vSpacer "node-info-v-spacer"
                      , UI.div #. "" #+
                          [ element elTraceAcceptorHost
@@ -220,6 +235,19 @@ mkNodeWidget nameOfNode = do
                  , vSpacer "node-info-v-spacer"
                  , UI.div #. "" #+
                      [ element elUptimeOutdateWarning
+                     , UI.span # set UI.html "&nbsp;" #+ []
+                     ]
+                 , vSpacer "node-info-v-spacer"
+                 , UI.div #. "" #+
+                     [ element elOpCertStartKESPeriodOutdateWarning
+                     , UI.span # set UI.html "&nbsp;" #+ []
+                     ]
+                 , UI.div #. "" #+
+                     [ element elCurrentKESPeriodOutdateWarning
+                     , UI.span # set UI.html "&nbsp;" #+ []
+                     ]
+                 , UI.div #. "" #+
+                     [ element elRemainingKESPeriodsOutdateWarning
                      , UI.span # set UI.html "&nbsp;" #+ []
                      ]
                  , vSpacer "node-info-v-spacer"
@@ -654,6 +682,9 @@ mkNodeWidget nameOfNode = do
           , (ElPeersNumber,             elPeersNumber)
           , (ElTraceAcceptorHost,       elTraceAcceptorHost)
           , (ElTraceAcceptorPort,       elTraceAcceptorPort)
+          , (ElOpCertStartKESPeriod,    elOpCertStartKESPeriod)
+          , (ElCurrentKESPeriod,        elCurrentKESPeriod)
+          , (ElRemainingKESPeriods,     elRemainingKESPeriods)
           , (ElNodeErrors,              elNodeErrorsList)
           , (ElMempoolTxsNumber,        elMempoolTxsNumber)
           , (ElMempoolTxsPercent,       elMempoolTxsPercent)
@@ -687,6 +718,9 @@ mkNodeWidget nameOfNode = do
           , (ElNodePlatformOutdateWarning,       elNodePlatformOutdateWarning)
           , (ElNodeCommitHrefOutdateWarning,     elNodeCommitHrefOutdateWarning)
           , (ElUptimeOutdateWarning,             elUptimeOutdateWarning)
+          , (ElOpCertStartKESPeriodOutdateWarning, elOpCertStartKESPeriodOutdateWarning)
+          , (ElCurrentKESPeriodOutdateWarning,     elCurrentKESPeriodOutdateWarning)
+          , (ElRemainingKESPeriodsOutdateWarning,  elRemainingKESPeriodsOutdateWarning)
           , (ElSlotOutdateWarning,               elSlotOutdateWarning)
           , (ElBlocksNumberOutdateWarning,       elBlocksNumberOutdateWarning)
           , (ElBlocksForgedNumberOutdateWarning, elBlocksForgedNumberOutdateWarning)

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/GUI/Updater.hs
@@ -90,7 +90,7 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementString  $ niNodePlatform ni)            $ elements ! ElNodePlatform
     void $ updateNodeCommit   (niNodeCommit ni) (niNodeShortCommit ni)        $ elements ! ElNodeCommitHref
     void $ updateElementValue (ElementString activeNodeMark)                  $ elements ! ElActiveNode
-    void $ updateNodeUpTime   (niUpTime ni)                                   $ elements ! ElUptime
+    void $ updateNodeUpTime   (niUpTime ni)                                   $ elements ! ElUptime 
     void $ updateElementValue (ElementInteger $ niEpoch ni)                   $ elements ! ElEpoch
     void $ updateElementValue (ElementInteger $ niSlot ni)                    $ elements ! ElSlot
     void $ updateElementValue (ElementInteger $ niBlocksNumber ni)            $ elements ! ElBlocksNumber
@@ -130,6 +130,11 @@ updatePaneGUI window nodesState params acceptors nodesStateElems = do
     void $ updateElementValue (ElementDouble  $ nmRTSGcElapsed nm)            $ elements ! ElRTSGcElapsed
     void $ updateElementValue (ElementInteger $ nmRTSGcNum nm)                $ elements ! ElRTSGcNum
     void $ updateElementValue (ElementInteger $ nmRTSGcMajorNum nm)           $ elements ! ElRTSGcMajorNum
+
+    updateKESInfo [ (niOpCertStartKESPeriod ni, elements ! ElOpCertStartKESPeriod)
+                  , (niCurrentKESPeriod ni,     elements ! ElCurrentKESPeriod)
+                  , (niRemainingKESPeriods ni,  elements ! ElRemainingKESPeriods)
+                  ]
 
     updatePeersList (niPeersInfo ni) peerInfoItems
 
@@ -184,6 +189,11 @@ updateGridGUI window nodesState _params acceptors gridNodesStateElems =
     void $ updateElementValue (ElementDouble  $ nmRTSGcElapsed nm)       $ elements ! ElRTSGcElapsed
     void $ updateElementValue (ElementInteger $ nmRTSGcNum nm)           $ elements ! ElRTSGcNum
     void $ updateElementValue (ElementInteger $ nmRTSGcMajorNum nm)      $ elements ! ElRTSGcMajorNum
+
+    updateKESInfo [ (niOpCertStartKESPeriod ni, elements ! ElOpCertStartKESPeriod)
+                  , (niCurrentKESPeriod ni,     elements ! ElCurrentKESPeriod)
+                  , (niRemainingKESPeriods ni,  elements ! ElRemainingKESPeriods)
+                  ]
 
 updateElementValue
   :: ElementValue
@@ -268,6 +278,15 @@ updatePeersList peersInfo' peersInfoItems = do
     -- Make item visible.
     showElement $ piItem item
 
+updateKESInfo :: [(Integer, Element)] -> UI ()
+updateKESInfo valuesWithElems =
+  forM_ valuesWithElems $ \(value, kesElem) ->
+    if value == 9999999999
+      -- This value cannot be such a big, so it wasn't replaced by the
+      -- real metric. It means there's no KES at all (node uses an old protocol).
+      then void $ updateElementValue (ElementString "—")    kesElem
+      else void $ updateElementValue (ElementInteger value) kesElem
+
 updateErrorsList
   :: [NodeError]
   -> Element
@@ -347,6 +366,12 @@ markOutdatedElements params ni nm els = do
                                                       ]
 
   markValue  now (niEpochLastUpdate ni)        bcLife (els ! ElEpoch)
+  markValueW now (niOpCertStartKESPeriodLastUpdate ni) niLife [els ! ElOpCertStartKESPeriod]
+                                                              [els ! ElOpCertStartKESPeriodOutdateWarning]
+  markValueW now (niCurrentKESPeriodLastUpdate ni)     niLife [els ! ElCurrentKESPeriod]
+                                                              [els ! ElCurrentKESPeriodOutdateWarning]
+  markValueW now (niRemainingKESPeriodsLastUpdate ni)  niLife [els ! ElRemainingKESPeriods]
+                                                              [els ! ElRemainingKESPeriodsOutdateWarning]
   markValueW now (niSlotLastUpdate ni)         bcLife [els ! ElSlot]
                                                       [els ! ElSlotOutdateWarning]
   markValueW now (niBlocksNumberLastUpdate ni) bcLife [els ! ElBlocksNumber]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/NodeState/Types.hs
@@ -87,6 +87,12 @@ data NodeInfo = NodeInfo
   , niPeersInfo                     :: ![PeerInfo]
   , niTraceAcceptorHost             :: !String
   , niTraceAcceptorPort             :: !String
+  , niRemainingKESPeriods           :: !Integer
+  , niRemainingKESPeriodsLastUpdate :: !Word64
+  , niOpCertStartKESPeriod          :: !Integer
+  , niOpCertStartKESPeriodLastUpdate :: !Word64
+  , niCurrentKESPeriod              :: !Integer
+  , niCurrentKESPeriodLastUpdate    :: !Word64
   , niNodeErrors                    :: ![NodeError]
   } deriving (Generic, NFData, Show)
 
@@ -197,6 +203,12 @@ defaultNodeInfo = NodeInfo
   , niPeersInfo                     = []
   , niTraceAcceptorHost             = "-"
   , niTraceAcceptorPort             = "-"
+  , niRemainingKESPeriods           = 9999999999
+  , niRemainingKESPeriodsLastUpdate = 0
+  , niOpCertStartKESPeriod          = 9999999999
+  , niOpCertStartKESPeriodLastUpdate = 0
+  , niCurrentKESPeriod              = 9999999999
+  , niCurrentKESPeriodLastUpdate    = 0
   , niNodeErrors                    = []
   }
 


### PR DESCRIPTION
Show KES-info in RTView.

Corresponding changes in `cardano-node`: https://github.com/input-output-hk/cardano-node/pull/1503

Please note that, if the node is launched with an old protocol (without KES-info), corresponding fields don't hide, but show `"—"` instead. The reason is this: in `Grid view` we have a table where each row corresponds to metric. Suppose three nodes were connected to RTView, but one of them (node `A`) works with `Byron` and two another (`B` and `C`) - with `Cardano`. In this case I still have the same 3 KES-related rows, but for `A` it will be show `"—"`, and for `B` and `C` - real values.