### PR TITLE
CAD-1890: supporting changes

### DIFF
--- a/benchmarks/shelley3pools/benchmark.sh
+++ b/benchmarks/shelley3pools/benchmark.sh
@@ -5,7 +5,6 @@ BASEDIR=$(realpath $(dirname "$0"))
 . "${BASEDIR}"/../../scripts/common.sh
 
 prebuild 'cardano-tx-generator' || exit 1
-prebuild 'cardano-rt-view-service' || exit 1
 prebuild 'cardano-node' || exit 1
 prebuild 'cardano-cli' || exit 1
 

--- a/cabal.project
+++ b/cabal.project
@@ -19,9 +19,6 @@ allow-newer: base
 -- always write GHC env files, because they are needed by the doctests.
 write-ghc-environment-files: always
 
-package cardano-node
-  ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
-
 package cardano-api
   ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
 
@@ -29,6 +26,9 @@ package cardano-cli
   ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
 
 package cardano-config
+  ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
+
+package cardano-node
   ghc-options: -Werror -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields
 
 package cryptonite
@@ -85,7 +85,13 @@ package small-steps
 package small-steps-test
   tests: False
 
----------- 8< -----------
+-- ---------------------------------------------------------
+
+
+-- The two following one-liners will restore / cut off the remainder of this file (for nix-shell users):
+-- git checkout HEAD "$(git rev-parse --show-toplevel)"/cabal.project
+-- sed -ni '1,/--- 8< ---/ p' "$(git rev-parse --show-toplevel)"/cabal.project
+-- Please do not put any `source-repository-package` clause above this line.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
@@ -114,19 +120,8 @@ source-repository-package
   --sha256: 0pvhn2kh838284cwxy74mm24g6mgws2vxs3ipdsr1cx2mzpcrsxr
   subdir: cardano-node
 
--- source-repository-package
---   type: git
---   location: https://github.com/input-output-hk/cardano-db-sync
---   tag: e7a94d28c25d11800062b5354436b03c3aefae6e
---   --sha256: 0zghl2gp4ghazry1znsvvyp56f3z42fj675agld91ngpgmk4dj39
---   subdir: cardano-db
 
--- source-repository-package
---   type: git
---   location: https://github.com/input-output-hk/cardano-db-sync
---   tag: e7a94d28c25d11800062b5354436b03c3aefae6e
---   --sha256: 0zghl2gp4ghazry1znsvvyp56f3z42fj675agld91ngpgmk4dj39
---   subdir: cardano-db-sync
+---------- >8 -----------
 
 source-repository-package
   type: git
@@ -412,24 +407,12 @@ source-repository-package
   --sha256: 0zxmp001mixrba1fzjgzcjf6vl6i5d3q837267njyvmkajdrxgx7
   subdir: Win32-network
 
-source-repository-package
-  type: git
-  location: https://github.com/snoyberg/http-client.git
-  tag: 1a75bdfca014723dd5d40760fad854b3f0f37156
-  --sha256: 0537bjhk9bzhvl76haswsv7xkkyzrmv5xfph3fydcd953q08hqdb
-  subdir: http-client
-
 constraints:
-  -- cardano-node's constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
   , brick >= 0.47
   , libsystemd-journal >= 1.4.4
   , systemd >= 2.3.0
-  -- Local extras over cardano-node:
-  , katip >= 0.8.4.0
-  , quiet >= 0.2
-  , vty < 5.27
 
 package comonad
   flags: -test-doctests

--- a/cabal.project
+++ b/cabal.project
@@ -6,12 +6,14 @@ packages:
     cardano-tx-generator
     tx-generator-shelley
     bm-timeline
-    --ext/cardano-node.git/cardano-api
-    --ext/cardano-node.git/cardano-cli
-    --ext/cardano-node.git/cardano-node
-    --ext/cardano-node.git/cardano-config
-    --ext/cardano-db-sync.git/cardano-db
-    --ext/cardano-db-sync.git/cardano-db-sync
+    -- ../ouroboros-network/ouroboros-consensus
+    -- ../ouroboros-network/ouroboros-consensus-byron
+    -- ../ouroboros-network/ouroboros-consensus-cardano
+    -- ../ouroboros-network/ouroboros-consensus-shelley
+    -- ../cardano-node/cardano-api
+    -- ../cardano-node/cardano-cli
+    -- ../cardano-node/cardano-node
+    -- ../cardano-node/cardano-config
 
 allow-newer: base
 

--- a/scripts/cabal-inside-nix-shell.sh
+++ b/scripts/cabal-inside-nix-shell.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cabal_project="$(git rev-parse --show-toplevel)"/cabal.project
+
+set -x
+sed -i 's_^    -- ../_    ../_' "$cabal_project"
+sed -ni '1,/--- 8< ---/ p'      "$cabal_project"

--- a/scripts/sync-to.sh
+++ b/scripts/sync-to.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+this_repo=$(git rev-parse --show-toplevel)
+this_project=$this_repo/cabal.project
+this_sources=$this_repo/nix/sources.json
+
+other_repo=${1:-$(realpath "$this_repo"/../cardano-node)}
+other_project=$other_repo/cabal.project
+other_sources=$other_repo/nix/sources.json
+other_name=$(basename "$other_repo")
+
+dir_nix_hash() {
+        local dir=$1
+        local commit=$2
+        pushd "${dir}" >/dev/null || return
+        nix-prefetch-git "file://$(realpath "${dir}")" "${commit}" 2>/dev/null \
+                | jq '.sha256' | xargs echo
+        popd >/dev/null || return
+}
+
+cabal_project_current_commit() {
+        local project_file=$1
+        local repo_name=$2
+        grep "^[ ]*location: .*/${repo_name}\$" "${project_file}" -A1 \
+                | tail -n-1 | sed 's/^.* tag: //'
+}
+
+cabal_project_current_hash() {
+        local project_file=$1
+        local repo_name=$2
+        grep "^[ ]*location: .*/${repo_name}\$" "${project_file}" -A2 \
+                | tail -n-1 | sed 's/^.* --sha256: //'
+}
+
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+test -r "$other_project" ||
+        fail "Usage:  $(basename "$0") [SYNC-FROM-REPO=../cardano-node]"
+
+other_commit_now=$(git -C "$other_repo" rev-parse HEAD)
+test -n "${other_commit_now}" || \
+        fail "Repository ${other_repo} doesn't have a valid git state."
+
+other_hash_now=$(dir_nix_hash "$other_repo" "${other_commit_now}")
+test -n "${other_hash_now}" || \
+        fail "Failed to 'nix-prefetch-git' on $other_repo"
+
+repo_sources_pin_commit() {
+        local repo=$1 pin=$2
+        jq --arg pin "$pin" '.[$pin].rev' "$repo"/nix/sources.json -r
+}
+
+repo_sources_pin_hash() {
+        local repo=$1 pin=$2
+        jq --arg pin "$pin" '.[$pin].sha256' "$repo"/nix/sources.json -r
+}
+
+update_sources_pin() {
+        local repo=$1 pin=$2 commit=$3 hash=$4 oldcommit oldhash
+
+        oldcommit=$(repo_sources_pin_commit "$repo" "$pin")
+        oldhash=$(repo_sources_pin_hash     "$repo" "$pin")
+        if test "$oldcommit" != "$commit" -o "$oldhash" != "$hash"
+        then sed -i "s/${oldcommit}/${commit}/" "${repo}"/nix/sources.json
+             sed -i "s/${oldhash}/${hash}/"     "${repo}"/nix/sources.json
+             cat <<EOF
+Updated ${repo}/nix/sources.json pin for $pin:
+  ${oldcommit} -> ${commit}
+  ${oldhash} -> ${hash}
+EOF
+        fi
+}
+
+## Ensure non-updateable part at committed/indexed state:
+git checkout-index --force   "$this_project"
+sed -ni '1,/--- >8 ---/  p'  "$this_project"
+
+## Copy over the entire 'source-repository-package' section:
+sed -n  '1,/--- 8< ---/! p' "$other_project" |
+grep -v "Please do not"   >> "$this_project"
+
+## Copy over the index-state
+other_state_line=$(sed -n '/index-state:/  p' "$other_project")
+sed -i '/index-state:/ s/^.*$/'"$other_state_line"/  "$this_project"
+
+## Update the repo itself
+other_commit_old=$(cabal_project_current_commit "$this_project" "$other_name")
+other_hash_old=$(cabal_project_current_hash     "$this_project" "$other_name")
+sed -i "s/${other_commit_old}/${other_commit_now}/" "${this_project}"
+sed -i "s/${other_hash_old}/${other_hash_now}/"     "${this_project}"
+
+cat <<EOF
+Updated $this_project from $other_project:
+  ${other_commit_old} -> ${other_commit_now}
+  ${other_hash_old} -> ${other_hash_now}
+EOF
+
+## Update sources.json
+update_sources_pin "$this_repo" "$other_name" \
+                   "$other_commit_now" "$other_hash_now"
+
+sources_update_list=(
+        haskell.nix
+        iohk-nix
+)
+for pin in ${sources_update_list[*]}
+do update_sources_pin "$this_repo" "$pin" \
+                      $(repo_sources_pin_commit "$other_repo" "$pin") \
+                      $(repo_sources_pin_hash   "$other_repo" "$pin")
+done

--- a/shell.nix
+++ b/shell.nix
@@ -60,7 +60,7 @@ let
     inherit withHoogle;
 
     shellHook = ''
-      echo "Modifying cabal.project to allow Cabal pick up Nix-provided dependencies:"
+      echo "Modifying cabal.project for interactive development"
 
       ./scripts/cabal-inside-nix-shell.sh
     '';

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@
 , sourcesOverride ? {}
 , minimal ? false
 , withHoogle ? (! minimal)
-, withUpstreamDeps ? false
+, withUpstreamDeps ? true
 , pkgs ? import ./nix {
     inherit config sourcesOverride;
   }


### PR DESCRIPTION
Infra improvements for more efficient benchmark development:

- cabal-in-nix-shell:  support Nix-based interactive co-development with `ouroboros-network` and `cardano-node`
- `scripts/sync-to.sh`:  semi-automated syncing of `cabal.project`
- kill the last Nix divergences from the node -- Hydra caching should be perfect now
- update the `Makefile`