### PR TITLE
CAD-1786: RTView interactive dialog

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -196,64 +196,64 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/backend-trace-forwarder
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   plugins/backend-trace-acceptor
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8f2086aff6b315b41a39b727f860c3477205ed8a
-  --sha256: 0ajiqa92zdydvxy9d1n640i7k5v5z6pf6v8q31yx2rrnm3hdg9lh
+  tag: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
+  --sha256: 1fgwcllpnx9394p3fh2j9r2x1g97w0ywd0zhsbnnb42vj5k3pb6q
   subdir:   tracer-transformers
 
 source-repository-package

--- a/cardano-rt-view/cardano-rt-view.cabal
+++ b/cardano-rt-view/cardano-rt-view.cabal
@@ -17,6 +17,7 @@ library
 
   exposed-modules:     Cardano.Benchmarking.RTView
                        Cardano.Benchmarking.RTView.CLI
+                       Cardano.Benchmarking.RTView.Config
 
                        Cardano.Benchmarking.RTView.Acceptor
 
@@ -48,6 +49,8 @@ library
                      , containers
                      , contra-tracer
                      , deepseq
+                     , directory
+                     , filepath
                      , formatting
                      , iohk-monitoring
                      , lobemo-backend-trace-acceptor
@@ -58,6 +61,7 @@ library
                      , text
                      , time
                      , threepenny-gui
+                     , yaml
 
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Benchmarking.RTView
@@ -9,19 +8,17 @@ import           Cardano.Prelude hiding (newMVar)
 
 import           Control.Concurrent.Async (async, waitAnyCancel)
 import           Control.Concurrent.MVar.Strict (MVar, newMVar)
-import           Data.List (nub, nubBy)
-import qualified System.Exit as Ex
+import qualified Data.Text.IO as TIO
 
 import           Cardano.BM.Backend.Switchboard (addUserDefinedBackend)
-import           Cardano.BM.Configuration (Configuration, getAcceptAt, setup)
 import           Cardano.BM.Data.Backend (Backend (..))
-import           Cardano.BM.Data.Configuration (RemoteAddr (..), RemoteAddrNamed (..))
 import qualified Cardano.BM.Setup as Setup
 import           Cardano.BM.Trace (Trace, logNotice)
 import           Cardano.BM.Tracing (appendName)
 
 import           Cardano.Benchmarking.RTView.Acceptor (launchMetricsAcceptor)
 import           Cardano.Benchmarking.RTView.CLI (RTViewParams (..))
+import           Cardano.Benchmarking.RTView.Config (prepareConfigAndParams)
 import           Cardano.Benchmarking.RTView.ErrorBuffer (ErrorBuffer, effectuate, realize,
                                                           unrealize)
 import           Cardano.Benchmarking.RTView.NodeState.Types (NodesState, defaultNodesState)
@@ -30,10 +27,12 @@ import           Cardano.Benchmarking.RTView.Server (launchServer)
 
 -- | Run the service.
 runCardanoRTView :: RTViewParams -> IO ()
-runCardanoRTView params = do
-  config <- readConfig (rtvConfig params)
-  acceptors <- checkIfTraceAcceptorIsDefined config (rtvConfig params)
-  makeSureTraceAcceptorsAreUnique acceptors
+runCardanoRTView params' = do
+  TIO.putStrLn "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
+  TIO.putStrLn "┃ RTView: real-time view service for cardano-node ┃"
+  TIO.putStrLn "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛"
+
+  (config, params, acceptors) <- prepareConfigAndParams params'
 
   (tr :: Trace IO Text, switchBoard) <- Setup.setupTrace_ config "cardano-rt-view"
   let accTr = appendName "acceptor" tr
@@ -60,49 +59,3 @@ runCardanoRTView params = do
   serverThr   <- async $ launchServer nodesStateMVar params acceptors
 
   void $ waitAnyCancel [acceptorThr, updaterThr, serverThr]
-
--- | Reads the service' configuration file (path is passed via '--config' CLI option).
-readConfig :: FilePath -> IO Configuration
-readConfig pathToConfig = setup pathToConfig `catch` exceptHandler
- where
-  exceptHandler :: IOException -> IO Configuration
-  exceptHandler e =
-    Ex.die $ "Exception while reading configuration "
-             <> pathToConfig
-             <> ", exception: "
-             <> show e
-
--- | RTView service requires at least one |TraceAcceptor|.
-checkIfTraceAcceptorIsDefined
-  :: Configuration
-  -> FilePath
-  -> IO [RemoteAddrNamed]
-checkIfTraceAcceptorIsDefined config pathToConfig =
-  getAcceptAt config >>= \case
-    Just acceptors -> return acceptors
-    Nothing -> Ex.die $ "No trace acceptors found in the configuration: " <> pathToConfig
-
--- | If configuration contains more than one trace acceptor,
---   check if they are unique, to avoid socket problems.
-makeSureTraceAcceptorsAreUnique
-  :: [RemoteAddrNamed]
-  -> IO ()
-makeSureTraceAcceptorsAreUnique acceptors = do
-  checkIfNodesNamesAreUnique
-  checkIfNetParametersAreUnique
- where
-  checkIfNodesNamesAreUnique =
-    when (length names /= length (nub names)) $
-      Ex.die "Nodes' names in trace acceptors must be unique!"
-
-  checkIfNetParametersAreUnique =
-    when (length addrs /= length (nubBy compareNetParams addrs)) $
-      Ex.die "Nodes' network parameters in trace acceptors must be unique!"
-
-  compareNetParams (RemoteSocket h1 p1) (RemoteSocket h2 p2) = h1 == h2 && p1 == p2
-  compareNetParams (RemoteSocket _ _)   (RemotePipe _)       = False
-  compareNetParams (RemotePipe _)       (RemoteSocket _ _)   = False
-  compareNetParams (RemotePipe p1)      (RemotePipe p2)      = p1 == p2
-
-  names = [name | RemoteAddrNamed name _ <- acceptors]
-  addrs = [addr | RemoteAddrNamed _ addr <- acceptors]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/CLI.hs
@@ -1,25 +1,70 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 module Cardano.Benchmarking.RTView.CLI
     ( RTViewParams (..)
+    , defaultRTViewParams
+    , defaultRTVConfig
+    , defaultRTVStatic
+    , defaultRTVPort
+    , defaultRTVNodeInfoLife
+    , defaultRTVBlockchainInfoLife
+    , defaultRTVResourcesInfoLife
+    , defaultRTVRTSInfoLife
     , parseRTViewParams
     ) where
 
 import           Cardano.Prelude hiding (option)
-import           Network.Socket (PortNumber)
-import           Options.Applicative (Parser, auto, bashCompleter, completer, help, long, metavar,
-                                      option, showDefault, strOption, value)
 import           Prelude (String)
+
+import           Data.Yaml (FromJSON, ToJSON)
+import           GHC.Generics (Generic)
+
+import           Options.Applicative (HasCompleter, HasMetavar, HasName, HasValue, Mod, Parser,
+                                      auto, bashCompleter, completer, help, long, metavar, option,
+                                      showDefault, strOption, value)
 
 -- | Type for CLI parameters required for the service.
 data RTViewParams
   = RTViewParams
       { rtvConfig             :: !FilePath
       , rtvStatic             :: !FilePath
-      , rtvPort               :: !PortNumber
+      , rtvPort               :: !Int
       , rtvNodeInfoLife       :: !Word64
       , rtvBlockchainInfoLife :: !Word64
       , rtvResourcesInfoLife  :: !Word64
       , rtvRTSInfoLife        :: !Word64
-      }
+      } deriving (Generic, FromJSON, ToJSON)
+
+defaultRTViewParams :: RTViewParams
+defaultRTViewParams = RTViewParams
+  { rtvConfig             = defaultRTVConfig
+  , rtvStatic             = defaultRTVStatic
+  , rtvPort               = defaultRTVPort
+  , rtvNodeInfoLife       = defaultRTVNodeInfoLife
+  , rtvBlockchainInfoLife = defaultRTVBlockchainInfoLife
+  , rtvResourcesInfoLife  = defaultRTVResourcesInfoLife
+  , rtvRTSInfoLife        = defaultRTVRTSInfoLife
+  }
+
+defaultRTVConfig, defaultRTVStatic :: FilePath
+defaultRTVConfig = ""
+defaultRTVStatic = "static"
+
+defaultRTVPort :: Int
+defaultRTVPort = 8024
+
+defaultRTVNodeInfoLife
+  , defaultRTVBlockchainInfoLife
+  , defaultRTVResourcesInfoLife
+  , defaultRTVRTSInfoLife :: Word64
+defaultRTVNodeInfoLife       = secToNanosec 5
+defaultRTVBlockchainInfoLife = secToNanosec 35
+defaultRTVResourcesInfoLife  = secToNanosec 35
+defaultRTVRTSInfoLife        = secToNanosec 45
+
+secToNanosec :: Int -> Word64
+secToNanosec s = fromIntegral $ s * 1000000000
 
 parseRTViewParams :: Parser RTViewParams
 parseRTViewParams =
@@ -27,30 +72,33 @@ parseRTViewParams =
     <$> parseFilePath
           "config"
           "file"
-          "Configuration file for real-time view service"
+          "Configuration file for RTView service. If not provided, interactive dialog will be started."
+          defaultRTVConfig
     <*> parseFilePath
           "static"
           "directory"
           "Directory with static content"
+          defaultRTVStatic
     <*> parsePort
           "port"
           "The port number"
+          defaultRTVPort
     <*> parseDiffTime
           "node-info-life"
           "Lifetime of node info"
-          5
+          defaultRTVNodeInfoLife
     <*> parseDiffTime
           "blockchain-info-life"
           "Lifetime of blockchain info"
-          35
+          defaultRTVBlockchainInfoLife
     <*> parseDiffTime
           "resources-info-life"
           "Lifetime of resources info"
-          35
+          defaultRTVResourcesInfoLife
     <*> parseDiffTime
           "rts-info-life"
           "Lifetime of GHC RTS info"
-          45
+          defaultRTVRTSInfoLife
 
 -- Aux parsers
 
@@ -58,38 +106,44 @@ parseFilePath
   :: String
   -> String
   -> String
+  -> FilePath
   -> Parser FilePath
-parseFilePath optname completion desc =
-  strOption
-    $ long optname
-        <> metavar "FILEPATH"
-        <> help desc
-        <> completer (bashCompleter completion)
+parseFilePath optname completion desc defaultPath =
+  let flags :: (HasCompleter f, HasMetavar f, HasName f, HasValue f)
+            => Mod f FilePath
+      flags = long optname
+           <> metavar "FILEPATH"
+           <> help desc
+           <> completer (bashCompleter completion)
+           <> value defaultPath
+  in strOption $ if null defaultPath
+                   then flags
+                   else flags <> showDefault
 
 parsePort
   :: String
   -> String
-  -> Parser PortNumber
-parsePort optname desc =
-  option ((fromIntegral :: Int -> PortNumber) <$> auto) (
+  -> Int
+  -> Parser Int
+parsePort optname desc defaultPort =
+  option auto (
        long optname
     <> metavar "PORT"
     <> help desc
+    <> value defaultPort
+    <> showDefault
   )
 
 parseDiffTime
   :: String
   -> String
-  -> Int
+  -> Word64
   -> Parser Word64
-parseDiffTime optname desc defaultTimeInSec =
+parseDiffTime optname desc defaultTime =
   option (secToNanosec <$> auto) (
        long optname
     <> metavar "DIFFTIME"
     <> help desc
-    <> value (secToNanosec defaultTimeInSec)
+    <> value defaultTime
     <> showDefault
   )
- where
-  secToNanosec :: Int -> Word64
-  secToNanosec s = fromIntegral $ s * 1000000000

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/Config.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/Config.hs
@@ -1,0 +1,417 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Benchmarking.RTView.Config
+    ( prepareConfigAndParams
+    ) where
+
+import           Cardano.Prelude
+
+import           Control.Monad (forM_)
+import           Data.List (nub, nubBy)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Text.IO as TIO
+import           Data.Yaml (ParseException, decodeFileEither, encodeFile)
+import           System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileExist,
+                                   getTemporaryDirectory, getXdgDirectory, listDirectory,
+                                   removeFile)
+import           System.FilePath ((</>), takeDirectory)
+import qualified System.Exit as Ex
+import           Text.Read (readMaybe)
+
+import           Cardano.BM.Configuration (Configuration, getAcceptAt, setup)
+import qualified Cardano.BM.Configuration.Model as CM
+import           Cardano.BM.Data.BackendKind (BackendKind (..))
+import           Cardano.BM.Data.Configuration (RemoteAddr (..), RemoteAddrNamed (..))
+import           Cardano.BM.Data.Output (ScribeDefinition (..), ScribeFormat (..),
+                                         ScribeKind (..), ScribePrivacy (..))
+import           Cardano.BM.Data.Severity (Severity (..))
+
+import           Cardano.Benchmarking.RTView.CLI (RTViewParams (..), defaultRTViewParams,
+                                                  defaultRTVPort, defaultRTVStatic)
+
+-- | There are few possible ways how we can prepare RTView configuration:
+--   1. By running interactive dialog with the user. If `--config` CLI-option
+--      isn't provided, the user will answer few questions and actual configuration
+--      will be prepared based on these answers.
+--   2. By providing configuration explicitly. If `--config`, `--static` and `--port`
+--      options are provided, these values will be used (interactive dialog will be skipped).
+--   3. By using the last used configuration. If the user already launched
+--      `cardano-rt-view-service` previously, the configuration was stored in
+--      user's local directory (different for each supported platform),
+--      and by default that configuration will be used again.
+prepareConfigAndParams
+  :: RTViewParams
+  -> IO (Configuration, RTViewParams, [RemoteAddrNamed])
+prepareConfigAndParams params' = do
+  (config, params) <-
+    if configFileIsProvided params'
+      then do
+        configFromFile <- readConfigFile $ rtvConfig params'
+        return (configFromFile, params')
+      else
+        checkIfPreviousConfigExists >>= \case
+          Just (prevConfig, prevParams) -> askUserAboutPrevConfig prevConfig prevParams
+          Nothing -> startDialogToPrepareConfig
+  acceptors <- checkIfTraceAcceptorIsDefined config
+  makeSureTraceAcceptorsAreUnique acceptors
+  -- To prevent TraceAcceptorPipeError "Network.Socket.bind: resource busy...
+  rmPipesIfNeeded acceptors
+  -- Configuration and parameters look good, save it for next sessions.
+  saveConfigurationForNextSessions config
+  saveRTViewParamsForNextSessions params
+  return (config, params, acceptors)
+
+configFileIsProvided :: RTViewParams -> Bool
+configFileIsProvided params = not . null $ rtvConfig params
+
+-- | Reads the service' configuration file (path is passed via '--config' CLI option).
+readConfigFile :: FilePath -> IO Configuration
+readConfigFile pathToConfig = setup pathToConfig `catch` exceptHandler
+ where
+  exceptHandler :: IOException -> IO Configuration
+  exceptHandler e =
+    Ex.die $ "Exception while reading configuration "
+             <> pathToConfig
+             <> ", exception: "
+             <> show e
+
+readRTViewParamsFile :: FilePath -> IO RTViewParams
+readRTViewParamsFile pathToParams =
+  decodeFileEither pathToParams >>= \case
+    Left (e :: ParseException) -> Ex.die $ "Exception while reading RTView parameters "
+                                         <> pathToParams <> ", exception: " <> show e
+    Right (params :: RTViewParams) -> return params
+
+-- | If `cardano-rt-view-service` already ws used on this computer,
+--   the configuration was saved in user's local directory, which
+--   differs on different platforms.
+savedConfigurationFile :: IO FilePath
+savedConfigurationFile = do
+  -- For configuration files. It uses the XDG_CONFIG_HOME environment variable.
+  -- On non-Windows systems, the default is ~/.config.
+  -- On Windows, the default is %APPDATA% (e.g. C:/Users/<user>/AppData/Roaming).
+  dir <- getXdgDirectory XdgConfig ""
+  return $ dir </> "rt-view.yaml"
+
+savedRTViewParamsFile :: IO FilePath
+savedRTViewParamsFile = do
+  dir <- getXdgDirectory XdgConfig ""
+  return $ dir </> "rt-view-params.yaml"
+
+checkIfPreviousConfigExists :: IO (Maybe (Configuration, RTViewParams))
+checkIfPreviousConfigExists = do
+  configExists <- savedConfigurationFile >>= doesFileExist
+  paramsExist  <- savedRTViewParamsFile >>= doesFileExist
+  if configExists && paramsExist
+    then do
+      config <- savedConfigurationFile >>= readConfigFile
+      params <- savedRTViewParamsFile >>= readRTViewParamsFile
+      return $ Just (config, params)
+    else
+      return Nothing
+
+askUserAboutPrevConfig
+  :: Configuration
+  -> RTViewParams
+  -> IO (Configuration, RTViewParams)
+askUserAboutPrevConfig savedConfig savedParams = do
+  TIO.putStrLn "Saved configuration file is found. Do you want to use it? <Y/N>"
+  TIO.getLine >>= \case
+    "Y" -> return (savedConfig, savedParams)
+    "y" -> return (savedConfig, savedParams)
+    ""  -> return (savedConfig, savedParams)
+    "N" -> startDialogToPrepareConfig
+    "n" -> startDialogToPrepareConfig
+    _   -> startDialogToPrepareConfig
+
+startDialogToPrepareConfig :: IO (Configuration, RTViewParams)
+startDialogToPrepareConfig = do
+  TIO.putStrLn $ "How many nodes will you connect (1 - "
+               <> show maximumNode <> ", default is " <> show defaultNodesNumber <> "): "
+  nodesNumber <- askAboutNodesNumber
+
+  TIO.putStrLn $ "Input the names of the nodes (default are \""
+               <> showDefaultNodesNames nodesNumber <> "\"): "
+  nodesNames <- askAboutNodesNames nodesNumber
+
+  TIO.putStrLn $ "Indicate the port for the web service (" <> show minimumPort
+               <> " - " <> show maximumPort <> ", default is "
+               <> show defaultRTVPort <> "): "
+  port <- askAboutWebPort
+
+  TIO.putStrLn "Connections shall be made via pipes (P, default way) or networking sockets (S)?"
+  remoteAddrs <- askAboutPipesAndSockets >>= \case
+    Pipe -> do
+      defDir <- defaultPipesDir
+      TIO.putStrLn $ "Ok, pipes will be used. Indicate the directory for them, default is \""
+                     <> T.pack defDir <> "\": "
+      askAboutLocationForPipes nodesNumber
+    Socket -> do
+      TIO.putStrLn $ "Ok, sockets will be used. Indicate the port base to listen for connections ("
+                     <> show minimumPort <> " - " <> show maximumPort <> ", default is "
+                     <> show defaultFirstPortForSockets <> "): "
+      askAboutFirstPortForSockets nodesNumber
+
+  TIO.putStrLn $ "Indicate the directory with static content for the web service, default is \""
+                 <> T.pack defaultRTVStatic <> "\":"
+  staticDir <- askAboutStaticDir
+
+  -- Form configuration and params based on user's input.
+  config <- CM.empty
+  CM.setMinSeverity config Info
+  CM.setSetupBackends config [KatipBK, LogBufferBK, TraceAcceptorBK]
+  CM.setDefaultBackends config [KatipBK]
+  CM.setSetupScribes config [ ScribeDefinition
+                              { scName     = "stdout"
+                              , scKind     = StdoutSK
+                              , scFormat   = ScText
+                              , scPrivacy  = ScPublic
+                              , scMinSev   = Notice
+                              , scMaxSev   = maxBound
+                              , scRotation = Nothing
+                              }
+                            ]
+  CM.setDefaultScribes config ["StdoutSK::stdout"]
+  CM.setBackends config "cardano-rt-view.acceptor" (Just [ LogBufferBK
+                                                         , UserDefinedBK "ErrorBufferBK"
+                                                         ])
+  let remoteAddrsNamed = map (\(nName, rAddr) -> RemoteAddrNamed nName rAddr)
+                             $ zip nodesNames remoteAddrs
+  CM.setAcceptAt config (Just remoteAddrsNamed)
+
+  let params = defaultRTViewParams { rtvPort = port
+                                   , rtvStatic = staticDir
+                                   }
+  return (config, params)
+
+defaultNodesNumber :: Int
+defaultNodesNumber = 3
+
+maximumNode :: Int
+maximumNode = 99
+
+defaultNodeNamePrefix :: Text
+defaultNodeNamePrefix = "node-"
+
+defaultNodesNames :: Int -> [Text]
+defaultNodesNames nodesNum = map (\nNum -> defaultNodeNamePrefix <> show nNum) [1 .. nodesNum]
+
+showDefaultNodesNames :: Int -> Text
+showDefaultNodesNames nodesNumber =
+  T.intercalate "\", \"" $ defaultNodesNames nodesNumber
+
+defaultFirstPortForSockets :: Int
+defaultFirstPortForSockets = 3000
+
+minimumPort, maximumPort :: Int
+minimumPort = 1024
+maximumPort = 65535
+
+defaultPipesDir :: IO FilePath
+defaultPipesDir = do
+  tmp <- getTemporaryDirectory
+  return $ tmp </> "rt-view-pipes"
+
+askAboutNodesNumber :: IO Int
+askAboutNodesNumber = do
+  nodesNumberRaw <- TIO.getLine
+  nodesNumber <-
+    if T.null nodesNumberRaw
+      then return defaultNodesNumber
+      else case readMaybe (T.unpack nodesNumberRaw) of
+             Just (n :: Int) -> return n
+             Nothing -> do
+               TIO.putStrLn "It's not a number, please input the number instead: "
+               askAboutNodesNumber
+  if nodesNumber < 1 || nodesNumber > maximumNode
+    then do
+      TIO.putStrLn $ "Wrong number of nodes, please input the number from 1 to "
+                     <> show maximumNode <> ": "
+      askAboutNodesNumber
+    else do
+      TIO.putStrLn $ "Ok, " <> show nodesNumber <> " nodes."
+      return nodesNumber
+
+askAboutNodesNames :: Int -> IO [Text]
+askAboutNodesNames nodesNumber = askNodeNames 1
+ where
+   askNodeNames :: Int -> IO [Text]
+   askNodeNames i = do
+     aName <- askNodeName i
+     if | T.null aName && i == 1 -> do
+            TIO.putStrLn $ "Ok, default names \"" <> showDefaultNodesNames nodesNumber
+                           <> "\" will be used."
+            return $ defaultNodesNames nodesNumber
+        | i == nodesNumber -> do
+            TIO.putStrLn $ "Ok, the last node has name \"" <> aName <> "\""
+            return $ aName : []
+        | otherwise -> do
+            TIO.putStrLn $ "Ok, node " <> show i <> " has name \"" <> aName
+                           <> "\", input the next one:"
+            names <- askNodeNames (i + 1)
+            return $ aName : names
+
+   askNodeName :: Int -> IO Text
+   askNodeName i = do
+    aName <- TIO.getLine
+    if | T.null aName && i == 1 ->
+           return ""
+       | T.null aName && i /= 1 -> do
+           TIO.putStrLn "Node's name cannot be empty, please input again: "
+           askNodeName i
+       | T.any (== ' ') aName -> do
+           TIO.putStrLn "Node's name cannot contain spaces, please input again:  "
+           askNodeName i
+       | otherwise -> return aName
+
+askAboutWebPort :: IO Int
+askAboutWebPort = do
+  portRaw <- TIO.getLine
+  port <-
+    if T.null portRaw
+      then return defaultRTVPort
+      else case readMaybe (T.unpack portRaw) of
+             Just (n :: Int) -> return n
+             Nothing -> do
+               TIO.putStrLn "It's not a number, please input the number instead: "
+               askAboutWebPort
+  if port < minimumPort || port > maximumPort
+    then do
+      TIO.putStrLn $ "Please choose the port between " <> show minimumPort <> " and "
+                   <> show maximumPort <> ": "
+      askAboutWebPort
+    else do
+      TIO.putStrLn $ "Ok, the service will be listening on http://127.0.0.1:" <> show port
+      return port
+
+data ConnectionWay
+  = Pipe
+  | Socket
+
+askAboutPipesAndSockets :: IO ConnectionWay
+askAboutPipesAndSockets = do
+  decisionRaw <- TIO.getLine
+  case decisionRaw of
+    "P" -> return Pipe
+    "p" -> return Pipe
+    ""  -> return Pipe
+    "S" -> return Socket
+    "s" -> return Socket
+    _   -> return Pipe
+
+askAboutLocationForPipes :: Int -> IO [RemoteAddr]
+askAboutLocationForPipes nodesNumber = do
+  dir <- T.strip <$> TIO.getLine
+  if T.null dir
+    then do
+      defDir <- defaultPipesDir
+      TIO.putStrLn $ "Ok, default directory \"" <> T.pack defDir <> "\" will be used."
+      createDirectoryIfMissing True defDir
+      return $ map (\defName -> RemotePipe (defDir </> T.unpack defName))
+                   $ defaultNodesNames nodesNumber
+    else do
+      TIO.putStrLn $ "Ok, directory \"" <> dir <> "\" will be used for the pipes."
+      createDirectoryIfMissing True (T.unpack dir)
+      return $ map (\defName -> RemotePipe ((T.unpack dir) </> (T.unpack defName)))
+                   $ defaultNodesNames nodesNumber
+
+askAboutFirstPortForSockets :: Int -> IO [RemoteAddr]
+askAboutFirstPortForSockets nodesNumber = do
+  firstPort <- askAboutFirstPort
+  let portsForAllNodes = [firstPort .. firstPort + nodesNumber - 1]
+  TIO.putStrLn $ "Ok, these ports will be used to accept nodes' metrics: " <> showPorts portsForAllNodes
+  return $ map (\p -> RemoteSocket "127.0.0.1" (show p)) portsForAllNodes
+ where
+  showPorts :: [Int] -> Text
+  showPorts ports = T.intercalate ", " $ map (T.pack . show) ports
+
+askAboutFirstPort :: IO Int
+askAboutFirstPort = do
+  portRaw <- TIO.getLine
+  port <-
+    if T.null portRaw
+      then return defaultFirstPortForSockets
+      else case readMaybe (T.unpack portRaw) of
+             Just (n :: Int) -> return n
+             Nothing -> do
+               TIO.putStrLn "It's not a number, please input the number instead: "
+               askAboutFirstPort
+  if port < minimumPort || port > maximumPort
+    then do
+      TIO.putStrLn $ "Please choose the port between " <> show minimumPort <> " and "
+                   <> show maximumPort <> ": "
+      askAboutFirstPort
+    else
+      return port
+
+askAboutStaticDir :: IO FilePath
+askAboutStaticDir = do
+  dir <- T.strip <$> TIO.getLine
+  if T.null dir
+    then do
+      TIO.putStrLn $ "Ok, default directory will be used."
+      return defaultRTVStatic
+    else do
+      TIO.putStrLn $ "Ok, static content will be taken from directory \"" <> dir <> "\"."
+      return $ T.unpack dir
+
+rmPipesIfNeeded :: [RemoteAddrNamed] -> IO ()
+rmPipesIfNeeded acceptors = do
+  let pipesDirs = map collectPipesDirs acceptors
+  forM_ pipesDirs $ \dir ->
+    when (not . null $ dir) $ do
+      allFiles <- listDirectory dir
+      let allPipes = filter (\file -> defaultNodeNamePrefix `T.isPrefixOf` (T.pack file)) allFiles
+      forM_ allPipes $ \pipe -> removeFile (dir </> pipe)
+ where
+  collectPipesDirs (RemoteAddrNamed _ (RemoteSocket _ _)) = ""
+  collectPipesDirs (RemoteAddrNamed _ (RemotePipe path)) = takeDirectory path
+
+saveConfigurationForNextSessions :: Configuration -> IO ()
+saveConfigurationForNextSessions config = do
+  path <- savedConfigurationFile
+  CM.toRepresentation config >>= encodeFile path
+
+saveRTViewParamsForNextSessions :: RTViewParams -> IO ()
+saveRTViewParamsForNextSessions params = do
+  path <- savedRTViewParamsFile
+  encodeFile path params
+
+-- | RTView service requires at least one |TraceAcceptor|.
+checkIfTraceAcceptorIsDefined
+  :: Configuration
+  -> IO [RemoteAddrNamed]
+checkIfTraceAcceptorIsDefined config =
+  getAcceptAt config >>= \case
+    Just acceptors -> return acceptors
+    Nothing -> Ex.die "No trace acceptors found in the configuration, please add at leas one."
+
+-- | If configuration contains more than one trace acceptor,
+--   check if they are unique, to avoid socket problems.
+makeSureTraceAcceptorsAreUnique
+  :: [RemoteAddrNamed]
+  -> IO ()
+makeSureTraceAcceptorsAreUnique acceptors = do
+  checkIfNodesNamesAreUnique
+  checkIfNetParametersAreUnique
+ where
+  checkIfNodesNamesAreUnique =
+    when (length names /= length (nub names)) $
+      Ex.die "Nodes' names in trace acceptors must be unique!"
+
+  checkIfNetParametersAreUnique =
+    when (length addrs /= length (nubBy compareNetParams addrs)) $
+      Ex.die "Nodes' network parameters in trace acceptors must be unique!"
+
+  compareNetParams (RemoteSocket h1 p1) (RemoteSocket h2 p2) = h1 == h2 && p1 == p2
+  compareNetParams (RemoteSocket _ _)   (RemotePipe _)       = False
+  compareNetParams (RemotePipe _)       (RemoteSocket _ _)   = False
+  compareNetParams (RemotePipe p1)      (RemotePipe p2)      = p1 == p2
+
+  names = [name | RemoteAddrNamed name _ <- acceptors]
+  addrs = [addr | RemoteAddrNamed _ addr <- acceptors]

--- a/cardano-rt-view/src/Cardano/Benchmarking/RTView/Server.hs
+++ b/cardano-rt-view/src/Cardano/Benchmarking/RTView/Server.hs
@@ -31,7 +31,7 @@ launchServer nsMVar params acceptors =
  where
   config = UI.defaultConfig
     { UI.jsStatic = Just $ rtvStatic params
-    , UI.jsPort   = Just $ fromIntegral (rtvPort params)
+    , UI.jsPort   = Just $ rtvPort params
     }
 
 mainPage

--- a/stack.yaml
+++ b/stack.yaml
@@ -177,7 +177,7 @@ extra-deps:
         - Win32-network
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 8f2086aff6b315b41a39b727f860c3477205ed8a
+    commit: 14143b6e39e89ac0cba6ef1509f19e5ee54bd03c
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
Now there are few possible ways how we can prepare RTView configuration:

1. By running an interactive dialog with the user. If `--config` CLI-option isn't provided, the user will answer a few questions and actual configuration will be prepared based on these answers.
2. By providing configuration explicitly. If `--config`, `--static` and `--port` options are provided, these values will be used (an interactive dialog will be skipped).
3. By using the last used configuration. If the user already launched `cardano-rt-view-service` previously, the configuration was stored in the user's local directory (different for each supported platform), and by default, that configuration will be used again.

_PR https://github.com/input-output-hk/cardano-benchmarking/pull/165 should be simplified after this PR is merged!_