### PR TITLE
CAD-1393: Mainnet Candidate benchmarking setup & generator changes

### DIFF
--- a/benchmarks/existing-cluster/.gitignore
+++ b/benchmarks/existing-cluster/.gitignore
@@ -1,0 +1,3 @@
+db
+logs
+socket

--- a/benchmarks/existing-cluster/configuration/config-proxy.json
+++ b/benchmarks/existing-cluster/configuration/config-proxy.json
@@ -1,0 +1,180 @@
+{
+  "ApplicationName": "cardano-sl",
+  "ApplicationVersion": 0,
+  "ByronGenesisFile": "mainnet_candidate_4-byron-genesis.json",
+  "ByronGenesisHash": "406bd7edfa14db46edb367d18f5b3dba8d0c626b7c1c19f283867a70d05945c9",
+  "LastKnownBlockVersion-Alt": 0,
+  "LastKnownBlockVersion-Major": 2,
+  "LastKnownBlockVersion-Minor": 0,
+  "MaxKnownMajorProtocolVersion": 2,
+  "PBftSignatureThreshold": 0.9,
+  "Protocol": "Cardano",
+  "RequiresNetworkMagic": "RequiresNoMagic",
+  "ShelleyGenesisFile": "mainnet_candidate_4-shelley-genesis.json",
+  "ShelleyGenesisHash": "ef8a74ab8587db4c95a7b98cd15406faf7044d9ff47b977f54053f7ad4fd9e59",
+  "TestShelleyHardForkAtEpoch": 1,
+  "TraceBlockFetchClient": false,
+  "TraceBlockFetchDecisions": false,
+  "TraceBlockFetchProtocol": false,
+  "TraceBlockFetchProtocolSerialised": false,
+  "TraceBlockFetchServer": false,
+  "TraceChainDb": true,
+  "TraceChainSyncBlockServer": false,
+  "TraceChainSyncClient": false,
+  "TraceChainSyncHeaderServer": false,
+  "TraceChainSyncProtocol": false,
+  "TraceDNSResolver": true,
+  "TraceDNSSubscription": true,
+  "TraceErrorPolicy": true,
+  "TraceForge": true,
+  "TraceHandshake": false,
+  "TraceIpSubscription": true,
+  "TraceLocalChainSyncProtocol": false,
+  "TraceLocalErrorPolicy": true,
+  "TraceLocalHandshake": false,
+  "TraceLocalTxSubmissionProtocol": false,
+  "TraceLocalTxSubmissionServer": false,
+  "TraceMempool": true,
+  "TraceMux": false,
+  "TraceTxInbound": false,
+  "TraceTxOutbound": false,
+  "TraceTxSubmissionProtocol": false,
+  "TracingVerbosity": "NormalVerbosity",
+  "TurnOnLogMetrics": true,
+  "TurnOnLogging": true,
+  "ViewMode": "SimpleView",
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "FileSK",
+      "logs/node.json"
+    ],
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+  "hasEKG": 12788,
+  "hasPrometheus": [
+    "127.0.0.1",
+    12798
+  ],
+  "minSeverity": "Info",
+  "options": {
+    "mapBackends": {
+      "cardano.node-metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.BlockFetchDecision.peers": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.ChainDB.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.Forge.metrics": [
+        "EKGViewBK"
+      ],
+      "cardano.node.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ]
+    },
+    "mapSubtrace": {
+      "#ekgview": {
+        "contents": [
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": ".monoclock.basic.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": "diff.RTS.cpuNs.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
+              "tag": "StartsWith"
+            },
+            [
+              {
+                "contents": "diff.RTS.gcNum.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ]
+        ],
+        "subtrace": "FilterTrace"
+      },
+      "benchmark": {
+        "contents": [
+          "GhcRtsStats",
+          "MonotonicClock"
+        ],
+        "subtrace": "ObservableTrace"
+      },
+      "cardano.epoch-validation.utxo-stats": {
+        "subtrace": "NoTrace"
+      },
+      "cardano.node-metrics": {
+        "subtrace": "Neutral"
+      },
+      "cardano.node.metrics": {
+        "subtrace": "Neutral"
+      }
+    }
+  },
+  "rotation": {
+    "rpKeepFilesNum": 10,
+    "rpLogLimitBytes": 5000000,
+    "rpMaxAgeHours": 24
+  },
+  "setupBackends": [
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scKind": "FileSK",
+      "scName": "logs/node.json",
+      "scFormat": "ScJson"
+    },
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ]
+}

--- a/benchmarks/existing-cluster/configuration/config-txgen.json
+++ b/benchmarks/existing-cluster/configuration/config-txgen.json
@@ -1,0 +1,180 @@
+{
+  "ApplicationName": "cardano-sl",
+  "ApplicationVersion": 0,
+  "ByronGenesisFile": "mainnet_candidate_4-byron-genesis.json",
+  "ByronGenesisHash": "406bd7edfa14db46edb367d18f5b3dba8d0c626b7c1c19f283867a70d05945c9",
+  "LastKnownBlockVersion-Alt": 0,
+  "LastKnownBlockVersion-Major": 2,
+  "LastKnownBlockVersion-Minor": 0,
+  "MaxKnownMajorProtocolVersion": 2,
+  "PBftSignatureThreshold": 0.9,
+  "Protocol": "Cardano",
+  "RequiresNetworkMagic": "RequiresNoMagic",
+  "ShelleyGenesisFile": "mainnet_candidate_4-shelley-genesis.json",
+  "ShelleyGenesisHash": "ef8a74ab8587db4c95a7b98cd15406faf7044d9ff47b977f54053f7ad4fd9e59",
+  "TestShelleyHardForkAtEpoch": 1,
+  "TraceBlockFetchClient": false,
+  "TraceBlockFetchDecisions": false,
+  "TraceBlockFetchProtocol": false,
+  "TraceBlockFetchProtocolSerialised": false,
+  "TraceBlockFetchServer": false,
+  "TraceChainDb": true,
+  "TraceChainSyncBlockServer": false,
+  "TraceChainSyncClient": false,
+  "TraceChainSyncHeaderServer": false,
+  "TraceChainSyncProtocol": false,
+  "TraceDNSResolver": true,
+  "TraceDNSSubscription": true,
+  "TraceErrorPolicy": true,
+  "TraceForge": true,
+  "TraceHandshake": false,
+  "TraceIpSubscription": true,
+  "TraceLocalChainSyncProtocol": false,
+  "TraceLocalErrorPolicy": true,
+  "TraceLocalHandshake": false,
+  "TraceLocalTxSubmissionProtocol": false,
+  "TraceLocalTxSubmissionServer": false,
+  "TraceMempool": true,
+  "TraceMux": false,
+  "TraceTxInbound": false,
+  "TraceTxOutbound": false,
+  "TraceTxSubmissionProtocol": false,
+  "TracingVerbosity": "MaximalVerbosity",
+  "TurnOnLogMetrics": true,
+  "TurnOnLogging": true,
+  "ViewMode": "SimpleView",
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "FileSK",
+      "logs/generator.json"
+    ],
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+  "hasEKG": 12788,
+  "hasPrometheus": [
+    "127.0.0.1",
+    12798
+  ],
+  "minSeverity": "Debug",
+  "options": {
+    "mapBackends": {
+      "cardano.node-metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.BlockFetchDecision.peers": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.ChainDB.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.Forge.metrics": [
+        "EKGViewBK"
+      ],
+      "cardano.node.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ]
+    },
+    "mapSubtrace": {
+      "#ekgview": {
+        "contents": [
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": ".monoclock.basic.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": "diff.RTS.cpuNs.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
+              "tag": "StartsWith"
+            },
+            [
+              {
+                "contents": "diff.RTS.gcNum.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ]
+        ],
+        "subtrace": "FilterTrace"
+      },
+      "benchmark": {
+        "contents": [
+          "GhcRtsStats",
+          "MonotonicClock"
+        ],
+        "subtrace": "ObservableTrace"
+      },
+      "cardano.epoch-validation.utxo-stats": {
+        "subtrace": "NoTrace"
+      },
+      "cardano.node-metrics": {
+        "subtrace": "Neutral"
+      },
+      "cardano.node.metrics": {
+        "subtrace": "Neutral"
+      }
+    }
+  },
+  "rotation": {
+    "rpKeepFilesNum": 10,
+    "rpLogLimitBytes": 5000000,
+    "rpMaxAgeHours": 24
+  },
+  "setupBackends": [
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scKind": "FileSK",
+      "scName": "logs/generator.json",
+      "scFormat": "ScJson"
+    },
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ]
+}

--- a/benchmarks/existing-cluster/configuration/genesis-byron.json
+++ b/benchmarks/existing-cluster/configuration/genesis-byron.json
@@ -1,0 +1,1 @@
+mainnet_candidate_4-byron-genesis.json

--- a/benchmarks/existing-cluster/configuration/genesis-shelley.json
+++ b/benchmarks/existing-cluster/configuration/genesis-shelley.json
@@ -1,0 +1,1 @@
+mainnet_candidate_4-shelley-genesis.json

--- a/benchmarks/existing-cluster/configuration/mainnet_candidate_4-byron-genesis.json
+++ b/benchmarks/existing-cluster/configuration/mainnet_candidate_4-byron-genesis.json
@@ -1,0 +1,63 @@
+{ "bootStakeholders":
+    { "473cfa74426964f50d93973de6b0f2e40f3320fe9e670ed1e891de10": 1
+    , "c1b2ae2a90a808788615fa96a01ced3a6e67e669348efded4eaed473": 1
+    , "da379ef48add30b195d9b8bdafc2fdf5998753a7959ad26320bf2ebe": 1
+    }
+, "heavyDelegation":
+    { "473cfa74426964f50d93973de6b0f2e40f3320fe9e670ed1e891de10":
+        { "omega": 0
+        , "issuerPk":
+            "5jlrrnjBpWzFOE84xc6uh8Ke1Be/NEcIYW3f0n1C8zGDSCZwNd1xm40Zu7Ri+6hcCScaa93KA39gNFn0mtZOSw=="
+        , "delegatePk":
+            "gPSUJ9TxeDi3mn8pWrztZvChWsDIqkuuwVxfU6cm2CwP8vFNgfBo7mMFJwxdsG08xraJ4qXbIWynAmTfeHL0Tg=="
+        , "cert":
+            "5544f210551803bfbcffbeeb807503d2cfa3909131248c12594a0feaf13b939d2e9eb81d8e8e667a688659d7714cbf3b16841b264b393de32b6f3d0f2a041307"
+        }
+    , "c1b2ae2a90a808788615fa96a01ced3a6e67e669348efded4eaed473":
+        { "omega": 0
+        , "issuerPk":
+            "RYaRZCsjTNYMojPGW1hAGZcYaWY84stEXQd95FqVyLxU0iDoEHP1Oh9+5xxyPEGZ9z5jxCva0WpE+4AVtyQy4Q=="
+        , "delegatePk":
+            "CswJCLqUCrDQa5pb4NX8uQlv8uy7ZxbjnD5cSAIvgf4G9Ql0ZaA7wnS4yjJysi5uZyV2qnwwt3koP6djhvwuJQ=="
+        , "cert":
+            "25cade766847eabc070cf8dee62bfbf315676a7805fb2d5058c981edab1150f2e24ad9f8a64a1f178076955506e1920d10564637852561ba821c231aa0478d03"
+        }
+    , "da379ef48add30b195d9b8bdafc2fdf5998753a7959ad26320bf2ebe":
+        { "omega": 0
+        , "issuerPk":
+            "g4lK99OuTyyRDTCK4772Z56CM+KsLX5PIDkd5wBRhEHvbFBiPVno3o+5HZ07wZrKRDCdYH4NINuJ8WR7oSRsIQ=="
+        , "delegatePk":
+            "+lqfLp1qM/vGMJvmeRgpl82ECWFzvKR5JulHnjrkfhg0Cn2LK/4c+IQrtp/zu4dzHOaCHj+zqmunrdomMlgNug=="
+        , "cert":
+            "cc6d1fd828841c47adbb9968f7cfd86770380001762b354a09fc84a6d17d05c116e8723f90b70469a5231a7f35851b79b2ed9f1526ade3f1f5c65ae9def56a09"
+        }
+    }
+, "startTime": 1595682000
+, "nonAvvmBalances":
+    { "Ae2tdPwUPEYyv5UFN9PSgqfquhfkpxsv6M8h7K223pSL4JAnxGCGSGJq6wU":
+        "33000000000000000"
+    }
+, "blockVersionData":
+    { "scriptVersion": 0
+    , "slotDuration": "20000"
+    , "maxBlockSize": "2000000"
+    , "maxHeaderSize": "2000000"
+    , "maxTxSize": "4096"
+    , "maxProposalSize": "700"
+    , "mpcThd": "20000000000000"
+    , "heavyDelThd": "300000000000"
+    , "updateVoteThd": "1000000000000"
+    , "updateProposalThd": "100000000000000"
+    , "updateImplicit": "10000"
+    , "softforkRule":
+        { "initThd": "900000000000000"
+        , "minThd": "600000000000000"
+        , "thdDecrement": "50000000000000"
+        }
+    , "txFeePolicy":
+        { "summand": "155381000000000" , "multiplier": "43946000000" }
+    , "unlockStakeEpoch": "18446744073709551615"
+    }
+, "protocolConsts": { "k": 108 , "protocolMagic": 42 }
+, "avvmDistr": {}
+}

--- a/benchmarks/existing-cluster/configuration/mainnet_candidate_4-config.json
+++ b/benchmarks/existing-cluster/configuration/mainnet_candidate_4-config.json
@@ -1,0 +1,180 @@
+{
+  "ApplicationName": "cardano-sl",
+  "ApplicationVersion": 0,
+  "ByronGenesisFile": "mainnet_candidate_4-byron-genesis.json",
+  "ByronGenesisHash": "406bd7edfa14db46edb367d18f5b3dba8d0c626b7c1c19f283867a70d05945c9",
+  "LastKnownBlockVersion-Alt": 0,
+  "LastKnownBlockVersion-Major": 2,
+  "LastKnownBlockVersion-Minor": 0,
+  "MaxKnownMajorProtocolVersion": 2,
+  "PBftSignatureThreshold": 0.9,
+  "Protocol": "Cardano",
+  "RequiresNetworkMagic": "RequiresNoMagic",
+  "ShelleyGenesisFile": "mainnet_candidate_4-shelley-genesis.json",
+  "ShelleyGenesisHash": "ef8a74ab8587db4c95a7b98cd15406faf7044d9ff47b977f54053f7ad4fd9e59",
+  "TestShelleyHardForkAtEpoch": 1,
+  "TraceBlockFetchClient": false,
+  "TraceBlockFetchDecisions": false,
+  "TraceBlockFetchProtocol": false,
+  "TraceBlockFetchProtocolSerialised": false,
+  "TraceBlockFetchServer": false,
+  "TraceChainDb": true,
+  "TraceChainSyncBlockServer": false,
+  "TraceChainSyncClient": false,
+  "TraceChainSyncHeaderServer": false,
+  "TraceChainSyncProtocol": false,
+  "TraceDNSResolver": true,
+  "TraceDNSSubscription": true,
+  "TraceErrorPolicy": true,
+  "TraceForge": true,
+  "TraceHandshake": false,
+  "TraceIpSubscription": true,
+  "TraceLocalChainSyncProtocol": false,
+  "TraceLocalErrorPolicy": true,
+  "TraceLocalHandshake": false,
+  "TraceLocalTxSubmissionProtocol": false,
+  "TraceLocalTxSubmissionServer": false,
+  "TraceMempool": true,
+  "TraceMux": false,
+  "TraceTxInbound": false,
+  "TraceTxOutbound": false,
+  "TraceTxSubmissionProtocol": false,
+  "TracingVerbosity": "NormalVerbosity",
+  "TurnOnLogMetrics": true,
+  "TurnOnLogging": true,
+  "ViewMode": "SimpleView",
+  "defaultBackends": [
+    "KatipBK"
+  ],
+  "defaultScribes": [
+    [
+      "FileSK",
+      "logs/node.json"
+    ],
+    [
+      "StdoutSK",
+      "stdout"
+    ]
+  ],
+  "hasEKG": 12788,
+  "hasPrometheus": [
+    "127.0.0.1",
+    12798
+  ],
+  "minSeverity": "Info",
+  "options": {
+    "mapBackends": {
+      "cardano.node-metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.BlockFetchDecision.peers": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.ChainDB.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ],
+      "cardano.node.Forge.metrics": [
+        "EKGViewBK"
+      ],
+      "cardano.node.metrics": [
+        "EKGViewBK",
+        {
+          "kind": "UserDefinedBK",
+          "name": "LiveViewBackend"
+        }
+      ]
+    },
+    "mapSubtrace": {
+      "#ekgview": {
+        "contents": [
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": ".monoclock.basic.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "cardano.epoch-validation.benchmark",
+              "tag": "Contains"
+            },
+            [
+              {
+                "contents": "diff.RTS.cpuNs.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ],
+          [
+            {
+              "contents": "#ekgview.#aggregation.cardano.epoch-validation.benchmark",
+              "tag": "StartsWith"
+            },
+            [
+              {
+                "contents": "diff.RTS.gcNum.timed.",
+                "tag": "Contains"
+              }
+            ]
+          ]
+        ],
+        "subtrace": "FilterTrace"
+      },
+      "benchmark": {
+        "contents": [
+          "GhcRtsStats",
+          "MonotonicClock"
+        ],
+        "subtrace": "ObservableTrace"
+      },
+      "cardano.epoch-validation.utxo-stats": {
+        "subtrace": "NoTrace"
+      },
+      "cardano.node-metrics": {
+        "subtrace": "Neutral"
+      },
+      "cardano.node.metrics": {
+        "subtrace": "Neutral"
+      }
+    }
+  },
+  "rotation": {
+    "rpKeepFilesNum": 10,
+    "rpLogLimitBytes": 5000000,
+    "rpMaxAgeHours": 24
+  },
+  "setupBackends": [
+    "KatipBK"
+  ],
+  "setupScribes": [
+    {
+      "scKind": "FileSK",
+      "scName": "logs/node.json",
+      "scFormat": "ScJson"
+    },
+    {
+      "scFormat": "ScText",
+      "scKind": "StdoutSK",
+      "scName": "stdout",
+      "scRotation": null
+    }
+  ]
+}

--- a/benchmarks/existing-cluster/configuration/mainnet_candidate_4-shelley-genesis.json
+++ b/benchmarks/existing-cluster/configuration/mainnet_candidate_4-shelley-genesis.json
@@ -1,0 +1,52 @@
+{
+  "activeSlotsCoeff": 0.05,
+  "protocolParams": {
+    "protocolVersion": {
+      "minor": 0,
+      "major": 2
+    },
+    "decentralisationParam": 1,
+    "eMax": 18,
+    "extraEntropy": {
+      "tag": "NeutralNonce"
+    },
+    "maxTxSize": 16384,
+    "maxBlockBodySize": 65536,
+    "maxBlockHeaderSize": 1100,
+    "minFeeA": 44,
+    "minFeeB": 155381,
+    "minUTxOValue": 1000000,
+    "poolDeposit": 500000000,
+    "minPoolCost": 340000000,
+    "keyDeposit": 2000000,
+    "nOpt": 150,
+    "rho": 0.003,
+    "tau": 0.20,
+    "a0": 0.3
+  },
+  "genDelegs": {
+    "42d339844d4593edc456d1c80b256fa57e9b4b4dccda5b587ea7a958": {
+      "delegate": "53465dff1bf47517a5b354888b32972647d208cac07907aa8efa5a03",
+      "vrf": "61e67274fe923060e82635768ec21e62846023804cc0f080c5c2b475151c2770"
+    },
+    "95dbfe2cf93a2db109863659c10dd5785201d71eb43ae4a264d2b731": {
+      "delegate": "2ca5c291c7f00776e8c6a2482198bb03ff90abd638dc650936739b8d",
+      "vrf": "7b6a8ba747c498db386227fe0747dba44197816d82bc662e92c32a00f0e4906e"
+    },
+    "28466494f218d24d9627c4ffcf55671f894f775ee782bfd61ca3a4e8": {
+      "delegate": "bd4a372503f35313c4f17e3cdc012f460119af1841c509c763218fc8",
+      "vrf": "4c6d14ca2697dd446d4963c99dcb2a02419052beaad3c9aa7e37c261c8138c94"
+    }
+  },
+  "updateQuorum": 3,
+  "networkId": "Mainnet",
+  "initialFunds": {},
+  "maxLovelaceSupply": 45000000000000000,
+  "networkMagic": 42,
+  "epochLength": 21600,
+  "systemStart": "2020-07-25T13:00:00Z",
+  "slotsPerKESPeriod": 7200,
+  "slotLength": 1,
+  "maxKESEvolutions": 62,
+  "securityParam": 108
+}

--- a/benchmarks/existing-cluster/configuration/mainnet_candidate_4-topology.json
+++ b/benchmarks/existing-cluster/configuration/mainnet_candidate_4-topology.json
@@ -1,0 +1,9 @@
+{
+  "Producers": [
+    {
+      "addr": "relays-new.mainnet-candidate-4.dev.cardano.org",
+      "port": 3001,
+      "valency": 2
+    }
+  ]
+}

--- a/benchmarks/existing-cluster/configuration/topology.json
+++ b/benchmarks/existing-cluster/configuration/topology.json
@@ -1,0 +1,1 @@
+mainnet_candidate_4-topology.json

--- a/benchmarks/existing-cluster/convert-faucet-funds-to-txgen-args.sh
+++ b/benchmarks/existing-cluster/convert-faucet-funds-to-txgen-args.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2016
+
+BASEDIR=$(realpath "$(dirname "$0")")
+. "$BASEDIR"/../../scripts/common.sh
+
+key=$1
+faucet_funds=$2
+api_key=${3:-put_the_correct_api_key_here}
+
+cli_args=(
+        shelley address build
+        --payment-verification-key-file "$key"
+        --mainnet
+)
+addr=$(cardano-cli "${cli_args[@]}")
+test -n "$addr" ||
+        fail "couldn't get address for key file:  $key"
+
+curl -XPOST "https://$faucet/send-money/$addr?apiKey=$api_key"

--- a/benchmarks/existing-cluster/get-address-utxos.sh
+++ b/benchmarks/existing-cluster/get-address-utxos.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2016
+
+BASEDIR=$(realpath "$(dirname "$0")")
+. "$BASEDIR"/../../scripts/common.sh
+
+addr=$1
+
+args=(
+        shelley query utxo
+        --testnet-magic 42
+        --address "$addr"
+)
+
+{
+        echo -n '['
+        CARDANO_NODE_SOCKET_PATH=socket \
+            cardano-cli "${args[@]}" |
+            grep -F '"' |
+            sed 's_ [ ]*_, _g;
+                 s_^_, [ "id": _; s_$_ ]_;
+                 s_"id": \(".*"\), \([0-9][0-9]*\), \([0-9][0-9]*\)_{ "txid": \1, "txix": \2 }, { "addr": "'"$addr"'", "coin": \3 }_'
+        echo ']'
+} | sed 's_\[,_\[_'

--- a/benchmarks/existing-cluster/request-faucet-funds.sh
+++ b/benchmarks/existing-cluster/request-faucet-funds.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2016
+
+BASEDIR=$(realpath "$(dirname "$0")")
+. "$BASEDIR"/../../scripts/common.sh
+
+key=$1
+faucet=${2:-faucet.mainnet-candidate-4.dev.cardano.org}
+api_key=${3:-put_the_correct_api_key_here}
+
+cli_args=(
+        shelley address build
+        --payment-verification-key-file "$key"
+        --mainnet
+)
+addr=$(cardano-cli "${cli_args[@]}")
+test -n "$addr" ||
+        fail "couldn't get address for key file:  $key"
+
+curl -XPOST "https://$faucet/send-money/$addr?apiKey=$api_key"

--- a/benchmarks/existing-cluster/workload.sh
+++ b/benchmarks/existing-cluster/workload.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090
+
+BASEDIR=$(realpath "$(dirname "$0")")
+. "$BASEDIR"/../../scripts/common.sh
+
+prebuild 'cardano-tx-generator' || exit 1
+
+usage() {
+        cat <<EOF
+Usage: $(basename "$0") COMMAND ARGS..
+
+Commands:
+
+  sync-chain           Sync a local proxy node DB against the cluster specified
+                         in the 'configuration' subdirectory of
+                         $BASEDIR
+
+  workload-from-coin SIGKEYFILE TXID TXIX ADDR COIN
+                       Begin a transaction generation workload, by using
+                         the pair of a synced local proxy node and txgen,
+                         targeting the latter at the node specified by
+                         $BASEDIR/topology.json
+                       Initial funds are obtained from the specified coin
+
+  workload-from-utxo SIGKEYFILE UTXO-FILE
+                       Begin a transaction generation workload, by using
+                         the pair of a synced local proxy node and txgen,
+                         targeting the latter at the node specified by
+                         $BASEDIR/topology.json
+                       Initial funds are obtained from the specified UTxO
+                         JSON file of the following (informal) schema:
+                         [[{ "txid": TXID, "txix": TXIX },
+                           { "addr": ADDR, "coin": LOVELACE }]
+                         , ...]
+                         Which is, essentially, a list of TxIn/TxOut pairs.
+
+EOF
+} >&2
+
+txs=4000
+tps=20
+targets=2
+fee=400000
+
+main() {
+        cmd=${1:-hel}; shift
+        case "$cmd" in
+                sync-chain | sync ) op_sync_chain;;
+                workload-from-* )   op_workload "$cmd" "$@";;
+                * ) usage; exit 1;;
+        esac
+}
+
+op_sync_chain() {
+        run cardano-node "${args_proxy[@]}"
+        run cardano-tx-generator "${args_txgen[@]}"
+}
+
+node_pid=
+shutdown_node() {
+        test -n "$node_pid" && {
+                echo "--( shutting down node PID $node_pid.."
+                kill "$node_pid"
+        }
+        rm -f "$BASEDIR"/socket
+}
+trap shutdown_node EXIT
+
+op_workload() {
+        mode=$1; shift
+        skey=${1:?$(usage)}; shift
+        case "$mode" in
+                workload-from-coin )
+                        txid=${1:?$(usage)}
+                        txix=${2:?$(usage)}
+                        addr=${3:?$(usage)}
+                        coin=${4:?$(usage)}
+                        args_funds=(
+                                --utxo-funds-key "$skey"
+                                --tx-out         "$addr+$coin"
+                                --tx-in          "$txid"'#'"$txix"
+                        );;
+                workload-from-utxo )
+                        utxo_file=${1:?$(usage)}
+                        args_funds=(
+                                --split-utxo-funds-key "$skey"
+                                --split-utxo           "$utxo_file"
+                        );; esac
+        local nodeaddr nodeport n
+        nodeport=$(jq '.Producers[0].port' \
+                      $BASEDIR/configuration/topology.json -r)
+        args_txgen=()
+        for n in $(seq 1 $targets)
+        do nodeaddr=$(jq '.Producers[0].addr' \
+                        $BASEDIR/configuration/topology.json -r)
+           if test -n "$(echo $nodeaddr | grep 'amazon\|aws\|com\|net\|org')"
+           then nodeip=$(echo $nodeaddr | \
+                                 xargs host | head -n1 | sed 's/.*has address //')
+           else nodeip=$nodeaddr; fi
+           echo "--( target node $n:  $nodeaddr:$nodeip:$nodeport" >&2
+           args_txgen+=(
+             --target-node    '("'$nodeip'",'$nodeport')'
+           )
+        done
+
+        args_txgen+=(
+        --config         "$BASEDIR"/configuration/config-txgen.json
+        --socket-path    "$BASEDIR"/socket
+        --num-of-txs     $txs
+        --add-tx-size    0
+        --inputs-per-tx  1
+        --outputs-per-tx 1
+        --tx-fee         $fee
+        --tps            $tps
+        --init-cooldown  60
+
+        --shelley        ## Cardano mode in Shelley era
+        --addr-mainnet
+        )
+        args_txgen+=("${args_funds[@]}")
+
+        rm -rf logs
+
+        echo "--( parameters:  txs=$txs, tps=$tps, targets=$targets, fee=$fee"
+        echo "--( starting node, logs in ./logs"
+        mkdir -p logs
+        run cardano-node         "${args_proxy[@]}" >logs/node.log 2>&1 &
+        node_pid=$!
+        echo -n "--( waiting for node (pid $node_pid) socket ($BASEDIR/socket) to appear:  "
+        while test ! -e "$BASEDIR/socket"; do echo -n .; sleep 1; done; echo "ok, got it."
+        run cardano-tx-generator "${args_txgen[@]}" 2>&1 | tee logs/generator.log
+}
+
+args_proxy=(
+        'run'
+        --config         "$BASEDIR"/configuration/config-proxy.json
+        --database-path  "$BASEDIR"/db
+        --socket-path    "$BASEDIR"/socket
+        --topology       "$BASEDIR"/configuration/topology.json
+)
+
+main "$@"

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -9,6 +11,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-missed-specialisations #-}
@@ -27,7 +30,7 @@ module Cardano.Benchmarking.GeneratorTx
   ) where
 
 import           Cardano.Prelude
-import           Prelude (String, error, id)
+import           Prelude (error, id)
 
 import           Control.Concurrent (threadDelay)
 import           Control.Monad (fail, forM, forM_)
@@ -35,6 +38,8 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (left, newExceptT, right)
 import           Control.Tracer (traceWith)
 
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BS
 import           Data.Foldable (find)
 import qualified Data.IP as IP
 import           Data.List.NonEmpty (NonEmpty (..))
@@ -43,12 +48,15 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (Maybe (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
+import           Data.Text (Text, pack)
 import           Data.Word (Word64)
 import           Network.Socket (AddrInfo (..), AddrInfoFlag (..), Family (..), SocketType (Stream),
                                  addrFamily, addrFlags, addrSocketType, defaultHints, getAddrInfo)
 
-import           Cardano.Config.Types (NodeAddress (..), NodeHostAddress (..), SigningKeyFile (..))
+import           Cardano.Chain.Common (decodeAddressBase58)
+import           Cardano.Config.Types
+                   ( NodeAddress (..), NodeHostAddress(..)
+                   , SigningKeyFile(..))
 
 import           Cardano.Api.TxSubmit
 import           Cardano.Api.Typed
@@ -80,9 +88,9 @@ secureFunds :: ConfigSupportsTxGen mode era
   => Benchmark
   -> Mode mode era
   -> GeneratorFunds
-  -> ExceptT TxGenError IO (SigningKeyOf era, (TxIn, TxOut era))
+  -> ExceptT TxGenError IO (SigningKeyOf era, Set (TxIn, TxOut era))
 
-secureFunds Benchmark{bTxFee, bInitialTTL} m (FundsGenesis keyF) = do
+secureFunds b@Benchmark{bTxFee, bInitialTTL} m (FundsGenesis keyF) = do
   key <- readSigningKey (modeEra m) keyF
   let (_, TxOut _ genesisCoin) = extractGenesisFunds m key
       toAddr = keyAddress m key
@@ -97,18 +105,53 @@ secureFunds Benchmark{bTxFee, bInitialTTL} m (FundsGenesis keyF) = do
       [ "******* Funding secured (", show txin, " -> ", show txout
       , "), submission result: " , show r ]
     e -> fail $ show e
-  pure (key, (txin, txout))
+  (key, ) <$> splitFunds b m key (txin, txout)
 
-secureFunds _ m@ModeShelley{} (FundsUtxo keyF txin txout) = do
+secureFunds b m@ModeShelley{} (FundsUtxo keyF txin txout) = do
   key <- readSigningKey (modeEra m) keyF
-  pure (key, (txin, txout))
+  (key, ) <$> splitFunds b m key (txin, txout)
 
-secureFunds _ m@ModeCardanoShelley{} (FundsUtxo keyF txin txout) = do
+secureFunds b m@ModeCardanoShelley{} (FundsUtxo keyF txin txout) = do
   key <- readSigningKey (modeEra m) keyF
-  pure (key, (txin, txout))
+  (key, ) <$> splitFunds b m key (txin, txout)
+
+secureFunds _ m (FundsSplitUtxo keyF utxoF) = do
+  key <- readSigningKey (modeEra m) keyF
+  utxo <- withExceptT (UtxoReadFailure . pack) . newExceptT $ A.eitherDecode <$> BS.readFile utxoF
+  pure (key, utxo)
 
 secureFunds _ m f =
   error $ "secureFunds:  unsupported config: " <> show m <> " / " <> show f
+
+parseAddress ::
+     Era era
+  -> Text
+  -> Address era
+parseAddress = \case
+  EraByron ->
+    either (panic . ("Bad Base58 address: " <>) . show) ByronAddress
+    . decodeAddressBase58
+  EraShelley -> \addr ->
+    fromMaybe (panic $ "Bad Shelley address: " <> addr) $
+    deserialiseAddress AsShelleyAddress addr
+
+instance FromJSON (Address Byron) where
+  parseJSON = A.withText "ByronAddress" $ pure . parseAddress EraByron
+
+instance FromJSON (Address Shelley) where
+  parseJSON = A.withText "ShelleyAddress" $ pure . parseAddress EraShelley
+
+instance FromJSON (Address era) => FromJSON (TxOut era) where
+  parseJSON = A.withObject "TxOut" $ \v ->
+    TxOut
+      <$> (             v A..: "addr")
+      <*> (Lovelace <$> v A..: "coin")
+
+instance FromJSON TxIn where
+  parseJSON = A.withObject "TxIn" $ \v -> do
+    TxIn
+      <$> (TxId <$> v A..: "txid")
+      <*> (TxIx <$> v A..: "txix")
 
 -----------------------------------------------------------------------------------------
 -- Obtain initial funds.
@@ -229,19 +272,14 @@ runBenchmark
   => Benchmark
   -> Mode mode era
   -> SigningKeyOf era
-  -> (TxIn, TxOut era)
+  -> Set (TxIn, TxOut era)
   -> ExceptT TxGenError IO ()
 runBenchmark b@Benchmark{ bTargets
                         , bTps
                         , bInitCooldown=InitCooldown initCooldown
                         }
-             m fundsKey funds = do
+             m fundsKey fundsWithSufficientCoins = do
   let recipientAddress = keyAddress m fundsKey
-
-  liftIO . traceWith (trTxSubmit m) . TraceBenchTxSubDebug
-    $ "******* Tx generator, phase 1: make enough available UTxO entries using: " <> (show funds :: String)
-  fundsWithSufficientCoins <-
-    splitFunds b m fundsKey funds
 
   liftIO . traceWith (trTxSubmit m) . TraceBenchTxSubDebug
     $ "******* Tx generator: waiting " ++ show initCooldown ++ "s *******"
@@ -348,7 +386,7 @@ txGenerator Benchmark
                                   (repeat txOut)
   initRecipientIndex = 0 :: Int
   -- The same output for all transactions.
-  valueForRecipient = Lovelace 100000000 -- 100 ADA, discuss this value.
+  valueForRecipient = Lovelace 10000000 -- 10 ADA
   !txOut = TxOut recipientAddress valueForRecipient
   totalValue = valueForRecipient + bTxFee
   -- Send possible change to the same 'recipientAddress'.
@@ -395,7 +433,7 @@ txGenerator Benchmark
     -> ExceptT TxGenError IO ((TxIn, TxOut era), Set (TxIn, TxOut era))
   findAvailableFunds funds thresh =
     case find (predTxD thresh) funds of
-      Nothing    -> left InsufficientFundsForRecipientTx
+      Nothing    -> left $ InsufficientFundsForRecipientTx thresh
       Just found -> right (found, Set.delete found funds)
 
   -- Find the first tx output that contains sufficient amount of money.

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
@@ -92,7 +92,7 @@ newtype NumberOfOutputsPerTx =
   deriving (Eq, Ord, Num, Show)
 
 newtype NumberOfTxs =
-  NumberOfTxs Word64
+  NumberOfTxs { unNumberOfTxs :: Word64 }
   deriving (Eq, Ord, Num, Show)
 
 newtype TPSRate =

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
@@ -20,10 +20,6 @@ import           Options.Applicative
 import qualified Options.Applicative as Opt
 import qualified Control.Arrow as Arr
 import           Network.Socket (PortNumber)
-import           Options.Applicative (Parser, auto, bashCompleter, completer, flag, help, long,
-                                      metavar, option, strOption)
-import           Prelude (String)
-
 import           Cardano.Api.Typed
 import           Cardano.Config.Types (NodeAddress (..), NodeHostAddress (..), SigningKeyFile (..),
                                        SocketPath (..))

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -293,7 +293,7 @@ mkMode
   -> SocketPath
   -> LoggingLayer
   -> Mode mode era
-mkMode ptcl@Consensus.ProtocolByron{} EraByron nmo amm iom (SocketPath sock) ll =
+mkMode ptcl@Consensus.ProtocolByron{} EraByron nmagic_opt is_addr_mn iom (SocketPath sock) ll =
   ModeByron
     pInfoConfig
     (configCodec pInfoConfig)
@@ -302,13 +302,13 @@ mkMode ptcl@Consensus.ProtocolByron{} EraByron nmo amm iom (SocketPath sock) ll 
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
        (ByronMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
-    nmo
-    amm
+    nmagic_opt
+    is_addr_mn
     iom
     (createTracers ll)
  where
    ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode ptcl@Consensus.ProtocolShelley{} EraShelley nmo amm iom (SocketPath sock) ll =
+mkMode ptcl@Consensus.ProtocolShelley{} EraShelley nmagic_opt is_addr_mn iom (SocketPath sock) ll =
   ModeShelley
     pInfoConfig
     (configCodec pInfoConfig)
@@ -316,13 +316,13 @@ mkMode ptcl@Consensus.ProtocolShelley{} EraShelley nmo amm iom (SocketPath sock)
        sock
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        ShelleyMode)
-    nmo
-    amm
+    nmagic_opt
+    is_addr_mn
     iom
     (createTracers ll)
  where
    ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode ptcl@Consensus.ProtocolCardano{} EraByron nmo amm iom (SocketPath sock) ll =
+mkMode ptcl@Consensus.ProtocolCardano{} EraByron nmagic_opt is_addr_mn iom (SocketPath sock) ll =
   ModeCardanoByron
     pInfoConfig
     (configCodec pInfoConfig)
@@ -331,13 +331,13 @@ mkMode ptcl@Consensus.ProtocolCardano{} EraByron nmo amm iom (SocketPath sock) l
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
        (CardanoMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
-    nmo
-    amm
+    nmagic_opt
+    is_addr_mn
     iom
     (createTracers ll)
  where
    ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode ptcl@Consensus.ProtocolCardano{} EraShelley nmo amm iom (SocketPath sock) ll =
+mkMode ptcl@Consensus.ProtocolCardano{} EraShelley nmagic_opt is_addr_mn iom (SocketPath sock) ll =
   ModeCardanoShelley
     pInfoConfig
     (configCodec pInfoConfig)
@@ -346,8 +346,8 @@ mkMode ptcl@Consensus.ProtocolCardano{} EraShelley nmo amm iom (SocketPath sock)
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
        (CardanoMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
-    nmo
-    amm
+    nmagic_opt
+    is_addr_mn
     iom
     (createTracers ll)
  where

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -164,6 +164,7 @@ type ModeSupportsTxGen mode =
 
 type EraSupportsTxGen era =
   ( Eq (Address era)
+  , FromJSON (TxOut era)
   , Key (SigningKeyRoleOf era)
   , Ord (TxOut era)
   , Show (Tx era)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -8,17 +8,13 @@ import           Cardano.Api.Typed
 import           Cardano.Prelude
 
 data TxGenError =
-    CurrentlyCannotSendTxToRelayNode !FilePath
-  -- ^ Relay nodes cannot currently be transaction recipients.
-  | InsufficientFundsForRecipientTx !Lovelace
-  -- ^ Error occurred while creating the target node address.
-  | NeedMinimumThreeSigningKeyFiles ![FilePath]
-  -- ^ Need at least 3 signing key files.
-  | TooSmallTPSRate !Double
-  -- ^ TPS is less than lower limit.
+    InsufficientFundsForRecipientTx !Lovelace !Lovelace
+  -- ^ The calculated expenditure (second value) was not available as a single
+  --   UTxO entry.  The first value is the largest single UTxO available.
   | TxFileError !(FileError TextEnvelopeError)
-  | SecretKeyDeserialiseError !Text
-  | SecretKeyReadError !Text
   | SplittingSubmissionError !Text
   | UtxoReadFailure !Text
+  | SuppliedUtxoTooSmall !Int !Int
+  -- ^ The supplied UTxO size (second value) was less than the requested
+  --   number of transactions to send (first value).
   deriving Show

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -10,7 +10,7 @@ import           Cardano.Prelude
 data TxGenError =
     CurrentlyCannotSendTxToRelayNode !FilePath
   -- ^ Relay nodes cannot currently be transaction recipients.
-  | InsufficientFundsForRecipientTx
+  | InsufficientFundsForRecipientTx !Lovelace
   -- ^ Error occurred while creating the target node address.
   | NeedMinimumThreeSigningKeyFiles ![FilePath]
   -- ^ Need at least 3 signing key files.
@@ -20,4 +20,5 @@ data TxGenError =
   | SecretKeyDeserialiseError !Text
   | SecretKeyReadError !Text
   | SplittingSubmissionError !Text
+  | UtxoReadFailure !Text
   deriving Show

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -53,8 +53,9 @@ import           Cardano.Benchmarking.GeneratorTx.CLI.Parsers
 
 
 data GeneratorFunds
-  = FundsGenesis SigningKeyFile
-  | FundsUtxo    SigningKeyFile TxIn (TxOut Shelley)
+  = FundsGenesis   SigningKeyFile
+  | FundsUtxo      SigningKeyFile TxIn (TxOut Shelley)
+  | FundsSplitUtxo SigningKeyFile FilePath
   deriving Show
 
 parseGeneratorFunds :: Opt.Parser GeneratorFunds
@@ -70,6 +71,14 @@ parseGeneratorFunds =
         "UTxO funds signing key."
     <*> pTxIn
     <*> pTxOut)
+  <|>
+  (FundsSplitUtxo
+    <$> parseSigningKeysFile
+        "split-utxo-funds-key"
+        "UTxO funds signing key."
+    <*> parseFilePath
+        "split-utxo"
+        "UTxO funds file.")
 
 keyAddress :: Mode mode era -> SigningKeyOf era -> Address era
 keyAddress m = case modeEra m of

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -90,7 +90,7 @@ benchmarkConnectTxSubmit p localAddr remoteAddr myTxSubClient =
   peerMultiplex =
     simpleSingletonVersions
       n2nVer
-      (NtN.NodeToNodeVersionData { NtN.networkMagic = modeNetworkMagic p})
+      (NtN.NodeToNodeVersionData { NtN.networkMagic = modeNetworkMagicN2N p})
       (NtN.DictVersion NtN.nodeToNodeCodecCBORTerm) $
       NtN.nodeToNodeProtocols NtN.defaultMiniProtocolParameters $ \them _ ->
         NtN.NodeToNodeProtocols

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
@@ -22,11 +22,8 @@ import           Data.Text
 import           Cardano.Prelude hiding (option)
 import           Control.Monad (fail)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
-import           Data.Text (Text, pack, unpack)
-import           Data.Version (showVersion)
 import qualified Options.Applicative as Opt
 import           Paths_cardano_tx_generator (version)
-import           Prelude (String)
 
 import qualified Cardano.Chain.Genesis as Genesis
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
@@ -115,8 +115,8 @@ runCommand (GenerateTxs logConfigFp
                         socketFp
                         cliPartialBenchmark
                         someEra
-                        nmo
-                        amm
+                        nmagic_opt
+                        is_addr_mn
                         funds) =
   withIOManagerE $ \iocp -> do
     -- Logging layer
@@ -132,19 +132,19 @@ runCommand (GenerateTxs logConfigFp
           ptcl :: Protocol IO ByronBlockHFC ProtocolByron
                <- firstExceptT (ProtocolInstantiationError . pack . show) $
                     mkConsensusProtocolByron config Nothing
-          pure . SomeMode $ mkMode ptcl EraByron nmo amm iocp socketFp loggingLayer
+          pure . SomeMode $ mkMode ptcl EraByron nmagic_opt is_addr_mn iocp socketFp loggingLayer
         NodeProtocolConfigurationShelley config -> do
           ptcl :: Protocol IO ShelleyBlockHFC ProtocolShelley
                <- firstExceptT (ProtocolInstantiationError . pack . show) $
                     mkConsensusProtocolShelley config Nothing
-          pure . SomeMode $ mkMode ptcl EraShelley nmo amm iocp socketFp loggingLayer
+          pure . SomeMode $ mkMode ptcl EraShelley nmagic_opt is_addr_mn iocp socketFp loggingLayer
         NodeProtocolConfigurationCardano byC shC hfC -> do
           ptcl :: Protocol IO CardanoBlock ProtocolCardano
                <- firstExceptT (ProtocolInstantiationError . pack . show) $
                     mkConsensusProtocolCardano byC shC hfC Nothing
           case someEra of
             SomeEra era ->
-              pure . SomeMode $ mkMode ptcl era nmo amm iocp socketFp loggingLayer
+              pure . SomeMode $ mkMode ptcl era nmagic_opt is_addr_mn iocp socketFp loggingLayer
           -- case someEra of
           --   SomeEra EraByron ->
           --     pure . SomeMode $ mkMode ptcl EraByron iocp socketFp loggingLayer


### PR DESCRIPTION
- allow the generator to use externally-supplied UTxO
- support the the generator magic overrides necessary for Mainnet Candidate clusters
- setup for targeting an MC cluster
- address -> UTxO extraction script
- some Dead Code Elimination

Supercedes https://github.com/input-output-hk/cardano-benchmarking/pull/155