### PR TITLE
CAD-1842: RTView Darwin, independent exe.

### DIFF
--- a/nix/darwin-release.nix
+++ b/nix/darwin-release.nix
@@ -19,19 +19,24 @@ let
 
 in pkgs.runCommand name {
     buildInputs = with pkgs.buildPackages; [
+      binutils
+      darwin.cctools
+      nix
       haskellBuildUtils.package
       zip
     ];
   } ''
   mkdir -p $out release
 
-  rewrite-libs release ${rtViewServiceExe}/bin/*
-
   cd release
   mkdir ./static
   cp -R ${staticDir}/* ./static/
 
+  cp ${rtViewServiceExe}/bin/* .
+
   chmod -R +w .
+
+  rewrite-libs ./ ${rtViewServiceExe}/bin/*
 
   dist_file=$out/${name}.zip
   zip -r $dist_file .

--- a/release.nix
+++ b/release.nix
@@ -102,7 +102,8 @@ let
       resourcesDir = ./cardano-rt-view/resources;
     };
     cardano-rt-view-service-darwin-release = import ./nix/darwin-release.nix {
-      inherit (pkgsFor "x86_64-darwin") pkgs project;
+      inherit (pkgsFor "x86_64-darwin") pkgs;
+      inherit project;
       exes = filter (p: p.system == "x86_64-darwin") (collectJobs jobs.native.exes.cardano-rt-view);
       staticDir = ./cardano-rt-view/static;
     };


### PR DESCRIPTION
Making independent executable `cardano-rt-view-service` for Darwin platform. Now all required `dylib`s will be a part of `zip`-archive.