### PR TITLE
CAD-1418: generator update to 1.20

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -89,29 +89,29 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
-  --sha256: 1w5pgsal897g5n5vpfvrvkkgv2bmqzdbs3jzw9xbphf9jhk3jsai
+  tag: f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5
+  --sha256: 0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
-  --sha256: 1w5pgsal897g5n5vpfvrvkkgv2bmqzdbs3jzw9xbphf9jhk3jsai
+  tag: f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5
+  --sha256: 0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr
   subdir: cardano-cli
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
-  --sha256: 1w5pgsal897g5n5vpfvrvkkgv2bmqzdbs3jzw9xbphf9jhk3jsai
+  tag: f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5
+  --sha256: 0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr
   subdir: cardano-config
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
-  --sha256: 1w5pgsal897g5n5vpfvrvkkgv2bmqzdbs3jzw9xbphf9jhk3jsai
+  tag: f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5
+  --sha256: 0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr
   subdir: cardano-node
 
 -- source-repository-package
@@ -172,78 +172,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
-  --sha256: 1asc4pgkspqlrg67jykz7h1i9wqf4ms1q1gxllcr3dpa566zdc5q
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package
@@ -331,85 +331,85 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
-  --sha256: 0pii9myzb5ckf2vagd9b7fsmk78w72z8lw3zyyfzw58dyapy5c70
+  tag: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
+  --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: Win32-network
 
 source-repository-package

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -126,6 +126,7 @@ secureFunds Benchmark{bTxCount=NumberOfTxs (fromIntegral -> ntxs)}
 secureFunds _ m f =
   error $ "secureFunds:  unsupported config: " <> show m <> " / " <> show f
 
+-- https://github.com/input-output-hk/cardano-node/issues/1857
 parseAddress ::
      Era era
   -> Text

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -178,6 +178,7 @@ type ConfigSupportsTxGen mode era =
 
 deriving instance Eq (Address era) => Ord (Address era)
 
+-- https://github.com/input-output-hk/cardano-node/issues/1855 would be the proper solution.
 deriving instance (Generic TxIn)
 deriving instance (Ord TxIn)
 instance ToJSON TxIn

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -109,7 +109,7 @@ import           Network.Mux (WithMuxBearer(..))
 import           Ouroboros.Consensus.Block.Abstract (CodecConfig)
 import qualified Ouroboros.Consensus.Cardano as Consensus
 import           Ouroboros.Consensus.Config
-                   ( SecurityParam(..), TopLevelConfig(..)
+                   ( TopLevelConfig(..)
                    , configBlock, configCodec, configLedger)
 import           Ouroboros.Consensus.Config.SupportsNode
                    (ConfigSupportsNode(..), getNetworkMagic)
@@ -119,6 +119,8 @@ import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
 import           Ouroboros.Consensus.Node.ProtocolInfo
                    (ProtocolInfo (..))
 import           Ouroboros.Consensus.Node.Run (RunNode)
+import           Ouroboros.Consensus.Shelley.Protocol
+                   (StandardCrypto, StandardShelley)
 import           Ouroboros.Network.Driver (TraceSendRecv (..))
 import           Ouroboros.Network.Protocol.TxSubmission.Type (TxSubmission)
 import           Ouroboros.Network.NodeToClient (Handshake, IOManager)
@@ -134,7 +136,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Unary
 -- Shelley-specific imports
 import qualified Ouroboros.Consensus.Cardano.ShelleyHFC as Shelley
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
 
 -- Node API imports
 import           Cardano.Api.Typed
@@ -188,9 +189,9 @@ instance ToJSON TxIx where
 deriving instance Eq (Address era) => (Eq (TxOut era))
 deriving instance Eq (Address era) => (Ord (TxOut era))
 
-type ShelleyBlock    = Shelley.ShelleyBlock    TPraosStandardCrypto
-type ShelleyBlockHFC = Shelley.ShelleyBlockHFC TPraosStandardCrypto
-type CardanoBlock    = Consensus.CardanoBlock  TPraosStandardCrypto
+type ShelleyBlock    = Shelley.ShelleyBlock    StandardShelley
+type ShelleyBlockHFC = Shelley.ShelleyBlockHFC StandardShelley
+type CardanoBlock    = Consensus.CardanoBlock  StandardCrypto
 
 type family BlockOf mode :: Type where
   BlockOf ByronMode      = ByronBlock
@@ -300,7 +301,7 @@ mkMode ptcl@Consensus.ProtocolByron{} EraByron nmagic_opt is_addr_mn iom (Socket
        sock
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
-       (ByronMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
+       (ByronMode (Byron.EpochSlots 21600)))
     nmagic_opt
     is_addr_mn
     iom
@@ -329,7 +330,7 @@ mkMode ptcl@Consensus.ProtocolCardano{} EraByron nmagic_opt is_addr_mn iom (Sock
        sock
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
-       (CardanoMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
+       (CardanoMode (Byron.EpochSlots 21600)))
     nmagic_opt
     is_addr_mn
     iom
@@ -344,7 +345,7 @@ mkMode ptcl@Consensus.ProtocolCardano{} EraShelley nmagic_opt is_addr_mn iom (So
        sock
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
-       (CardanoMode (Byron.EpochSlots 21600) (SecurityParam 2160)))
+       (CardanoMode (Byron.EpochSlots 21600)))
     nmagic_opt
     is_addr_mn
     iom

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -91,6 +91,7 @@ keyAddress m toNetId = case modeEra m of
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress
 
+-- https://github.com/input-output-hk/cardano-node/issues/1856 would be the proper solution.
 genesisKeyPseudoTxIn :: Mode mode era -> SigningKeyOf era -> Address era -> TxIn
 genesisKeyPseudoTxIn m@ModeShelley{} key _ =
   genesisUTxOPseudoTxIn
@@ -108,6 +109,7 @@ genesisKeyPseudoTxIn m@ModeByron{}
 genesisKeyPseudoTxIn m _ _ =
   error $ "genesisKeyPseudoTxIn:  unsupported mode: " <> show m
 
+-- https://github.com/input-output-hk/cardano-node/issues/1861 would be the proper solution.
 modeGenesisFunds :: Mode mode era
                    -> [(Address era, Lovelace)]
 modeGenesisFunds = \case

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -72,12 +72,14 @@ import           Cardano.Benchmarking.GeneratorTx.Era
 import           Cardano.Benchmarking.GeneratorTx.Tx.Byron
 
 
+-- https://github.com/input-output-hk/cardano-node/issues/1858 is the proper solution.
 castTxMode :: Mode mode era -> Tx era -> TxForMode mode
 castTxMode ModeByron{}          tx@ByronTx{}   = TxForByronMode  tx
 castTxMode ModeShelley{}        tx@ShelleyTx{} = TxForShelleyMode tx
 castTxMode ModeCardanoByron{}   tx@ByronTx{}   = TxForCardanoMode $ Left tx
 castTxMode ModeCardanoShelley{} tx@ShelleyTx{} = TxForCardanoMode $ Right tx
 
+-- https://github.com/input-output-hk/cardano-node/issues/1853 would be the long-term solution.
 toGenTx :: Mode mode era -> Tx era -> GenTx (HFCBlockOf mode)
 toGenTx ModeShelley{}        (ShelleyTx tx) = inject $ Shelley.mkShelleyTx tx
 toGenTx ModeByron{}          (ByronTx tx)   = inject $ normalByronTxToGenTx tx
@@ -87,6 +89,7 @@ toGenTx ModeCardanoByron{}   (ByronTx tx)   = GenTxByron   $ normalByronTxToGenT
 shelleyTxId :: GenTxId (BlockOf ShelleyMode) -> TxId
 shelleyTxId (Shelley.ShelleyTxId (ShelleyLedger.TxId i)) = TxId (Crypto.castHash i)
 
+-- https://github.com/input-output-hk/cardano-node/issues/1859 is the proper solution.
 fromGenTxId :: Mode mode era -> GenTxId (HFCBlockOf mode) -> TxId
 fromGenTxId ModeShelley{}
   (HFC.project' (Proxy @(WrapGenTxId ShelleyBlock)) -> x) = shelleyTxId x
@@ -151,6 +154,7 @@ mkTransaction :: forall mode era
   -> Tx era
 mkTransaction p key payloadSize ttl fee txins txouts =
   signTransaction p key $ makeTransaction p
+  -- https://github.com/input-output-hk/cardano-node/issues/1854 would be the long-term solution.
  where
    makeTransaction :: Mode mode era -> TxBody era
    makeTransaction m = case modeEra m of

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -61,7 +61,7 @@ import qualified Ouroboros.Consensus.Byron.Ledger as Byron hiding (TxId)
 
 -- Shelley-specific imports
 import qualified Ouroboros.Consensus.Shelley.Ledger.Mempool as Shelley
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
 import qualified Shelley.Spec.Ledger.Address as Shelley
 import qualified Shelley.Spec.Ledger.Coin as Shelley
 import qualified Shelley.Spec.Ledger.TxData as ShelleyLedger
@@ -110,7 +110,7 @@ fromByronTxOut :: Byron.TxOut -> TxOut Byron
 fromByronTxOut (Byron.TxOut addr coin) =
   TxOut (ByronAddress addr) (Lovelace $ Byron.lovelaceToInteger coin)
 
-fromShelleyAddr :: Shelley.Addr TPraosStandardCrypto -> Address Shelley
+fromShelleyAddr :: Shelley.Addr StandardShelley -> Address Shelley
 fromShelleyAddr (Shelley.Addr nw pc scr) = ShelleyAddress nw pc scr
 fromShelleyAddr _                        = error "fromShelleyAddr:  unhandled Shelley.Addr case"
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54",
-        "sha256": "1w5pgsal897g5n5vpfvrvkkgv2bmqzdbs3jzw9xbphf9jhk3jsai",
+        "rev": "f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5",
+        "sha256": "0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b22d8da9dd38c971ad40d9ad2d1a60cce53995fb",
-        "sha256": "0r6x6gnbb63c70h14l8fmv34cql2kzvsdabgm8bixvinlghpm1w1",
+        "rev": "83109208047b07d5f0c103c87e6685c61c36a9f6",
+        "sha256": "1wfflfhd3jc8j49kgbvw0absvibkwm77wrjjc9ls8xkrcnprn4l7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/b22d8da9dd38c971ad40d9ad2d1a60cce53995fb.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/83109208047b07d5f0c103c87e6685c61c36a9f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -106,7 +106,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: 497afd7dedc5d5b9bdcdb0e3cac6a50bd9f7dd54
+    commit: f8178d8e21a6acf6aecdea17ffbc2e3b5ccd23f5
     subdirs:
       - cardano-api
       - cardano-config
@@ -135,7 +135,7 @@ extra-deps:
     commit: 2547ad1e80aeabca2899951601079408becbc92c
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 74188f62ff743c690bdf287f7fa18eaa2ee354d4
+    commit: 2ae53965017e18b6a02988762e5e80f07e7709ed
     subdirs:
       # small-steps
       - semantics/executable-spec
@@ -157,7 +157,7 @@ extra-deps:
     commit: cde90a2b27f79187ca8310b6549331e59595e7ba
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac
+    commit: 7cda58405b6ee0d335b11e88e5c9989c7a3a6e03
     subdirs:
         - io-sim
         - io-sim-classes

--- a/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
+++ b/tx-generator-shelley/src/Cardano/Benchmarking/TxGenerator/Types.hs
@@ -32,13 +32,13 @@ import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Ouroboros.Consensus.Byron.Ledger.Mempool as Mempool (GenTx)
 import           Ouroboros.Consensus.Ledger.SupportsMempool as Mempool (GenTxId, TxId)
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
+import           Ouroboros.Consensus.Shelley.Protocol (StandardShelley)
 import           Ouroboros.Network.Driver (TraceSendRecv (..))
 import qualified Ouroboros.Network.Protocol.TxSubmission.Type as TS
 
 import           Control.Monad.Class.MonadSTM (TMVar)
 
-type              Block = ShelleyBlock  TPraosStandardCrypto
+type              Block = ShelleyBlock  StandardShelley
 type              Transaction = CC.UTxO.ATxAux ByteString
 
 newtype NumberOfTxs = NumberOfTxs {unNumberOfTxs :: Int}


### PR DESCRIPTION
- bump the dependencies to Release-1.20
- generators: update generators against updated deps
- add comments with links to `cardano-api`-related issues, in context of CAD-1418