### PR TITLE
CAD-1393: Cardano mode

### DIFF
--- a/benchmarks/shelley3pools/.gitignore
+++ b/benchmarks/shelley3pools/.gitignore
@@ -1,5 +1,6 @@
 
-configuration/genesis
+configuration/genesis*
+configuration/start-time
 
 db/
 logs/

--- a/benchmarks/shelley3pools/configuration/byron-protocol-params.json
+++ b/benchmarks/shelley3pools/configuration/byron-protocol-params.json
@@ -1,0 +1,23 @@
+{
+    "heavyDelThd": "300000000000",
+    "maxBlockSize": "2000000",
+    "maxHeaderSize": "2000000",
+    "maxProposalSize": "700",
+    "maxTxSize": "4096",
+    "mpcThd": "20000000000000",
+    "scriptVersion": 0,
+    "slotDuration": "1000",
+    "softforkRule": {
+        "initThd": "900000000000000",
+        "minThd": "600000000000000",
+        "thdDecrement": "50000000000000"
+    },
+    "txFeePolicy": {
+        "multiplier": "43946000000",
+        "summand": "155381000000000"
+    },
+    "unlockStakeEpoch": "18446744073709551615",
+    "updateImplicit": "10000",
+    "updateProposalThd": "100000000000000",
+    "updateVoteThd": "1000000000000"
+}

--- a/benchmarks/shelley3pools/configuration/configuration-generator.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-generator.yaml
@@ -1,3 +1,13 @@
+Protocol: 
+
+ByronGenesisFile: genesis-byron/genesis.json
+ByronGenesisHash: 
+ShelleyGenesisFile: genesis-shelley/genesis.json
+ShelleyGenesisHash: 
+
+RequiresNetworkMagic: RequiresMagic
+NumCoreNodes: 1
+
 # global filter; messages must have at least this severity to pass:
 minSeverity: Debug
 
@@ -78,19 +88,9 @@ options:
 ############### Cardano Node Configuration ###############
 ##########################################################
 
-
-NodeId:
-Protocol: TPraos
-GenesisFile: genesis/genesis.json
-NumCoreNodes: 1
-RequiresNetworkMagic: RequiresMagic
-PBftSignatureThreshold:
 TurnOnLogging: True
 ViewMode: SimpleView
 TurnOnLogMetrics: False
-SocketPath:
-
-
 
 #####    Update Parameters    #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
@@ -3,10 +3,16 @@
 ############### Cardano Byron Node Configuration #########
 ##########################################################
 
+ByronGenesisFile: genesis-byron/genesis.json
+ByronGenesisHash: 
+ShelleyGenesisFile: genesis-shelley/genesis.json
+ShelleyGenesisHash: 
 
-##### Locations #####
 
-GenesisFile: genesis/genesis.json
+
+
+PBftSignatureThreshold: 0.5
+TestShelleyHardForkAtEpoch: 1
 
 ##### Core protocol parameters #####
 
@@ -14,7 +20,7 @@ GenesisFile: genesis/genesis.json
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: 
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
@@ -3,10 +3,16 @@
 ############### Cardano Byron Node Configuration #########
 ##########################################################
 
+ByronGenesisFile: genesis-byron/genesis.json
+ByronGenesisHash: 
+ShelleyGenesisFile: genesis-shelley/genesis.json
+ShelleyGenesisHash: 
 
-##### Locations #####
 
-GenesisFile: genesis/genesis.json
+
+
+PBftSignatureThreshold: 0.5
+TestShelleyHardForkAtEpoch: 1
 
 ##### Core protocol parameters #####
 
@@ -14,7 +20,7 @@ GenesisFile: genesis/genesis.json
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: 
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
@@ -3,10 +3,16 @@
 ############### Cardano Byron Node Configuration #########
 ##########################################################
 
+ByronGenesisFile: genesis-byron/genesis.json
+ByronGenesisHash: 
+ShelleyGenesisFile: genesis-shelley/genesis.json
+ShelleyGenesisHash: 
 
-##### Locations #####
 
-GenesisFile: genesis/genesis.json
+
+
+PBftSignatureThreshold: 0.5
+TestShelleyHardForkAtEpoch: 1
 
 ##### Core protocol parameters #####
 
@@ -14,7 +20,7 @@ GenesisFile: genesis/genesis.json
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: 
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/parameters
+++ b/benchmarks/shelley3pools/configuration/parameters
@@ -1,6 +1,7 @@
 
 # the directory of the fresh genesis and keys
-GENESISDIR=configuration/genesis
+GENESISDIR_byron=configuration/genesis-byron
+GENESISDIR_shelley=configuration/genesis-shelley
 
 # genesis parameters
 GEN_SLOTLENGTH="0.2"
@@ -13,7 +14,7 @@ GEN_DECENTRALISATIONPARAM="0.5"
 MAGIC=42
 
 # total supply of Lovelaces in genesis
-TOTAL_SUPPLY=1000000000000
+TOTAL_SUPPLY=100000000000000
 
 # supply of pool-delegated Lovelaces in genesis
 POOL_SUPPLY=$((TOTAL_SUPPLY / 2))
@@ -56,3 +57,10 @@ txfee=1000000
 
 # number of transactions for cli benchmarking
 NUM_OF_ADDRESSES=1000
+
+start_time_file=configuration/start-time
+if test -f $start_time_file
+then start_time=$(cat $start_time_file)
+else start_time=$(date --date='5 seconds' +%s)
+     echo -n $start_time > $start_time_file
+fi

--- a/benchmarks/shelley3pools/prepare_genesis_byron.sh
+++ b/benchmarks/shelley3pools/prepare_genesis_byron.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090
+
+set -e
+
+basedir=$(realpath "$(dirname "$0")")
+. "$basedir"/../../scripts/common.sh
+. "$basedir"/configuration/parameters
+
+cd "$basedir"
+
+gendir=$GENESISDIR_byron
+cli=${CLICMD:-'run cardano-cli'}
+
+umask 077
+protocol_params="$basedir/configuration/byron-protocol-params.json"
+
+protocol_magic=$MAGIC
+total_balance=8000000000000002
+
+parameter_k=10
+n_poors=1
+n_delegates=3
+delegate_share=0.5
+avvm_entries=0
+avvm_entry_balance=10000000000000
+not_so_secret=2718281828
+
+tmpdir="`mktemp`.d"
+args=(
+      --genesis-output-dir           "${tmpdir}"
+      --start-time                   "${start_time}"
+      --protocol-parameters-file     "${protocol_params}"
+      --k                            ${parameter_k}
+      --protocol-magic               ${protocol_magic}
+      --n-poor-addresses             ${n_poors}
+      --n-delegate-addresses         ${n_delegates}
+      --total-balance                ${total_balance}
+      --delegate-share               ${delegate_share}
+      --avvm-entry-count             ${avvm_entries}
+      --avvm-entry-balance           ${avvm_entry_balance}
+      --real-pbft
+      --secret-seed                  ${not_so_secret}
+)
+
+$cli genesis "${args[@]}" "$@"
+
+rm -rf "$gendir"
+mkdir -p "$gendir"
+cp -ia ${tmpdir}/genesis.json           $gendir/
+cp -ia ${tmpdir}/delegate-keys.*.key    $gendir/
+cp -ia ${tmpdir}/delegation-cert.*.json $gendir/
+cp -ia ${tmpdir}/genesis-keys.*.key     $gendir/
+cp -ia ${tmpdir}/poor-keys.*.key        $gendir/
+
+$cli shelley key convert-byron-key \
+     --byron-payment-key-type \
+     --byron-signing-key-file           $gendir/poor-keys.000.key \
+     --out-file                         $gendir/poor-keys.000.skey
+
+$cli print-genesis-hash --genesis-json "$gendir"/genesis.json |
+        tail -1                       > $gendir/GENHASH

--- a/benchmarks/shelley3pools/prepare_genesis_expenditure.sh
+++ b/benchmarks/shelley3pools/prepare_genesis_expenditure.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090
+
+set -e
+
+basedir=$(realpath "$(dirname "$0")")
+. "$basedir"/../../scripts/common.sh
+. "$basedir"/configuration/parameters
+
+cd "$basedir"
+
+gendir=$GENESISDIR_shelley
+cli=${CLICMD:-'run cardano-cli'}
+
+coin=4000000000000000
+
+byron_delegate_key=$GENESISDIR_byron/delegate-keys.000.key
+byron_poor_key=$GENESISDIR_byron/poor-keys.000.key
+utxo_ext_vkey=$GENESISDIR_shelley/utxo-keys/utxo1.ext.vkey
+utxo_skey=$GENESISDIR_shelley/utxo-keys/utxo1.skey
+utxo_vkey=$GENESISDIR_shelley/utxo-keys/utxo1.vkey
+
+rm -f $utxo_ext_vkey $utxo_vkey $utxo_skey
+
+tmpfiles=()
+atexit() {
+        rm -f ${tmpfiles[*]}
+}
+trap atexit EXIT
+new_temp_file() {
+        local f
+        f=$(mktemp -t "$1-XXXXXXXX" )
+        tmpfiles+=($f)
+        echo "$f"
+}
+
+get_funds_via_byron_payment_key_byron() {
+        local src_skey=$1 target_skey=$2 target_vkey=$3 coin=$4
+        local src_key_addr target_key_addr
+        local byron_inter_skey txfile
+        byron_inter_skey=$(new_temp_file "byron-inter")
+        txfile=$(new_temp_file "genesis-expenditure")
+
+        rm -f $byron_inter_skey
+        ## create intermediate key
+        $cli keygen \
+             --byron-formats \
+             --no-password \
+             --secret $byron_inter_skey
+        target_key_addr=$($cli signing-key-address \
+                               --byron-formats \
+                               --testnet-magic $MAGIC \
+                               --secret $byron_inter_skey | head -n1)
+        ## move funds from genesis to intermediate
+        src_key_addr=$($cli signing-key-address \
+                            --byron-formats \
+                            --testnet-magic $MAGIC \
+                            --secret $src_skey | head -n1)
+        $cli issue-genesis-utxo-expenditure \
+             --byron-formats \
+             --genesis-json $GENESISDIR_byron/genesis.json \
+             --testnet-magic $MAGIC \
+             --wallet-key $src_skey \
+             --txout "(\"$target_key_addr\",$coin)" \
+             --rich-addr-from $src_key_addr \
+             --tx $txfile
+        CARDANO_NODE_SOCKET_PATH=logs/sockets/1 \
+        $cli submit-tx \
+             --testnet-magic $MAGIC \
+             --tx $txfile
+        ## convert intermediate key to Shelley format
+        $cli shelley key convert-byron-key \
+             --byron-payment-key-type \
+             --byron-signing-key-file $byron_inter_skey \
+             --out-file $target_skey
+        $cli shelley key verification-key \
+             --signing-key-file $target_skey \
+             --verification-key-file $target_vkey
+        sed -i 's/PaymentVerificationKeyByron_ed25519_bip32/GenesisUTxOVerificationKey_ed25519/' $target_vkey
+}
+
+wait_seconds() {
+        n=$1 expl="$2"
+        echo -n "--( waiting $expl:  $n"
+        while printf "\b\b\b%3d" $n
+              test $n -gt 0
+        do n=$((n-1)); sleep 1s; done
+} >&2
+
+query_addr_txin() {
+        local addr=$1 coin=$2; shift 2
+        echo "$(CARDANO_NODE_SOCKET_PATH=logs/sockets/1 \
+                cardano-cli shelley query utxo \
+                --address "$addr" \
+                --testnet-magic "$MAGIC" "$@" | \
+                grep "$coin" | \
+                cut -d' ' -f1)#0"
+}
+
+get_byron_key_addr() {
+        $cli signing-key-address \
+             --byron-formats \
+             --testnet-magic "$MAGIC" \
+             --secret "$1" | head -n1
+}
+
+get_shelley_key_addr() {
+        $cli shelley address build \
+            --testnet-magic "$MAGIC" \
+            --payment-verification-key-file "$1"
+}
+
+move_genesis_byron() {
+        local key=$1 srcaddr=$2 toaddr=$3 coin=$4
+
+        local txin
+        txin="$(query_addr_txin "$srcaddr" "$coin" --cardano-mode)"
+        if test -z "$txin"
+        then echo "ERROR: couldn't determine initial TxIn for addr $srcaddr">&2; exit 1; fi
+        echo "-- intermediate TxIn:        $txin" >&2
+
+        local tx
+        tx=$(new_temp_file "move.tx")
+        $cli issue-utxo-expenditure \
+             --byron-formats \
+             --testnet-magic "$MAGIC" \
+             --wallet-key "$key" \
+             --txin "(\"$txin\",0)" \
+             --txout "$toaddr:$coin" \
+             --tx "$tx"
+
+        $cli submit-tx \
+             --testnet-magic "$MAGIC" \
+             --tx "$tx"
+}
+
+move_utxo_shelley() {
+        local key=$1 srcaddr=$2 toaddr=$3 coin=$4
+
+        local txin
+        txin="$(query_addr_txin "$srcaddr" "$coin" --cardano-mode)"
+        if test -z "$txin"
+        then echo "ERROR: couldn't determine initial TxIn for addr $srcaddr">&2; exit 1; fi
+        echo "-- shelley TxIn:        $txin" >&2
+
+        local txbody
+        txbody=$(new_temp_file "move.txbody")
+        $cli shelley transaction build-raw \
+             --tx-in             "$txin" \
+             --tx-out            "$toaddr+$coin" \
+             --ttl               10000000 \
+             --fee               0 \
+             --out-file          "$txbody"
+        local tx
+        tx=$(new_temp_file "move.tx")
+        $cli shelley transaction sign \
+             --tx-body-file      "$txbody" \
+             --signing-key-file  "$key" \
+             --testnet-magic     "$MAGIC" \
+             --out-file          "$tx"
+        CARDANO_NODE_SOCKET_PATH=logs/sockets/1 \
+        $cli shelley transaction submit \
+             --tx-file           "$tx" \
+             --testnet-magic     "$MAGIC"
+}
+
+get_funds_directly_delegate() {
+        local src_skey=$1 target_skey=$2 target_vkey=$3 coin=$4
+        local utxo_ext_vkey
+        utxo_ext_vkey=$(new_temp_file "utxo.ext.vkey")
+
+        $cli shelley key convert-byron-key \
+             --byron-genesis-delegate-key-type \
+             --byron-signing-key-file $src_skey \
+             --out-file $target_skey
+        $cli shelley key verification-key \
+             --signing-key-file $target_skey \
+             --verification-key-file $utxo_ext_vkey
+        $cli shelley key non-extended-key \
+             --extended-verification-key-file $utxo_ext_vkey \
+             --verification-key-file $target_vkey
+        sed -i 's/GenesisDelegateVerificationKey_ed25519/GenesisUTxOVerificationKey_ed25519/' $target_vkey
+        rm -f $utxo_ext_vkey
+}
+
+get_funds_directly_poor() {
+        local src_skey=$1 target_skey=$2 target_vkey=$3 coin=$4
+        local utxo_ext_vkey
+        utxo_ext_vkey=$(new_temp_file "utxo.ext.vkey")
+
+        $cli shelley key convert-byron-key \
+             --byron-payment-key-type \
+             --byron-signing-key-file $src_skey \
+             --out-file $target_skey
+        $cli shelley key verification-key \
+             --signing-key-file $target_skey \
+             --verification-key-file $target_vkey
+}
+
+get_funds_poor_via_shelley() {
+        local src_skey=$1 target_skey=$2 target_vkey=$3 coin=$4
+        local inter_skey inter_vkey
+        inter_skey=$(new_temp_file "inter.skey")
+        inter_vkey=$(new_temp_file "inter.vkey")
+
+        $cli shelley key convert-byron-key \
+             --byron-payment-key-type \
+             --byron-signing-key-file $src_skey \
+             --out-file $inter_skey
+        $cli shelley key verification-key \
+             --signing-key-file $inter_skey \
+             --verification-key-file $inter_vkey
+
+        local src_addr
+        src_addr=$(get_byron_key_addr "$src_skey")
+
+        $cli shelley address key-gen \
+            --verification-key-file $target_vkey \
+            --signing-key-file      $target_skey
+
+        local to_addr
+        to_addr=$(get_shelley_key_addr "$target_vkey")
+        # to_addr_byron=$(cardano-cli shelley address info \
+        #                              --address "$to_addr" |
+        #                 jq .base16 --raw-output)
+
+        move_utxo_shelley "$inter_skey" "$src_addr" "$to_addr" "$coin"
+}
+
+wait_seconds 105 "until the first epoch passes"
+
+set -x
+# src_key=$byron_delegate_key
+src_key=$byron_poor_key
+echo "-- Byron funds source key:    $src_key" >&2
+
+src_addr=$(get_byron_key_addr "$src_key")
+
+if test -z "$src_addr"
+then echo "ERROR: couldn't determine address for $src_key">&2; exit 1; fi
+echo "-- Byron source key address:  $src_addr" >&2
+
+# get_funds_directly_poor "$src_key" "$utxo_skey" "$utxo_vkey" "$coin"
+# get_funds_directly_delegate "$src_key" "$utxo_skey" "$utxo_vkey" "$coin"
+# get_funds_via_byron_payment_key_byron "$src_key" "$utxo_skey" "$utxo_vkey" "$coin"
+get_funds_poor_via_shelley "$src_key" "$utxo_skey" "$utxo_vkey" "$coin"
+echo "-- derived Shelley keys:      $utxo_skey $utxo_vkey" >&2
+
+addr=$(get_shelley_key_addr $utxo_vkey)
+if test -z "$addr"
+then echo "ERROR: couldn't determine address for $utxo_vkey">&2; exit 1; fi
+echo "-- derived Shelley key addr:  $addr" >&2
+
+txout="$addr+$coin"
+
+wait_seconds 10 "until the funds UTxO settles"
+
+txin="$(query_addr_txin "$addr" "$coin")"
+if test -z "$txin"
+then echo "ERROR: couldn't determine initial TxIn for $utxo_vkey">&2; exit 1; fi
+echo "-- funds TxIn:                $txin" >&2
+
+
+jq '{ txout: "\($txout)"
+    , txin:  $txin
+    }
+'  --arg txin  "$txin" \
+   --arg txout "$txout" \
+   <<<0
+
+{
+        echo -e "\nUTxO of src_addr ($src_addr):"
+        CARDANO_NODE_SOCKET_PATH=logs/sockets/1 \
+        $cli \
+            shelley query utxo \
+            --testnet-magic $MAGIC \
+            --address "$src_addr"
+
+        echo -e "\nUTxO of addr ($addr):"
+        CARDANO_NODE_SOCKET_PATH=logs/sockets/1 \
+        $cli \
+            shelley query utxo \
+            --testnet-magic $MAGIC \
+            --address "$addr"
+} >&2

--- a/benchmarks/shelley3pools/prepare_genesis_shelley_staked.sh
+++ b/benchmarks/shelley3pools/prepare_genesis_shelley_staked.sh
@@ -9,7 +9,7 @@ basedir=$(realpath "$(dirname "$0")")
 
 cd "$basedir"
 
-gendir=$GENESISDIR
+gendir=$GENESISDIR_shelley
 cli=${CLICMD:-'run cardano-cli'}
 
 ###
@@ -106,7 +106,7 @@ mv "$gendir"/genesis.spec.json.  "$gendir"/genesis.spec.json
 params=(--genesis-dir      "$gendir"
         --testnet-magic    "$MAGIC"
         --supply           "$TOTAL_SUPPLY"
-        --start-time       "$(date --iso-8601=s --date='5 seconds' --utc | cut -c-19)Z"
+        --start-time       "$(date --iso-8601=s --date=@$start_time --utc | cut -c-19)Z"
        )
 ## update genesis from template
 $cli shelley genesis create "${params[@]}"
@@ -254,5 +254,8 @@ jq '. +
       } + $initialFundsOfPools)
    }
    ' "${params[@]}" \
- < "$gendir"/genesis.json > "$gendir"/genesis.json.
-mv "$gendir"/genesis.json.  "$gendir"/genesis.json
+ < "$gendir"/genesis.json        > "$gendir"/genesis.json.
+mv "$gendir"/genesis.json.         "$gendir"/genesis.json
+
+$cli shelley genesis hash --genesis "$gendir"/genesis.json |
+        tr -d '"' > "$gendir"/GENHASH

--- a/benchmarks/shelley3pools/run-3pools.sh
+++ b/benchmarks/shelley3pools/run-3pools.sh
@@ -13,8 +13,6 @@ HOSTADDR=127.0.0.1
 # the nodes will listen on ports starting with:
 PORTBASE=3000
 
-GENESISDIR=configuration/genesis
-
 # redirect stderr if LiveView active
 REDIRSTDERR="2>/dev/null"
 REDIRSTDERR=
@@ -33,7 +31,9 @@ tmux split-window -h
 
 mkdir -p logs
 for N in 1 2 3
-do tmux select-pane -t $((N - 1))
+do N1=$((N - 1))
+   N13=$(printf "%03d" $N1)
+   tmux select-pane -t $N1
    tmux send-keys \
      "${TMUX_ENV_PASSTHROUGH[*]}
 
@@ -49,9 +49,11 @@ do tmux select-pane -t $((N - 1))
             --socket-path logs/sockets/${N} \
             --host-addr ${HOSTADDR} --port $((PORTBASE + N - 1)) \
             --config configuration/configuration-node-${N}.yaml \
-            --shelley-kes-key ${GENESISDIR}/node${N}/kes.skey \
-            --shelley-vrf-key ${GENESISDIR}/node${N}/vrf.skey \
-            --shelley-operational-certificate ${GENESISDIR}/node${N}/node.cert \
+            --signing-key            ${GENESISDIR_byron}/delegate-keys.$N13.key \
+            --delegation-certificate ${GENESISDIR_byron}/delegation-cert.$N13.json \
+            --shelley-kes-key ${GENESISDIR_shelley}/node${N}/kes.skey \
+            --shelley-vrf-key ${GENESISDIR_shelley}/node${N}/vrf.skey \
+            --shelley-operational-certificate ${GENESISDIR_shelley}/node${N}/node.cert \
             " ${REDIRSTDERR} \
      C-m
 done

--- a/benchmarks/shelley3pools/submit_delegation_tx.sh
+++ b/benchmarks/shelley3pools/submit_delegation_tx.sh
@@ -9,12 +9,12 @@ CLICMD=${CLICMD:-"run cardano-cli"}
 # === submit delegation transactions ===
 
 for N in ${STAKEPOOLS}; do
-  if [ -e ${GENESISDIR}/node${N}/tx-delegate${N}.tx ]; then
+  if [ -e ${GENESISDIR_shelley}/node${N}/tx-delegate${N}.tx ]; then
     CARDANO_NODE_SOCKET_PATH=logs/sockets/${N} \
     ${CLICMD} shelley transaction submit \
-                --tx-file ${GENESISDIR}/node${N}/tx-delegate${N}.tx \
+                --tx-file ${GENESISDIR_shelley}/node${N}/tx-delegate${N}.tx \
                 --testnet-magic ${MAGIC}
   else
-    echo "no delegation transaction ${GENESISDIR}/node${N}/tx-delegate${N}.tx found!"
+    echo "no delegation transaction ${GENESISDIR_shelley}/node${N}/tx-delegate${N}.tx found!"
   fi
 done

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -31,10 +31,12 @@ library
 
   build-depends:       aeson
                      , async
+                     , attoparsec
                      , base >=4.12 && <5
                      , bytestring
                      , cardano-api
                      , cardano-binary
+                     , cardano-cli
                      , cardano-config
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
@@ -49,6 +51,7 @@ library
                      , filepath
                      , formatting
                      , generic-monoid
+                     , generics-sop
                      , ghc-prim
                      , http-client
                      , http-types

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -16,7 +17,9 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Benchmarking.GeneratorTx.Genesis
-  ( extractGenesisFunds
+  ( GeneratorFunds(..)
+  , parseGeneratorFunds
+  , extractGenesisFunds
   , genesisExpenditure
   , keyAddress
   )
@@ -27,8 +30,12 @@ import           Prelude (error)
 
 import           Control.Arrow ((***))
 import qualified Data.Map.Strict as Map
+import qualified Options.Applicative as Opt
 
 -- Era-agnostic imports
+import           Cardano.Api.Typed
+import           Cardano.Config.Types
+                   (SigningKeyFile(..))
 import qualified Ouroboros.Consensus.Cardano as Consensus
 
 -- Byron-specific imports
@@ -36,81 +43,108 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
 
 -- Shelley-specific imports
-import qualified Ouroboros.Consensus.Shelley.Ledger.Ledger as Shelley
+import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 
-import           Cardano.Api.Typed
+-- Local imports
 import           Cardano.Benchmarking.GeneratorTx.Era
 import           Cardano.Benchmarking.GeneratorTx.Tx
 import           Cardano.Benchmarking.GeneratorTx.Tx.Byron
+import           Cardano.Benchmarking.GeneratorTx.CLI.Parsers
 
 
-keyAddress :: Era era -> SigningKeyOf era -> Address era
-keyAddress p@EraByron{} (getVerificationKey -> ByronVerificationKey k) =
-  ByronAddress $ Byron.makeVerKeyAddress (toByronNetworkMagic $ eraNetworkId p) k
-keyAddress p@EraShelley{} k =
-  makeShelleyAddress
-    (eraNetworkId p)
-    (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
-    NoStakeAddress
+data GeneratorFunds
+  = FundsGenesis SigningKeyFile
+  | FundsUtxo    SigningKeyFile TxIn (TxOut Shelley)
+  deriving Show
 
-genesisKeyPseudoTxIn :: Era era -> SigningKeyOf era -> Address era -> TxIn
-genesisKeyPseudoTxIn p@EraShelley{} key _ =
+parseGeneratorFunds :: Opt.Parser GeneratorFunds
+parseGeneratorFunds =
+  (FundsGenesis
+    <$> parseSigningKeysFile
+        "genesis-funds-key"
+        "Genesis UTxO funds signing key.")
+  <|>
+  (FundsUtxo
+    <$> parseSigningKeysFile
+        "utxo-funds-key"
+        "UTxO funds signing key."
+    <*> pTxIn
+    <*> pTxOut)
+
+keyAddress :: Mode mode era -> SigningKeyOf era -> Address era
+keyAddress m = case modeEra m of
+  EraByron{}   -> \(getVerificationKey -> ByronVerificationKey k) ->
+    ByronAddress
+      (Byron.makeVerKeyAddress (toByronNetworkMagic $ modeNetworkId m) k)
+  EraShelley{} -> \k ->
+    makeShelleyAddress
+      (modeNetworkId m)
+      (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
+      NoStakeAddress
+
+genesisKeyPseudoTxIn :: Mode mode era -> SigningKeyOf era -> Address era -> TxIn
+genesisKeyPseudoTxIn m@ModeShelley{} key _ =
   genesisUTxOPseudoTxIn
-    (eraNetworkId p)
+    (modeNetworkId m)
     (verificationKeyHash $ getVerificationKey $ castSigningKeyRolePaymentKeyGenesisUTxOKey key)
  where
    castSigningKeyRolePaymentKeyGenesisUTxOKey ::
      SigningKey PaymentKey -> SigningKey GenesisUTxOKey
    castSigningKeyRolePaymentKeyGenesisUTxOKey (PaymentSigningKey skey) =
      GenesisUTxOSigningKey skey
-genesisKeyPseudoTxIn p@EraByron{}
+genesisKeyPseudoTxIn m@ModeByron{}
                      (getVerificationKey -> ByronVerificationKey key)
                      (ByronAddress genAddr) =
-  fromByronTxIn $ byronGenesisUTxOTxIn (eraLedgerConfig p) key genAddr
+  fromByronTxIn $ byronGenesisUTxOTxIn (modeLedgerConfig m) key genAddr
+genesisKeyPseudoTxIn m _ _ =
+  error $ "genesisKeyPseudoTxIn:  unsupported mode: " <> show m
 
-eraGenesisFunds :: Era era
+modeGenesisFunds :: Mode mode era
                    -> [(Address era, Lovelace)]
-eraGenesisFunds p@EraShelley{} =
+modeGenesisFunds = \case
+  m@ModeShelley{} ->
     fmap (fromShelleyAddr *** fromShelleyLovelace)
-  . Map.toList
-  . Consensus.sgInitialFunds
-  . Shelley.shelleyLedgerGenesis
-  $ eraLedgerConfig p
-eraGenesisFunds p@EraByron{} =
+    . Map.toList
+    . Consensus.sgInitialFunds
+    . Shelley.shelleyLedgerGenesis
+    $ modeLedgerConfig m
+  m@ModeByron{} ->
     fmap (\(TxOut addr coin) -> (addr, coin))
-  . map (fromByronTxOut . Byron.fromCompactTxOut . snd)
-  . Map.toList
-  . Byron.unUTxO
-  . Byron.genesisUtxo
-  $ eraLedgerConfig p
+    . map (fromByronTxOut . Byron.fromCompactTxOut . snd)
+    . Map.toList
+    . Byron.unUTxO
+    . Byron.genesisUtxo
+    $ modeLedgerConfig m
+  m -> error $ "modeGenesisFunds:  unsupported mode: " <> show m
 
 extractGenesisFunds
-  :: forall era
+  :: forall mode era
   .  Eq (Address era)
-  => Era era
+  => Mode mode era
   -> SigningKeyOf era
   -> (TxIn, TxOut era)
-extractGenesisFunds p k =
+extractGenesisFunds m k =
     fromMaybe (error "No genesis funds for signing key.")
   . head
   . filter (isTxOutForKey . snd)
   . fmap genesisFundsEntryTxIO
-  . eraGenesisFunds
-  $ p
+  . modeGenesisFunds
+  $ m
  where
   genesisFundsEntryTxIO :: (Address era, Lovelace) -> (TxIn, TxOut era)
   genesisFundsEntryTxIO (addr, coin) =
-    (genesisKeyPseudoTxIn p k addr, TxOut addr coin)
+    (genesisKeyPseudoTxIn m k addr, TxOut addr coin)
 
   isTxOutForKey :: TxOut era -> Bool
-  isTxOutForKey (TxOut addr _) = keyAddress p k == addr
+  isTxOutForKey (TxOut addr _) = keyAddress m k == addr
 
-genesisExpenditure :: Era era -> SigningKeyOf era -> Address era -> Lovelace -> TxFee -> TTL -> (Tx era, TxIn, TxOut era)
-genesisExpenditure p key addr (Lovelace coin) (Lovelace fee) ttl =
+genesisExpenditure :: Mode mode era -> SigningKeyOf era -> Address era -> Lovelace -> TxFee -> TTL -> (Tx era, TxIn, TxOut era)
+genesisExpenditure m key addr (Lovelace coin) (Lovelace fee) ttl =
   (,,) tx txin txout
  where
-   tx = mkTransaction p key 0 ttl (Lovelace fee)
-          [genesisKeyPseudoTxIn p key (keyAddress p key)]
+   tx = mkTransaction m key 0 ttl (Lovelace fee)
+          [genesisKeyPseudoTxIn m key (keyAddress m key)]
           [txout]
    txin = TxIn (getTxId $ getTxBody tx) (TxIx 0)
    txout = TxOut addr (Lovelace (coin - fee))
+

--- a/nix/nixos/tx-generator-service.nix
+++ b/nix/nixos/tx-generator-service.nix
@@ -54,9 +54,7 @@
             "--tps"                    tps
             "--init-cooldown"          init_cooldown
 
-            "--sig-key"                sigKey
-
-            "--genesis-file"           localNodeConf.nodeConfig.GenesisFile
+            "--genesis-funds-key"      sigKey
           ] ++
           __attrValues
             (__mapAttrs (name: { ip, port }: "--target-node '(\"${ip}\",${toString port})'")

--- a/scripts/analyse.sh
+++ b/scripts/analyse.sh
@@ -55,7 +55,7 @@ extract_recvs() {
         jq '
           select (.data.kind == "Recv" and .data.msg.kind == "MsgBlock")
         | .at as $at           # bind timestamp
-        | .data.msg."tx ids"   # narrow to the txid list
+        | .data.msg.txIds      # narrow to the txid list
         | map ( .[23:87]       # cut the extra stuff
               | "\(.);\($at)") # produce the resulting string
         | .[]              # merge string lists over all messages

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -36,8 +36,9 @@ Usage:
     --mnemonic-suffix SUFFIX
                         Profiling output will get an additional suffix
 
-    --shelley           Set era to Shelley.  Default
-    --byron             Set era to Byron
+    --shelley           Non-HFC mode, Shelley era.  Default
+    --byron             Non-HFC mode, Byron era
+    --cardano           Cardano/HFC mode, Shelley era
 
     --quiet             Don't print much.  The default
     --verbose           Be verbose about what's going on
@@ -164,6 +165,7 @@ do case "$1" in
 
            --shelley )            era='shelley';;
            --byron )              era='byron';;
+           --cardano )            era='cardano-shelley';;
 
            --quiet )              verbose=;;
            --verbose )            verbose=t;;

--- a/scripts/explorer.MsgBlock.sh
+++ b/scripts/explorer.MsgBlock.sh
@@ -9,8 +9,8 @@ jq 'def katip_timestamp_to_iso8601:
         as $date_iso
       | { date_iso:    $date_iso
         , timestamp:   $date_iso | fromdateiso8601
-        , blkid:       .data.msg."block hash"
-        , txs:         (.data.msg."tx ids" | length)
+        , blkid:       .data.msg.blockHash
+        , txs:         (.data.msg.txIds | length)
         }
       )
     | sort_by (.timestamp)


### PR DESCRIPTION
1. Implement `Cardano` mode support in `cardano-tx-generator`
1. Implement `--cardano` mode in `shelley3pools`
1. Update to the recent log format changes (CAD-1455)
1. `--byron`/`RealPBFT` has regressed, as during initial tx submission we're getting the following:
```
DeserialiseFailure 118 "Deserialisation failure while decoding ((AbstractHash Blake2b_256 Tx),Word32).\nCBOR failed with error: DeserialiseFailure 108 \"An error occured while decoding AbstractHash.\\nError: Bytes not expected length\"" while submitting a Byron transaction to a node in RealPBFT mode using Cardano.Api.TxSubmit.submitTx
```

The error seems like it is implied by the `To/FromCBOR` instances in: https://github.com/input-output-hk/cardano-ledger-specs/blob/master/byron/ledger/impl/src/Cardano/Chain/UTxO/Tx.hs#L141-L155

This is especially interesting, since we're using `cardano-api` for local Tx submission, and it's pretty hard to mess up.

# Validation

Tested in AWS via the tip of https://github.com/input-output-hk/cardano-ops/pull/304