### PR TITLE
RTView: bump version to 1.19.1.

### DIFF
--- a/bm-timeline/bm-timeline.cabal
+++ b/bm-timeline/bm-timeline.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                bm-timeline
-version:             0.1.0.0
+version:             1.19.1
 description:         analyses the output of cluster3nodes benchmarking run
 license:             Apache-2.0
 license-files:

--- a/cardano-rt-view/cardano-rt-view.cabal
+++ b/cardano-rt-view/cardano-rt-view.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-rt-view
-version:               1.0.0
+version:               1.19.1
 description:           Real-time view service for cardano node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/cardano-rt-view/test/rt-view-analyzer/rt-view-analyzer.cabal
+++ b/cardano-rt-view/test/rt-view-analyzer/rt-view-analyzer.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                rt-view-analyzer
-version:             0.1.0.0
+version:             1.19.1
 description:         HTML page analyzer for RTView automatic testing
 license:             Apache-2.0
 license-files:

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -1,5 +1,5 @@
 name:                  cardano-tx-generator
-version:               1.7.0
+version:               1.19.1
 description:           The transaction generator for cardano node
 author:                IOHK
 maintainer:            operations@iohk.io

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@ let
       cardano-tx-generator;
     inherit (haskellPackages.cardano-rt-view.components.exes)
       cardano-rt-view-service;
+    inherit (haskellPackages.cardano-rt-view.identifier) version;
 
     # `tests` are the test suites which have been built.
     tests = collectComponents' "tests" haskellPackages;

--- a/nix/darwin-release.nix
+++ b/nix/darwin-release.nix
@@ -7,14 +7,14 @@
 ############################################################################
 
 { pkgs
-, releaseVersion
+, project
 , exes
 , staticDir
 }:
 
 let
   lib = pkgs.lib;
-  name = "cardano-rt-view-service-${releaseVersion}-darwin";
+  name = "cardano-rt-view-service-${project.version}-darwin";
   rtViewServiceExe = lib.head (lib.filter (exe: lib.hasInfix "cardano-rt-view-service" exe.name) exes);
 
 in pkgs.runCommand name {

--- a/nix/linux-release.nix
+++ b/nix/linux-release.nix
@@ -7,7 +7,7 @@
 ############################################################################
 
 { pkgs
-, releaseVersion
+, project
 , exes
 , staticDir
 , resourcesDir
@@ -15,7 +15,7 @@
 
 let
   lib = pkgs.lib;
-  name = "cardano-rt-view-service-${releaseVersion}-linux-x86_64";
+  name = "cardano-rt-view-service-${project.version}-linux-x86_64";
   rtViewServiceExe = lib.head (lib.filter (exe: lib.hasInfix "cardano-rt-view-service" exe.name) exes);
   appimagetool = pkgs.fetchurl {
     url = https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage;

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -7,14 +7,14 @@
 ############################################################################
 
 { pkgs
-, releaseVersion
+, project
 , exes
 , staticDir
 }:
 
 let
   lib = pkgs.lib;
-  name = "cardano-rt-view-service-${releaseVersion}-win64";
+  name = "cardano-rt-view-service-${project.version}-win64";
   rtViewServiceExe = lib.head (lib.filter (exe: lib.hasInfix "cardano-rt-view-service" exe.name) exes);
 
 in pkgs.runCommand name {

--- a/release.nix
+++ b/release.nix
@@ -40,10 +40,6 @@
 # Import pkgs, including IOHK common nix lib
 , pkgs ? import ./nix { inherit sourcesOverride; }
 
-# Release version of cardano-benchmarking, corresponds to GitHub tag, for example
-# https://github.com/input-output-hk/cardano-benchmarking/releases/tag/1.15.0
-, releaseVersion ? "1.0.0"
-
 }:
 
 with (import pkgs.iohkNix.release-lib) {
@@ -95,18 +91,18 @@ let
     musl64 = mapTestOnCross musl64 (packagePlatformsCross (filterProject noMusl64Build));
     "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross (filterProject noCrossBuild));
     cardano-rt-view-service-win64-release = import ./nix/windows-release.nix {
-      inherit pkgs releaseVersion;
+      inherit pkgs project;
       exes = collectJobs jobs.${mingwW64.config}.exes.cardano-rt-view;
       staticDir = ./cardano-rt-view/static;
     };
     cardano-rt-view-service-linux-release = import ./nix/linux-release.nix {
-      inherit pkgs releaseVersion;
+      inherit pkgs project;
       exes = collectJobs jobs.musl64.exes.cardano-rt-view;
       staticDir = ./cardano-rt-view/static;
       resourcesDir = ./cardano-rt-view/resources;
     };
     cardano-rt-view-service-darwin-release = import ./nix/darwin-release.nix {
-      inherit pkgs releaseVersion;
+      inherit pkgs project;
       exes = filter (p: p.system == "x86_64-darwin") (collectJobs jobs.native.exes.cardano-rt-view);
       staticDir = ./cardano-rt-view/static;
     };

--- a/release.nix
+++ b/release.nix
@@ -102,8 +102,7 @@ let
       resourcesDir = ./cardano-rt-view/resources;
     };
     cardano-rt-view-service-darwin-release = import ./nix/darwin-release.nix {
-      inherit releaseVersion;
-      inherit (pkgsFor "x86_64-darwin") pkgs;
+      inherit (pkgsFor "x86_64-darwin") pkgs project;
       exes = filter (p: p.system == "x86_64-darwin") (collectJobs jobs.native.exes.cardano-rt-view);
       staticDir = ./cardano-rt-view/static;
     };

--- a/tx-generator-shelley/tx-generator-shelley.cabal
+++ b/tx-generator-shelley/tx-generator-shelley.cabal
@@ -1,5 +1,5 @@
 name:                  tx-generator-shelley
-version:               0.2.0
+version:               1.19.1
 description:           The transaction generator for shelley
 author:                IOHK
 maintainer:            operations@iohk.io


### PR DESCRIPTION
Now `cardano-rt-view-service` has the same `version` as the `cardano-node` it is compatible with.