### PR TITLE
CAD-1643:  fix package set divergence

### DIFF
--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -142,7 +142,7 @@ import           Cardano.Api.TxSubmit
 import qualified Cardano.Api.Typed as Api
 
 -- Node imports
-import           Cardano.Node.Types (NodeAddress, SocketPath(..))
+import           Cardano.Node.Types (SocketPath(..))
 import           Cardano.Node.Configuration.Logging (LOContent(..), LoggingLayer (..))
 import           Cardano.Tracing.OrphanInstances.Byron()
 import           Cardano.Tracing.OrphanInstances.Common()

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,30 +2,30 @@
 , crossSystem ? null
 , config ? {}
 , sourcesOverride ? {}
-, gitrev ? null
-, customConfig ? {}
+, gitrev ? null, customConfig ? {}
 }:
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohkNix = import sources.iohk-nix {};
+  iohkNixMain = import sources.iohk-nix {};
   haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
   nixpkgs = if (sources ? nixpkgs)
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
-    else iohkNix.nixpkgs;
+    else (builtins.trace "Using IOHK default nixpkgs"
+      iohkNixMain.nixpkgs);
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohkNix.overlays.haskell-nix-extra
-    ++ iohkNix.overlays.crypto
+    ++ iohkNixMain.overlays.haskell-nix-extra
+    ++ iohkNixMain.overlays.crypto
     # iohkNix: nix utilities and niv:
-    ++ iohkNix.overlays.iohkNix
+    ++ iohkNixMain.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; rec {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,28 +23,16 @@
         "url": "https://github.com/input-output-hk/cardano-node/archive/4814003f14340d5a1fc02f3ac15437387a7ada9f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "cardano-sl": {
-        "branch": "develop",
-        "description": "Cryptographic currency implementing Ouroboros PoS protocol",
-        "homepage": "",
-        "owner": "input-output-hk",
-        "repo": "cardano-sl",
-        "rev": "d0cc2e6336e3c57771c775cafe831bc83db303d3",
-        "sha256": "1l0af54ivqs26ibsl4nih8800b99f99r1y33wcrnby28mjsph8s2",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-sl/archive/d0cc2e6336e3c57771c775cafe831bc83db303d3.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "27eff13aa0616e8ce5106e81339b0462f04af3bd",
-        "sha256": "0wn70ap5kgzcjpf7w3vm4z5h4d36a625fa2dhy1l79pjj6hj40ly",
+        "rev": "35b1ec8cd577bfc5abf7d0325f38aab01de5ed00",
+        "sha256": "0mg18i6g7nxd7qk0kaca6k8dsc3kam21772zlr19k03ff67ws55j",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/27eff13aa0616e8ce5106e81339b0462f04af3bd.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/35b1ec8cd577bfc5abf7d0325f38aab01de5ed00.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/shell-minimal.nix
+++ b/shell-minimal.nix
@@ -1,0 +1,1 @@
+import ./shell.nix { minimal = true; }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,8 @@
 # It just takes the shell attribute from default.nix.
 { config ? {}
 , sourcesOverride ? {}
-, withHoogle ? false
+, minimal ? false
+, withHoogle ? (! minimal)
 , pkgs ? import ./nix {
     inherit config sourcesOverride;
   }
@@ -24,24 +25,25 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [
-      #cardanoDbSync.cardano-db-sync
-      #cardanoNode.cardano-cli
-      #cardanoNode.cardano-node
-      #cabal-install
-      #stack
-      #ghcid
-      #hlint
-      stylish-haskell
-      #weeder
-      #gnumeric
-      #libreoffice
+      cabal-install
+      stack
       nix
       niv
-      #pkgconfig
-      #sqlite-interactive
-      #tmux
-      #git
-      #postgresql
+      pkgconfig
+      tmux
+      # postgresql
+    ] ++ lib.optionals (! minimal) [
+      # cardanoDbSync.cardano-db-sync
+      cardanoNode.cardano-cli
+      cardanoNode.cardano-node
+      ghcid
+      git
+      # gnumeric
+      # libreoffice
+      hlint
+      stylish-haskell
+      sqlite-interactive
+      weeder
     ];
 
     # Prevents cabal from choosing alternate plans, so that


### PR DESCRIPTION
1. update `haskell.nix`
1. `shelley3pools` tested to work in `--shelley` and `--cardano` modes, both in `--nix` and `--cabal` (via cabal-in-nix-shell).
1. fix a small warning
1. another pass of Nix divergence reduction with `cardano-node` repo