### PR TITLE
Update tx-generator-shelley for latest dependencies.

### DIFF
--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Error.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Error.hs
@@ -3,7 +3,6 @@ module Cardano.Benchmarking.TxGenerator.Error
   ) where
 
 import           Prelude
-import           Cardano.Api (ApiError)
 import           Cardano.Api.Typed
 import           Cardano.Binary (DecoderError)
 import           Cardano.Benchmarking.TxGenerator.Producer
@@ -17,13 +16,9 @@ data TxGenError =
   -- ^ Need at least 3 signing key files.
   | TooSmallTPSRate !Float
   -- ^ TPS is less than lower limit.
---  | SecretKeyDeserialiseError !Text
---  | SecretKeyReadError !Text
   | UTxOParseError !String
   | AddrParseError !DecoderError
-  | CardanoApiError !ApiError
   | TxFileError !(FileError TextEnvelopeError)
   | TxSubmitError !String
   | Phase1SplitError !PError
-  -- ^ error from Cardana.Api.Error
   deriving Show

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/NodeToNode.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/NodeToNode.hs
@@ -26,13 +26,15 @@ import           Codec.Serialise (DeserialiseFailure)
 import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
+import           Data.Map as Map
 import           Network.Mux (MuxMode(InitiatorMode), WithMuxBearer (..))
 import           Network.Socket (AddrInfo (..), SockAddr)
 
 import           Control.Tracer (Tracer (..), nullTracer)
 import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx)
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (supportedNodeToNodeVersions)
+
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolClientInfo, pClientInfoCodecConfig)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Consensus.Network.NodeToNode (Codecs(..), defaultCodecs)
@@ -92,8 +94,10 @@ benchmarkConnectTxSubmit iocp trs cfg network localAddr remoteAddr myTxSubClient
     (addrAddress remoteAddr)
  where
   myCodecs :: Codecs blk DeserialiseFailure m
-                ByteString ByteString ByteString ByteString ByteString
-  myCodecs  = defaultCodecs (pClientInfoCodecConfig cfg) (mostRecentSupportedNodeToNode (Proxy @blk))
+                ByteString ByteString ByteString ByteString ByteString ByteString
+  myCodecs  = defaultCodecs
+                  (pClientInfoCodecConfig cfg)
+                  ((Map.!) (supportedNodeToNodeVersions $ Proxy @blk ) maxBound)
   peerMultiplex :: Versions NtN.NodeToNodeVersion NtN.DictVersion
                      (OuroborosApplication InitiatorMode SockAddr ByteString IO () Void)
   peerMultiplex =


### PR DESCRIPTION
This PR makes `tx-generator-shelley` compile again