### PR TITLE
CAD-2335 Mary support

### DIFF
--- a/benchmarks/shelley3pools/benchmark.sh
+++ b/benchmarks/shelley3pools/benchmark.sh
@@ -12,7 +12,7 @@ prebuild 'cardano-tx-generator' || exit 1
 export CLICMD="run cardano-cli"
 
 TMUX_ENV_PASSTHROUGH=(
-         "export era=shelley; export DBDIR=${DBDIR}; export SOCKETDIR=${SOCKETDIR};"
+         "export era=${era}; export DBDIR=${DBDIR}; export SOCKETDIR=${SOCKETDIR};"
          "export SCRIPTS_LIB_SH_MODE=${SCRIPTS_LIB_SH_MODE};"
          "export __COMMON_SRCROOT=${__COMMON_SRCROOT};"
          "export DEFAULT_DEBUG=${DEFAULT_DEBUG};"

--- a/benchmarks/shelley3pools/benchmark.sh
+++ b/benchmarks/shelley3pools/benchmark.sh
@@ -42,15 +42,10 @@ else sed -i 's/"systemStart": ".*"/"systemStart": "'"$(date \
      ./hash_genesis.sh
 fi
 
-case $era in
-        byron )     protocol='RealPBFT';;
-        shelley )   protocol='TPraos';;
-        cardano-* ) protocol='Cardano';; esac
 
 for cf in ${BASEDIR}/configuration/*.yaml
 do sed -i 's/^ShelleyGenesisHash:.*$/ShelleyGenesisHash: '"$(cat "$GENESISDIR_shelley"/GENHASH)"'/' "$cf"
    sed -i 's/^ByronGenesisHash:.*$/ByronGenesisHash: '"$(cat "$GENESISDIR_byron"/GENHASH)"'/' "$cf"
-   sed -i 's/^Protocol:.*$/Protocol: '"$protocol"'/' "$cf"
 done
 
 # 2 run rt-view

--- a/benchmarks/shelley3pools/configuration/configuration-generator.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-generator.yaml
@@ -1,9 +1,9 @@
 Protocol: Cardano
 
 ByronGenesisFile: genesis-byron/genesis.json
-ByronGenesisHash: bf51bcbb04feda6ec9547028ca04dd313eb48ebe222556c1a7e06e3556a1487b
+ByronGenesisHash: 3fce4c5fbe6e510374ec0e8fea2d52a17850fbc1857f7d70596f41e1f0d29a9d
 ShelleyGenesisFile: genesis-shelley/genesis.json
-ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4849d
+ShelleyGenesisHash: 8917aa30c38529c316ef0a7163a07e5a1645b29ce2e1d20a5caf544002d97df9
 
 RequiresNetworkMagic: RequiresMagic
 NumCoreNodes: 1

--- a/benchmarks/shelley3pools/configuration/configuration-generator.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-generator.yaml
@@ -1,4 +1,4 @@
-Protocol: TPraos
+Protocol: Cardano
 
 ByronGenesisFile: genesis-byron/genesis.json
 ByronGenesisHash: bf51bcbb04feda6ec9547028ca04dd313eb48ebe222556c1a7e06e3556a1487b

--- a/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
@@ -20,7 +20,7 @@ TestShelleyHardForkAtEpoch: 1
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: Cardano
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
@@ -4,15 +4,17 @@
 ##########################################################
 
 ByronGenesisFile: genesis-byron/genesis.json
-ByronGenesisHash: bf51bcbb04feda6ec9547028ca04dd313eb48ebe222556c1a7e06e3556a1487b
+ByronGenesisHash: 3fce4c5fbe6e510374ec0e8fea2d52a17850fbc1857f7d70596f41e1f0d29a9d
 ShelleyGenesisFile: genesis-shelley/genesis.json
-ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4849d
+ShelleyGenesisHash: 8917aa30c38529c316ef0a7163a07e5a1645b29ce2e1d20a5caf544002d97df9
 
 
 
 
 PBftSignatureThreshold: 0.5
 TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-1.yaml
@@ -12,7 +12,7 @@ ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4
 
 
 PBftSignatureThreshold: 0.5
-TestShelleyHardForkAtEpoch: 1
+TestShelleyHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
@@ -20,7 +20,7 @@ TestShelleyHardForkAtEpoch: 1
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: Cardano
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
@@ -4,15 +4,17 @@
 ##########################################################
 
 ByronGenesisFile: genesis-byron/genesis.json
-ByronGenesisHash: bf51bcbb04feda6ec9547028ca04dd313eb48ebe222556c1a7e06e3556a1487b
+ByronGenesisHash: 3fce4c5fbe6e510374ec0e8fea2d52a17850fbc1857f7d70596f41e1f0d29a9d
 ShelleyGenesisFile: genesis-shelley/genesis.json
-ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4849d
+ShelleyGenesisHash: 8917aa30c38529c316ef0a7163a07e5a1645b29ce2e1d20a5caf544002d97df9
 
 
 
 
 PBftSignatureThreshold: 0.5
 TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-2.yaml
@@ -12,7 +12,7 @@ ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4
 
 
 PBftSignatureThreshold: 0.5
-TestShelleyHardForkAtEpoch: 1
+TestShelleyHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
@@ -20,7 +20,7 @@ TestShelleyHardForkAtEpoch: 1
 # The node also supports various test and mock instances.
 # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
 # is what we use on mainnet in Byron era.
-Protocol: TPraos
+Protocol: Cardano
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresMagic

--- a/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
@@ -4,15 +4,17 @@
 ##########################################################
 
 ByronGenesisFile: genesis-byron/genesis.json
-ByronGenesisHash: bf51bcbb04feda6ec9547028ca04dd313eb48ebe222556c1a7e06e3556a1487b
+ByronGenesisHash: 3fce4c5fbe6e510374ec0e8fea2d52a17850fbc1857f7d70596f41e1f0d29a9d
 ShelleyGenesisFile: genesis-shelley/genesis.json
-ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4849d
+ShelleyGenesisHash: 8917aa30c38529c316ef0a7163a07e5a1645b29ce2e1d20a5caf544002d97df9
 
 
 
 
 PBftSignatureThreshold: 0.5
 TestShelleyHardForkAtEpoch: 0
+TestAllegraHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
+++ b/benchmarks/shelley3pools/configuration/configuration-node-3.yaml
@@ -12,7 +12,7 @@ ShelleyGenesisHash: aa176323b677cd5a76d3a7f8afeb3238fa0386d2455ed0cc31b35a85c1a4
 
 
 PBftSignatureThreshold: 0.5
-TestShelleyHardForkAtEpoch: 1
+TestShelleyHardForkAtEpoch: 0
 
 ##### Core protocol parameters #####
 

--- a/benchmarks/shelley3pools/configuration/parameters
+++ b/benchmarks/shelley3pools/configuration/parameters
@@ -27,19 +27,19 @@ STAKEPOOLS="1 2"
 num_pools=$(echo $STAKEPOOLS | wc -w)
 
 # number of pools to run in a bulk pool
-num_bulk_pool_pools=100
+num_bulk_pool_pools=4
 
 # number of non-bulk pools
 num_non_bulk_pools=1
 
 # number of non-bulk pools
-num_delegators_per_pool=5
+num_delegators_per_pool=1
 
 # number of fake UTxO entries
-num_stuffed_utxo=5000
+num_stuffed_utxo=0
 
 # the number of transactions to enter into the chain
-numtx=10000
+numtx=500
 
 # inter-phase cooldown, seconds
 init_cooldown=5
@@ -57,7 +57,7 @@ inputstx=1
 outputstx=1
 
 # the transactions per seconds that the generator tries to achieve
-tps=1
+tps=50
 
 # cli benchmarking commands
 utxo_keys=3

--- a/benchmarks/shelley3pools/prepare_genesis_byron.sh
+++ b/benchmarks/shelley3pools/prepare_genesis_byron.sh
@@ -39,7 +39,6 @@ args=(
       --delegate-share               ${delegate_share}
       --avvm-entry-count             ${avvm_entries}
       --avvm-entry-balance           ${avvm_entry_balance}
-      --real-pbft
       --secret-seed                  ${not_so_secret}
 )
 

--- a/benchmarks/shelley3pools/run-tx-generator.sh
+++ b/benchmarks/shelley3pools/run-tx-generator.sh
@@ -12,7 +12,9 @@ TARGETNODES=`for N in $targetnodes; do echo -n "--target-node (\"127.0.0.1\",$((
 
 localsock=$BASEDIR/logs/sockets/1
 
-era=${1:-shelley}
+
+#export era="allegra"
+export era="mary"
 echo "--( args: $*"
 echo "--( era:  $era"
 
@@ -35,8 +37,22 @@ case $era in
 shelley )
         args+=(
           --genesis-funds-key ${GENESISDIR_shelley}/utxo-keys/utxo1.skey
+          --shelley
         )
         run 'cardano-tx-generator' "${args[@]}";;
+mary )
+        args+=(
+          --genesis-funds-key ${GENESISDIR_shelley}/utxo-keys/utxo1.skey
+          --mary
+        )
+        run 'cardano-tx-generator' "${args[@]}";;
+allegra )
+        args+=(
+          --genesis-funds-key ${GENESISDIR_shelley}/utxo-keys/utxo1.skey
+          --allegra
+        )
+        run 'cardano-tx-generator' "${args[@]}";;
+
 *) echo "ERROR:  unknown era '$era'" >&2;;
 esac
 
@@ -52,4 +68,4 @@ wait_seconds() {
 wait_seconds 30 'for the mempool transactions to settle in blocks'
 # ../../scripts/analyse.sh
 
-./kill-session.sh
+# ./kill-session.sh

--- a/benchmarks/shelley3pools/run-tx-generator.sh
+++ b/benchmarks/shelley3pools/run-tx-generator.sh
@@ -32,32 +32,11 @@ args=(
 echo "starting submission to:  $TARGETNODES"
 
 case $era in
-byron )
-        args+=(
-          --genesis-funds-key ${GENESISDIR_byron}/poor-keys.000.skey
-        )
-        run 'cardano-tx-generator' "${args[@]}";;
 shelley )
         args+=(
           --genesis-funds-key ${GENESISDIR_shelley}/utxo-keys/utxo1.skey
         )
         run 'cardano-tx-generator' "${args[@]}";;
-cardano-shelley )
-        txio="$($BASEDIR/prepare_genesis_expenditure.sh)"
-        if test -z "$txio"
-        then echo "ERROR: couldn't obtain funds for generator">&2; exit 1; fi
-        args+=(
-          --shelley
-          --utxo-funds-key    ${GENESISDIR_shelley}/utxo-keys/utxo1.skey
-          --tx-out            "$(jq .txout <<<$txio --raw-output)"
-          --tx-in             "$(jq .txin  <<<$txio --raw-output)"
-          # --fail-on-submission-errors
-        )
-        set +e
-        echo run 'cardano-tx-generator' "${args[@]}"
-        run 'cardano-tx-generator' "${args[@]}" |
-                grep 'launching Tx\|MsgAcceptVersion\|SubServFed\|Error\|Summary' |
-                tee "$BASEDIR"/logs/generator-summary.log;;
 *) echo "ERROR:  unknown era '$era'" >&2;;
 esac
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-11-15T00:00:00Z
+index-state: 2020-12-11T00:00:00Z
 
 packages:
     cardano-tx-generator
@@ -95,8 +95,8 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 400d18092ce604352cf36fe5f105b0d7c78be074
-  --sha256: 19r4mamm9bxc1hz32qgsrfnrfxwp4pgnb4d28fzai3izznil03vi
+  tag: f97de0bbf51c9bdc7b0eecb830cec8472b786555
+  --sha256: 14iy7483hjqsvvw48ql65y54q8giaphgg531l2fwqg70hypwn75k
   subdir:
     cardano-api
     cardano-api/test
@@ -110,8 +110,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 2574600da11065937c1f07e4b234ecb451016a2e
-  --sha256: 0nq8bpzsr3fd2i59a6s6qb6slpymjh47zv57wlifjfvhh0xlgmpx
+  tag: 6a6ea9695ee898dd7d4fd7a5d2cc639d7d5764f7
+  --sha256: 1hkq5i9fjjr4picx3plq3s09isrmx6jifpqf57c7viqfdrwlhjnj
   subdir:
     binary
     binary/test
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 581767d1329f3f702e332af08355e81a0f85333e
-  --sha256: 198p4v2bi36y6x512w35qycvjm7nds7jf8qh7r84pj1qsy43vf7w
+  tag: a638b9fa854fced8b8165631885268e3814f2d90
+  --sha256: 0jfdiha2xjjvqqi3dy410whzjiyhs3vxyic423ddlpbi1pdr3xdd
   subdir:
     byron/chain/executable-spec
     byron/crypto
@@ -148,8 +148,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 742e8525b96bf4b66fb61a00c8298d75d7931d5e
-  --sha256: 1132r58bjgdcf7yz3n77nlrkanqcmpn5b5km4nw151yar2dgifsv
+  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -163,8 +163,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 563e79f28c6da5c547463391d4c58a81442e48db
-  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
+  tag: a89c38ed5825ba17ca79fddb85651007753d699d
+  --sha256: 0i4p3jbr9pxhklgbky2g7rfqhccvkqzph0ak5x8bb6kwp7c7b8wf
   subdir:
     contra-tracer
     iohk-monitoring
@@ -178,8 +178,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c2bd6814e231bfd48059f306ef486b830e524aa8
-  --sha256: 0sjp5i4szp5nf1dkwang5w8pydjx5p22by8wisihs1410rxgwd7n
+  tag: 7d0f3f2d07c10169fcac33582a09d89423900a64
+  --sha256: 1951wl2c9ml9pj721j7y1h6c721f87c9jh8sy25nzfndzzxyncmw
   subdir:
     io-sim
     io-sim-classes

--- a/cabal.project
+++ b/cabal.project
@@ -95,8 +95,8 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: f97de0bbf51c9bdc7b0eecb830cec8472b786555
-  --sha256: 14iy7483hjqsvvw48ql65y54q8giaphgg531l2fwqg70hypwn75k
+  tag: c997529667d68821e430c82a8cc1165b4ee53308
+  --sha256: 17hzw8gv6nhd6vfhszkh24cd4p420g96cmpwzjlzwpaad5mnvfp2
   subdir:
     cardano-api
     cardano-api/test
@@ -178,8 +178,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7d0f3f2d07c10169fcac33582a09d89423900a64
-  --sha256: 1951wl2c9ml9pj721j7y1h6c721f87c9jh8sy25nzfndzzxyncmw
+  tag: 4fdc309f855792ed30271c30dcd9159232404787
+  --sha256: 1j03pzqw0n10m9af17q37b6l90x2qdajp30xjpv2247rwpgip31i
   subdir:
     io-sim
     io-sim-classes

--- a/cabal.project
+++ b/cabal.project
@@ -95,8 +95,8 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: c997529667d68821e430c82a8cc1165b4ee53308
-  --sha256: 17hzw8gv6nhd6vfhszkh24cd4p420g96cmpwzjlzwpaad5mnvfp2
+  tag: 67eedea16bc9674c9b0dc52c72d330697c6b882a
+  --sha256: 1cfr3njicpcs44w209c95skldd6xl3jwnvpvmhn8vh89m7byicgh
   subdir:
     cardano-api
     cardano-api/test

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -26,7 +26,7 @@ library
                        Cardano.Benchmarking.GeneratorTx.Benchmark
                        Cardano.Benchmarking.GeneratorTx.Error
                        Cardano.Benchmarking.GeneratorTx.Era
-                       Cardano.Benchmarking.GeneratorTx.Callback
+                       Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition
                        Cardano.Benchmarking.GeneratorTx.Genesis
                        Cardano.Benchmarking.GeneratorTx.NodeToNode
                        Cardano.Benchmarking.GeneratorTx.Tx

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -26,6 +26,7 @@ library
                        Cardano.Benchmarking.GeneratorTx.Benchmark
                        Cardano.Benchmarking.GeneratorTx.Error
                        Cardano.Benchmarking.GeneratorTx.Era
+                       Cardano.Benchmarking.GeneratorTx.Callback
                        Cardano.Benchmarking.GeneratorTx.Genesis
                        Cardano.Benchmarking.GeneratorTx.NodeToNode
                        Cardano.Benchmarking.GeneratorTx.Tx

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -1,19 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-missed-specialisations #-}
@@ -32,7 +25,7 @@ module Cardano.Benchmarking.GeneratorTx
   ) where
 
 import           Cardano.Prelude
-import           Prelude (error, id, String)
+import           Prelude (id, String)
 
 import           Control.Monad (fail)
 import           Control.Monad.Trans.Except.Extra (left, newExceptT, right)
@@ -238,9 +231,9 @@ splitFunds
         in
           case mFunds of
             Nothing                 -> reverse $ (splitTx, txIOList) : acc
-            Just (txInIndex, value) ->
+            Just (txInIndex, val) ->
               let !txInChange  = TxIn splitTxId txInIndex
-                  !txOutChange = TxOut srcAddr (mkTxOutValueAdaOnly value)
+                  !txOutChange = TxOut srcAddr (mkTxOutValueAdaOnly val)
               in
                 -- from the change create the next tx with numOutsPerInitTx UTxO entries
                 createSplittingTxs sKey
@@ -261,7 +254,7 @@ splitFunds
 --   So if one Cardano tx contains 10 outputs (with addresses of 10 recipients),
 --   we have 1 Cardano tx and 10 fiscal txs.
 runBenchmark :: forall era .
-    (ConfigSupportsTxGen CardanoMode era, IsShelleyBasedEra era)
+    IsShelleyBasedEra era
   => Tracer IO (TraceBenchTxSubmit TxId)
   -> Tracer IO NodeToNodeSubmissionTrace
   -> NetworkId
@@ -351,7 +344,7 @@ runBenchmark traceSubmit
 -----------------------------------------------------------------------------------------
 txGenerator
   :: forall era
-  .  (ConfigSupportsTxGen CardanoMode era, IsShelleyBasedEra era)
+  .  IsShelleyBasedEra era
   => Tracer IO (TraceBenchTxSubmit TxId)
   -> Benchmark
   -> AddressInEra era
@@ -454,7 +447,7 @@ txGenerator tracer Benchmark
 --
 launchTxPeer
   :: forall era
-  .  (ConfigSupportsTxGen CardanoMode era, IsShelleyBasedEra era)
+  .  IsShelleyBasedEra era
   => Tracer IO (TraceBenchTxSubmit TxId)
   -> Tracer IO NodeToNodeSubmissionTrace
   -> ConnectClient

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/CLI/Parsers.hs
@@ -152,9 +152,9 @@ pTxOut =
 parseAddressInEra :: IsCardanoEra era => Atto.Parser (AddressInEra era)
 parseAddressInEra = do
     addr <- parseAddressAny
-    case anyAddressInEra addr of
-      Nothing        -> fail "invalid address in the target era"
-      Just addrinera -> pure addrinera
+    case anyAddressInEra cardanoEra addr of
+      Nothing -> fail "invalid address in the target era"
+      Just a  -> pure a
 
 parseAddressAny :: Atto.Parser AddressAny
 parseAddressAny = do

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Callback.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Callback.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+module Cardano.Benchmarking.GeneratorTx.Callback
+  (
+    mkCallback
+  ) where
+
+import           Prelude (error)
+import           Cardano.Prelude hiding (TypeError, show)
+
+import qualified Ouroboros.Consensus.Cardano as Consensus
+import           Ouroboros.Consensus.Config
+                   ( configBlock, configCodec)
+import           Ouroboros.Consensus.Config.SupportsNode
+                   (ConfigSupportsNode(..), getNetworkMagic)
+import           Ouroboros.Consensus.Node.ProtocolInfo
+                   (ProtocolInfo (..))
+import           Ouroboros.Network.NodeToClient (IOManager)
+
+import           Cardano.Chain.Slotting
+import           Cardano.Api
+import           Cardano.Api.Typed
+import qualified Cardano.Api.Typed as Api
+
+-- Node imports
+import           Cardano.Node.Types (SocketPath(..))
+import           Cardano.Tracing.OrphanInstances.Byron()
+import           Cardano.Tracing.OrphanInstances.Common()
+import           Cardano.Tracing.OrphanInstances.Consensus()
+import           Cardano.Tracing.OrphanInstances.Network()
+import           Cardano.Tracing.OrphanInstances.Shelley()
+
+import Cardano.Benchmarking.GeneratorTx.Benchmark
+import Cardano.Benchmarking.GeneratorTx.Era
+import Cardano.Benchmarking.GeneratorTx.NodeToNode
+import Cardano.Benchmarking.GeneratorTx
+import Cardano.Benchmarking.GeneratorTx.Genesis (GeneratorFunds)
+
+type Funding era = Benchmark -> GeneratorFunds -> ExceptT TxGenError IO (SigningKey PaymentKey, [(TxIn, TxOut era)])
+type BenchmarkAction era
+      = Benchmark -> (SigningKey PaymentKey, [(TxIn, TxOut era)]) -> ExceptT TxGenError IO ()
+
+type Action era = Benchmark -> GeneratorFunds -> ExceptT TxGenError IO ()
+
+mkCallback
+  :: forall blok ptcl era.
+     (
+       IsShelleyBasedEra era
+     , ConfigSupportsTxGen CardanoMode era
+     )
+  =>  Consensus.Protocol IO blok ptcl
+  -> Maybe NetworkMagic
+  -> Bool
+  -> IOManager
+  -> SocketPath
+  -> BenchTracers IO CardanoBlock
+  -> Proxy era
+  -> Action era
+
+mkCallback ptcl@(Consensus.ProtocolCardano
+             _
+             Consensus.ProtocolParamsShelleyBased{Consensus.shelleyBasedGenesis}
+              _ _ _ _ _ _)
+            nmagic_opt is_addr_mn iom (SocketPath sock) tracers _proxy
+    = action
+  where
+    action benchmark fundOptions
+      =  funding benchmark fundOptions >>= benchmarkAction benchmark
+
+    ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
+    localConnectInfo = LocalNodeConnectInfo
+       sock
+       (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
+       (CardanoMode (EpochSlots 21600))        -- TODO: get this from genesis
+
+    connectClient :: ConnectClient
+    connectClient  = benchmarkConnectTxSubmit
+                       iom
+                       (btConnect_ tracers)
+                       (btSubmission_ tracers)
+                       (configCodec pInfoConfig)
+                       (getNetworkMagic $ configBlock pInfoConfig)
+
+    funding :: Funding era
+    funding = secureFunds
+                (btTxSubmit_ tracers)
+                localConnectInfo
+                networkId
+                shelleyBasedGenesis
+
+    benchmarkAction :: BenchmarkAction era
+    benchmarkAction = runBenchmark (btTxSubmit_ tracers) (btN2N_ tracers) networkId connectClient
+
+    networkId = if is_addr_mn
+      then Mainnet
+      else Testnet $ getNetworkMagic $ configBlock pInfoConfig
+
+mkCallback _ _ _ _ _ _ _ = error "mkCallbacks"

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -20,26 +20,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Benchmarking.GeneratorTx.Era
-  ( BlockOf
-  , ModeOfProtocol
-  , ConfigSupportsTxGen
+  (
+    ConfigSupportsTxGen
   , GenTxOf
   , GenTxIdOf
-  , HFCBlockOf
   , inject
   , project
-  , SomeMode(..)
   , Mode(..)
-  , SomeEra(..)
-  , Era(..)
-  , ReifyEra(..)
-  , ByronBlockHFC
-  , ShelleyBlock
-  , ShelleyBlockHFC
   , CardanoBlock
-
-  , SigningKeyOf
-  , SigningKeyRoleOf
 
   , InitCooldown(..)
   , NumberOfInputsPerTx(..)
@@ -60,23 +48,23 @@ module Cardano.Benchmarking.GeneratorTx.Era
   , SubmissionSummary(..)
 
   , mkMode
-  , modeEra
   , modeGenesis
   , modeCodecConfig
   , modeIOManager
   , modeLocalConnInfo
   , modeNetworkId
   , modeNetworkIdOverridable
-  , modeNetworkMagic
-  , modeNetworkMagicN2N
+  , modeNetworkMagicOverride
   , modeTopLevelConfig
   , modeTracers
   , trBase
   , trTxSubmit
+  , btTxSubmit_
   , trConnect
   , trSubmitMux
   , trLowLevel
   , trN2N
+  , createTracers
 
   , BenchTraceConstraints
   , BenchTracers(..)
@@ -84,6 +72,10 @@ module Cardano.Benchmarking.GeneratorTx.Era
   , TraceBenchTxSubmit(..)
   , TraceLowLevelSubmit(..)
   , createTracers
+
+  , SendRecvConnect
+  , SendRecvTxSubmission
+  , CardanoMode
   ) where
 
 import           Prelude (Show(..), String, error)
@@ -121,17 +113,10 @@ import           Ouroboros.Network.Protocol.TxSubmission.Type (TxSubmission)
 import           Ouroboros.Network.NodeToClient (Handshake, IOManager)
 import qualified Ouroboros.Network.NodeToNode as NtN
 
--- Byron-specific imports
-import qualified Cardano.Chain.Genesis as Byron
-import qualified Cardano.Chain.Slotting as Byron
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
-import           Ouroboros.Consensus.Cardano.ByronHFC
+import           Cardano.Chain.Slotting
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 
--- Shelley-specific imports
-import qualified Ouroboros.Consensus.Cardano.ShelleyHFC as Shelley
-import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import qualified Shelley.Spec.Ledger.API as Shelley
 
 -- Node API imports
@@ -150,25 +135,25 @@ import           Cardano.Tracing.OrphanInstances.Network()
 import           Cardano.Tracing.OrphanInstances.Shelley()
 
 import Cardano.Benchmarking.GeneratorTx.Benchmark
-
+import           Shelley.Spec.Ledger.API (ShelleyGenesis)
 {-------------------------------------------------------------------------------
   Era abstraction
 -------------------------------------------------------------------------------}
 
+
 type ModeSupportsTxGen mode =
-  ( BenchTraceConstraints (BlockOf mode)
-  , Mempool.HasTxId (GenTx (HFCBlockOf mode))
-  , Mempool.LedgerSupportsMempool (HFCBlockOf mode)
+  ( BenchTraceConstraints CardanoBlock
+  , Mempool.HasTxId (GenTx CardanoBlock)
+  , Mempool.LedgerSupportsMempool CardanoBlock
   , Show (TxSubmitResultForMode mode)
-  , Show (TxForMode mode)
-  , RunNode (HFCBlockOf mode))
+  , RunNode CardanoBlock)
 
 type EraSupportsTxGen era =
   ( IsCardanoEra era
   , Eq (Address era)
   , FromJSON (TxOut era)
-  , Key (SigningKeyRoleOf era)
-  , Show (TxOut (ApiEra era))
+  , Key PaymentKey
+  , Show (TxOut era)
   , Show (Tx era))
 
 type ConfigSupportsTxGen mode era =
@@ -176,186 +161,48 @@ type ConfigSupportsTxGen mode era =
 
 -- https://github.com/input-output-hk/cardano-node/issues/1855 would be the proper solution.
 deriving stock instance (Generic TxIn)
-deriving stock instance (Ord TxIn)
 instance ToJSON TxIn
 instance ToJSON TxId where
   toJSON (TxId x) = toJSON x
 instance ToJSON TxIx where
   toJSON (TxIx x) = toJSON x
 
-type ShelleyBlock    = Shelley.ShelleyBlock    StandardShelley
-type ShelleyBlockHFC = Shelley.ShelleyBlockHFC StandardShelley
 type CardanoBlock    = Consensus.CardanoBlock  StandardCrypto
 
-type family BlockOf mode :: Type where
-  BlockOf ByronMode      = ByronBlock
-  BlockOf ShelleyMode    = ShelleyBlock
-  BlockOf CardanoMode    = CardanoBlock
-  BlockOf t = TypeError (Ty.Text "Unsupported mode: "  :<>: ShowType t)
-
-type family HFCBlockOf mode :: Type where
-  HFCBlockOf ByronMode   = ByronBlockHFC
-  HFCBlockOf ShelleyMode = ShelleyBlockHFC
-  HFCBlockOf CardanoMode = CardanoBlock
-  HFCBlockOf t = TypeError (Ty.Text "Unsupported mode: "  :<>: ShowType t)
-
-type family SigningKeyRoleOf era :: Type where
-  SigningKeyRoleOf ByronEra   = ByronKey
-  SigningKeyRoleOf ShelleyEra = PaymentKey
-  SigningKeyRoleOf t = TypeError (Ty.Text "Unsupported era: "  :<>: ShowType t)
-
-type SigningKeyOf era = SigningKey (SigningKeyRoleOf era)
-
-type family ApiEra era where
-  ApiEra ByronEra   = ByronEra
-  ApiEra ShelleyEra = ShelleyEra
-
-class ReifyEra era where
-  reifyEra :: Era era
-
-instance ReifyEra ByronEra where
-  reifyEra = EraByron
-instance ReifyEra ShelleyEra where
-  reifyEra = EraShelley
-
-type GenTxOf   mode = GenTx   (HFCBlockOf mode)
-type GenTxIdOf mode = GenTxId (HFCBlockOf mode)
-
-type family ModeOfProtocol p :: Type where
-  ModeOfProtocol Consensus.ProtocolByron   = ByronMode
-  ModeOfProtocol Consensus.ProtocolShelley = ShelleyMode
-  ModeOfProtocol Consensus.ProtocolCardano = CardanoMode
-  ModeOfProtocol t = TypeError (Ty.Text "Unsupported protocol: "  :<>: ShowType t)
-
-data SomeMode =
-  forall mode era. ConfigSupportsTxGen mode era =>
-  SomeMode (Mode mode era)
+type GenTxOf   mode = GenTx   CardanoBlock
+type GenTxIdOf mode = GenTxId CardanoBlock
 
 -- | System-level submission context (not parameters)
 --   TODO:  rename the type to SubContext or something similar.
-data Mode mode era where
-  ModeByron
-    :: TopLevelConfig (HFCBlockOf ByronMode)
-    -> GenesisOf ByronEra
-    -> CodecConfig (HFCBlockOf ByronMode)
-    -> LocalNodeConnectInfo ByronMode (HFCBlockOf ByronMode)
-    -> Maybe NetworkMagic
-    -> Bool
-    -> IOManager
-    -> BenchTracers IO (HFCBlockOf ByronMode)
-    -> Mode ByronMode ByronEra
-  ModeShelley
-    :: TopLevelConfig (HFCBlockOf ShelleyMode)
-    -> GenesisOf ShelleyEra
-    -> CodecConfig (HFCBlockOf ShelleyMode)
-    -> LocalNodeConnectInfo ShelleyMode (HFCBlockOf ShelleyMode)
-    -> Maybe NetworkMagic
-    -> Bool
-    -> IOManager
-    -> BenchTracers IO (HFCBlockOf ShelleyMode)
-    -> Mode ShelleyMode ShelleyEra
-  ModeCardanoByron
-    :: TopLevelConfig (HFCBlockOf CardanoMode)
-    -> GenesisOf ByronEra
-    -> CodecConfig (HFCBlockOf CardanoMode)
-    -> LocalNodeConnectInfo CardanoMode (HFCBlockOf CardanoMode)
-    -> Maybe NetworkMagic
-    -> Bool
-    -> IOManager
-    -> BenchTracers IO (HFCBlockOf CardanoMode)
-    -> Mode CardanoMode ByronEra
+data Mode where
   ModeCardanoShelley
-    :: TopLevelConfig (HFCBlockOf CardanoMode)
-    -> GenesisOf ShelleyEra
-    -> CodecConfig (HFCBlockOf CardanoMode)
-    -> LocalNodeConnectInfo CardanoMode (HFCBlockOf CardanoMode)
+    :: TopLevelConfig CardanoBlock
+    -> Shelley.ShelleyGenesis StandardShelley
+    -> CodecConfig CardanoBlock
+    -> LocalNodeConnectInfo CardanoMode CardanoBlock
     -> Maybe NetworkMagic
     -> Bool
     -> IOManager
-    -> BenchTracers IO (HFCBlockOf CardanoMode)
-    -> Mode CardanoMode ShelleyEra
+    -> BenchTracers IO CardanoBlock
+    -> Mode
 
-instance Show (Mode mode era) where
-  show ModeByron{}          = "ModeByron"
-  show ModeShelley{}        = "ModeShelley"
-  show ModeCardanoByron{}   = "ModeCardanoByron"
+instance Show Mode where
   show ModeCardanoShelley{} = "ModeCardanoShelley"
 
-data SomeEra = forall era. EraSupportsTxGen era => SomeEra (Era era)
-
-data Era era where
-  EraByron   :: Era ByronEra
-  EraShelley :: Era ShelleyEra
-
-instance Show (Era era) where
-  show EraByron   = "EraByron"
-  show EraShelley = "EraShelley"
-
 mkMode
-  :: forall blok era ptcl
-  . ()
-  => Consensus.Protocol IO blok ptcl
-  -> Era era
+  :: forall blok ptcl.
+     Consensus.Protocol IO blok ptcl
   -> Maybe NetworkMagic
   -> Bool
   -> IOManager
   -> SocketPath
-  -> LoggingLayer
-  -> Mode (ModeOfProtocol ptcl) era
-mkMode ptcl@(Consensus.ProtocolByron
-             Consensus.ProtocolParamsByron{Consensus.byronGenesis}) EraByron nmagic_opt is_addr_mn iom (SocketPath sock) ll =
-  ModeByron
-    pInfoConfig
-    byronGenesis
-    (configCodec pInfoConfig)
-    (LocalNodeConnectInfo
-       sock
-       (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
-       -- TODO: get this from genesis
-       (ByronMode (Byron.EpochSlots 21600)))
-    nmagic_opt
-    is_addr_mn
-    iom
-    (createTracers ll)
- where
-   ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode ptcl@(Consensus.ProtocolShelley
-             Consensus.ProtocolParamsShelleyBased{Consensus.shelleyBasedGenesis} _) EraShelley nmagic_opt is_addr_mn iom (SocketPath sock) ll =
-  ModeShelley
-    pInfoConfig
-    shelleyBasedGenesis
-    (configCodec pInfoConfig)
-    (LocalNodeConnectInfo
-       sock
-       (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
-       ShelleyMode)
-    nmagic_opt
-    is_addr_mn
-    iom
-    (createTracers ll)
- where
-   ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode ptcl@(Consensus.ProtocolCardano
-             Consensus.ProtocolParamsByron{Consensus.byronGenesis} _ _ _ _ _ _ _) EraByron nmagic_opt is_addr_mn iom (SocketPath sock) ll =
-  ModeCardanoByron
-    pInfoConfig
-    byronGenesis
-    (configCodec pInfoConfig)
-    (LocalNodeConnectInfo
-       sock
-       (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
-       -- TODO: get this from genesis
-       (CardanoMode (Byron.EpochSlots 21600)))
-    nmagic_opt
-    is_addr_mn
-    iom
-    (createTracers ll)
- where
-   ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
+  -> BenchTracers IO CardanoBlock
+  -> Mode
 mkMode ptcl@(Consensus.ProtocolCardano
              _
              Consensus.ProtocolParamsShelleyBased{Consensus.shelleyBasedGenesis}
-             _ _ _ _ _ _) EraShelley nmagic_opt is_addr_mn iom (SocketPath sock) ll =
+             _ _ _ _ _ _)
+            nmagic_opt is_addr_mn iom (SocketPath sock) tracers =
   ModeCardanoShelley
     pInfoConfig
     shelleyBasedGenesis
@@ -364,14 +211,14 @@ mkMode ptcl@(Consensus.ProtocolCardano
        sock
        (Api.Testnet . getNetworkMagic . configBlock $ pInfoConfig)
        -- TODO: get this from genesis
-       (CardanoMode (Byron.EpochSlots 21600)))
+       (CardanoMode (EpochSlots 21600)))
     nmagic_opt
     is_addr_mn
     iom
-    (createTracers ll)
+    tracers
  where
    ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
-mkMode p e _ _ _ _ _ = error $ "mkMode:  unhandled protocol/era: " <> show p <> " / " <> show e
+mkMode p _ _ _ _ _ = error $ "mkMode:  unhandled protocol/era: " <> show p
 
 instance Show (Consensus.Protocol m blk p) where
   show Consensus.ProtocolByron{}   = "ProtocolByron"
@@ -380,92 +227,48 @@ instance Show (Consensus.Protocol m blk p) where
   show Consensus.ProtocolMary{} = "ProtocolMary"
   -- show Consensus.ProtocolLeaderSchedule{} = "ProtocolLeaderSchedule"
 
-modeEra :: Mode mode era -> Era era
-modeEra = \case
-  ModeByron{}          -> EraByron
-  ModeShelley{}        -> EraShelley
-  ModeCardanoByron{}   -> EraByron
-  ModeCardanoShelley{} -> EraShelley
 
-modeTopLevelConfig :: Mode mode era -> TopLevelConfig (HFCBlockOf mode)
-modeTopLevelConfig (ModeByron          x _ _ _ _ _ _ _) = x
-modeTopLevelConfig (ModeShelley        x _ _ _ _ _ _ _) = x
-modeTopLevelConfig (ModeCardanoByron   x _ _ _ _ _ _ _) = x
+modeTopLevelConfig :: Mode -> TopLevelConfig CardanoBlock
 modeTopLevelConfig (ModeCardanoShelley x _ _ _ _ _ _ _) = x
 
-modeGenesis :: Mode mode era -> GenesisOf era
-modeGenesis = \case
-  ModeByron          _ g _ _ _ _ _ _ -> g
-  ModeShelley        _ g _ _ _ _ _ _ -> g
-  ModeCardanoByron   _ g _ _ _ _ _ _ -> g
-  ModeCardanoShelley _ g _ _ _ _ _ _ -> g
+modeGenesis :: Mode -> ShelleyGenesis StandardShelley
+modeGenesis (ModeCardanoShelley          _ g _ _ _ _ _ _) = g
 
-modeCodecConfig :: Mode mode era -> CodecConfig (HFCBlockOf mode)
-modeCodecConfig    (ModeByron          _ _ x _ _ _ _ _) = x
-modeCodecConfig    (ModeShelley        _ _ x _ _ _ _ _) = x
-modeCodecConfig    (ModeCardanoByron   _ _ x _ _ _ _ _) = x
+modeCodecConfig :: Mode -> CodecConfig CardanoBlock
 modeCodecConfig    (ModeCardanoShelley _ _ x _ _ _ _ _) = x
 
-modeLocalConnInfo :: Mode mode era -> LocalNodeConnectInfo mode (HFCBlockOf mode)
-modeLocalConnInfo  (ModeByron          _ _ _ x _ _ _ _) = x
-modeLocalConnInfo  (ModeShelley        _ _ _ x _ _ _ _) = x
-modeLocalConnInfo  (ModeCardanoByron   _ _ _ x _ _ _ _) = x
+modeLocalConnInfo :: Mode -> LocalNodeConnectInfo CardanoMode CardanoBlock
 modeLocalConnInfo  (ModeCardanoShelley _ _ _ x _ _ _ _) = x
 
-modeNetworkMagicOverride :: Mode mode era -> Maybe NetworkMagic
-modeNetworkMagicOverride (ModeByron          _ _ _ _ x _ _ _) = x
-modeNetworkMagicOverride (ModeShelley        _ _ _ _ x _ _ _) = x
-modeNetworkMagicOverride (ModeCardanoByron   _ _ _ _ x _ _ _) = x
+modeNetworkMagicOverride :: Mode -> Maybe NetworkMagic
 modeNetworkMagicOverride (ModeCardanoShelley _ _ _ _ x _ _ _) = x
 
-modeAddressMainnetOverride :: Mode mode era -> Bool
-modeAddressMainnetOverride (ModeByron          _ _ _ _ _ x _ _) = x
-modeAddressMainnetOverride (ModeShelley        _ _ _ _ _ x _ _) = x
-modeAddressMainnetOverride (ModeCardanoByron   _ _ _ _ _ x _ _) = x
+modeAddressMainnetOverride :: Mode -> Bool
 modeAddressMainnetOverride (ModeCardanoShelley _ _ _ _ _ x _ _) = x
 
-modeIOManager :: Mode mode era -> IOManager
-modeIOManager      (ModeByron          _ _ _ _ _ _ x _) = x
-modeIOManager      (ModeShelley        _ _ _ _ _ _ x _) = x
-modeIOManager      (ModeCardanoByron   _ _ _ _ _ _ x _) = x
+modeIOManager :: Mode -> IOManager
 modeIOManager      (ModeCardanoShelley _ _ _ _ _ _ x _) = x
 
-modeTracers :: Mode mode era -> BenchTracers IO (HFCBlockOf mode)
-modeTracers        (ModeByron          _ _ _ _ _ _ _ x) = x
-modeTracers        (ModeShelley        _ _ _ _ _ _ _ x) = x
-modeTracers        (ModeCardanoByron   _ _ _ _ _ _ _ x) = x
+modeTracers :: Mode -> BenchTracers IO CardanoBlock
 modeTracers        (ModeCardanoShelley _ _ _ _ _ _ _ x) = x
 
-modeNetworkId :: Mode mode era -> NetworkId
+modeNetworkId :: Mode -> NetworkId
 modeNetworkId (modeAddressMainnetOverride -> True) = Mainnet
-modeNetworkId m@ModeByron{}   = Testnet . getNetworkMagic . configBlock $ modeTopLevelConfig m
-modeNetworkId m@ModeShelley{} = Testnet . getNetworkMagic . configBlock $ modeTopLevelConfig m
-modeNetworkId m@ModeCardanoByron{}   = Testnet . getNetworkMagic . configBlock $ modeTopLevelConfig m
 modeNetworkId m@ModeCardanoShelley{} = Testnet . getNetworkMagic . configBlock $ modeTopLevelConfig m
 
-modeNetworkIdOverridable :: Mode mode era -> NetworkId
+modeNetworkIdOverridable :: Mode -> NetworkId
 modeNetworkIdOverridable (modeAddressMainnetOverride -> True) = Mainnet
 modeNetworkIdOverridable m = modeNetworkId m
 
-modeNetworkMagic :: Mode mode era -> NetworkMagic
-modeNetworkMagic m@ModeByron{}          = getNetworkMagic . configBlock $ modeTopLevelConfig m
-modeNetworkMagic m@ModeShelley{}        = getNetworkMagic . configBlock $ modeTopLevelConfig m
-modeNetworkMagic m@ModeCardanoByron{}   = getNetworkMagic . configBlock $ modeTopLevelConfig m
-modeNetworkMagic m@ModeCardanoShelley{} = getNetworkMagic . configBlock $ modeTopLevelConfig m
+--type family GenesisOf era where
+--  GenesisOf ShelleyEra = Shelley.ShelleyGenesis StandardShelley
 
-modeNetworkMagicN2N :: Mode mode era -> NetworkMagic
-modeNetworkMagicN2N m = fromMaybe (modeNetworkMagic m) (modeNetworkMagicOverride m)
-
-type family GenesisOf era where
-  GenesisOf ByronEra   = Byron.Config
-  GenesisOf ShelleyEra = Shelley.ShelleyGenesis StandardShelley
-
-trBase       :: Mode mode era -> Trace IO Text
-trTxSubmit   :: Mode mode era -> Tracer IO (TraceBenchTxSubmit TxId)
-trConnect    :: Mode mode era -> Tracer IO SendRecvConnect
-trSubmitMux  :: Mode mode era -> Tracer IO (SendRecvTxSubmission (HFCBlockOf mode))
-trLowLevel   :: Mode mode era -> Tracer IO TraceLowLevelSubmit
-trN2N        :: Mode mode era -> Tracer IO NodeToNodeSubmissionTrace
+trBase       :: Mode -> Trace IO Text
+trTxSubmit   :: Mode -> Tracer IO (TraceBenchTxSubmit TxId)
+trConnect    :: Mode -> Tracer IO SendRecvConnect
+trSubmitMux  :: Mode -> Tracer IO (SendRecvTxSubmission CardanoBlock)
+trLowLevel   :: Mode -> Tracer IO TraceLowLevelSubmit
+trN2N        :: Mode -> Tracer IO NodeToNodeSubmissionTrace
 trBase       = btBase_       . modeTracers
 trTxSubmit   = btTxSubmit_   . modeTracers
 trConnect    = btConnect_    . modeTracers

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -1,19 +1,13 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -24,8 +18,6 @@ module Cardano.Benchmarking.GeneratorTx.Era
     ConfigSupportsTxGen
   , GenTxOf
   , GenTxIdOf
-  , inject
-  , project
   , CardanoBlock
 
   , InitCooldown(..)
@@ -46,10 +38,6 @@ module Cardano.Benchmarking.GeneratorTx.Era
 
   , SubmissionSummary(..)
 
-
-  , btTxSubmit_
-  , createTracers
-
   , BenchTraceConstraints
   , BenchTracers(..)
   , NodeToNodeSubmissionTrace(..)
@@ -62,7 +50,7 @@ module Cardano.Benchmarking.GeneratorTx.Era
   , CardanoMode
   ) where
 
-import           Prelude (Show(..), String, error)
+import           Prelude (Show(..), String)
 import           Cardano.Prelude hiding (TypeError, show)
 
 import qualified Codec.CBOR.Term as CBOR
@@ -72,45 +60,28 @@ import qualified Data.Aeson as A
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import           Data.Time.Clock (DiffTime, getCurrentTime)
-import           GHC.TypeLits
-import qualified GHC.TypeLits as Ty
 
 -- Mode-agnostic imports
 import           Cardano.BM.Data.Tracer
                    (emptyObject, mkObject, trStructured)
 import           Network.Mux (WithMuxBearer(..))
 import qualified Ouroboros.Consensus.Cardano as Consensus
-import           Ouroboros.Consensus.Config
-                   ( TopLevelConfig(..)
-                   , configBlock, configCodec)
-import           Ouroboros.Consensus.Config.SupportsNode
-                   (ConfigSupportsNode(..), getNetworkMagic)
 import           Ouroboros.Consensus.Ledger.SupportsMempool hiding (TxId)
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
-import           Ouroboros.Consensus.Node.ProtocolInfo
-                   (ProtocolInfo (..))
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Consensus.Shelley.Protocol
                    (StandardCrypto)
 import           Ouroboros.Network.Driver (TraceSendRecv (..))
 import           Ouroboros.Network.Protocol.TxSubmission.Type (TxSubmission)
-import           Ouroboros.Network.NodeToClient (Handshake, IOManager)
+import           Ouroboros.Network.NodeToClient (Handshake)
 import qualified Ouroboros.Network.NodeToNode as NtN
-
-import           Cardano.Chain.Slotting
-import           Ouroboros.Consensus.HardFork.Combinator.Basics
-import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
-
-import qualified Shelley.Spec.Ledger.API as Shelley
 
 -- Node API imports
 import           Cardano.Api
 import           Cardano.Api.TxSubmit
 import           Cardano.Api.Typed
-import qualified Cardano.Api.Typed as Api
 
 -- Node imports
-import           Cardano.Node.Types (SocketPath(..))
 import           Cardano.Node.Configuration.Logging (LOContent(..), LoggingLayer (..))
 import           Cardano.Tracing.OrphanInstances.Byron()
 import           Cardano.Tracing.OrphanInstances.Common()
@@ -119,7 +90,6 @@ import           Cardano.Tracing.OrphanInstances.Network()
 import           Cardano.Tracing.OrphanInstances.Shelley()
 
 import Cardano.Benchmarking.GeneratorTx.Benchmark
-import           Shelley.Spec.Ledger.API (ShelleyGenesis)
 {-------------------------------------------------------------------------------
   Era abstraction
 -------------------------------------------------------------------------------}

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -135,7 +135,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import qualified Shelley.Spec.Ledger.API as Shelley
 
 -- Node API imports
-import           Cardano.API
+import           Cardano.Api
 import           Cardano.Api.TxSubmit
 import           Cardano.Api.Typed
 import qualified Cardano.Api.Typed as Api

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -1,42 +1,30 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns #-}
 module Cardano.Benchmarking.GeneratorTx.Genesis
   ( GeneratorFunds(..)
   , parseGeneratorFunds
-  , extractGenesisFunds
+  , genesisFundForKey
   , genesisExpenditure
   , keyAddress
   )
 where
 
-import           Cardano.Prelude hiding (TypeError)
-import           Prelude (error)
-
-import           Control.Arrow ((***))
+import           Cardano.Prelude hiding (TypeError, filter)
+import           Prelude (error, filter)
 import qualified Data.Map.Strict as Map
+
 import qualified Options.Applicative as Opt
 
--- Era-agnostic imports
+import           Control.Arrow ((***))
 import           Cardano.Api.Typed
+import           Cardano.Api.Shelley (fromShelleyLovelace, fromShelleyStakeReference, fromShelleyPaymentCredential)
 import           Cardano.CLI.Types
-                   (SigningKeyFile(..))
-import qualified Ouroboros.Consensus.Cardano as Consensus
 
--- Byron-specific imports
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Chain.UTxO as Byron
-
--- Local imports
-import           Cardano.Benchmarking.GeneratorTx.Era
 import           Cardano.Benchmarking.GeneratorTx.Tx
-import           Cardano.Benchmarking.GeneratorTx.Tx.Byron
 import           Cardano.Benchmarking.GeneratorTx.CLI.Parsers
 
+import           Shelley.Spec.Ledger.API (ShelleyGenesis, sgInitialFunds)
 
 data GeneratorFunds
   = FundsGenesis   SigningKeyFile
@@ -66,105 +54,59 @@ parseGeneratorFunds =
         "split-utxo"
         "UTxO funds file.")
 
-keyAddress :: Mode mode era -> (Mode mode era -> NetworkId) -> SigningKeyOf era -> AddressInEra era
-keyAddress m toNetId = case modeEra m of
-  EraByron{}   -> \(getVerificationKey -> ByronVerificationKey k) ->
-    AddressInEra ByronAddressInAnyEra $
-      ByronAddress
-        (Byron.makeVerKeyAddress (toByronNetworkMagic $ toNetId m) k)
-  EraShelley{} -> \k ->
-    makeShelleyAddressInEra
-      (toNetId m)
+keyAddress :: forall era. IsShelleyBasedEra era => NetworkId -> SigningKey PaymentKey -> AddressInEra era
+keyAddress networkId k
+  = makeShelleyAddressInEra
+      networkId
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress
 
--- https://github.com/input-output-hk/cardano-node/issues/1856 would be the proper solution.
-genesisKeyPseudoTxIn :: Mode mode era -> SigningKeyOf era -> AddressInEra era -> TxIn
-genesisKeyPseudoTxIn m@ModeShelley{} key _ =
-  genesisUTxOPseudoTxIn
-    (modeNetworkId m)
-    (verificationKeyHash $ getVerificationKey $ castSigningKeyRolePaymentKeyGenesisUTxOKey key)
- where
-   castSigningKeyRolePaymentKeyGenesisUTxOKey ::
-     SigningKey PaymentKey -> SigningKey GenesisUTxOKey
-   castSigningKeyRolePaymentKeyGenesisUTxOKey (PaymentSigningKey skey) =
-     GenesisUTxOSigningKey skey
-genesisKeyPseudoTxIn m@ModeCardanoShelley{} key _ =
-  genesisUTxOPseudoTxIn
-    (modeNetworkId m)
-    (verificationKeyHash $ getVerificationKey $ castSigningKeyRolePaymentKeyGenesisUTxOKey key)
- where
-   castSigningKeyRolePaymentKeyGenesisUTxOKey ::
-     SigningKey PaymentKey -> SigningKey GenesisUTxOKey
-   castSigningKeyRolePaymentKeyGenesisUTxOKey (PaymentSigningKey skey) =
-     GenesisUTxOSigningKey skey
-genesisKeyPseudoTxIn m@ModeByron{}
-                     (getVerificationKey -> ByronVerificationKey key)
-                     (AddressInEra _ (ByronAddress genAddr)) =
-  fromByronTxIn $ byronGenesisUTxOTxIn (modeGenesis m) key genAddr
-genesisKeyPseudoTxIn m _ _ =
-  error $ "genesisKeyPseudoTxIn:  unsupported mode: " <> show m
 
--- https://github.com/input-output-hk/cardano-node/issues/1861 would be the proper solution.
-modeGenesisFunds :: forall mode era. Mode mode era -> [(AddressInEra era, Lovelace)]
-modeGenesisFunds = \case
-  m@ModeShelley{} ->
-    fmap (fromShelleyAddr m *** fromShelleyLovelace)
-    . Map.toList
-    . Consensus.sgInitialFunds
-    $ modeGenesis m
-  m@ModeByron{} ->
-    fmap getAddrCoin
-    . map (fromByronTxOut . Byron.fromCompactTxOut . snd)
-    . Map.toList
-    . Byron.unUTxO
-    . Byron.genesisUtxo
-    $ modeGenesis m
-  m@ModeCardanoShelley{} ->
-    fmap (fromShelleyAddr m *** fromShelleyLovelace)
-    . Map.toList
-    . Consensus.sgInitialFunds
-    $ modeGenesis m
-  m -> error $ "modeGenesisFunds:  unsupported mode: " <> show m
+genesisFunds :: forall era. IsShelleyBasedEra era
+  => NetworkId -> ShelleyGenesis StandardShelley -> [(AddressInEra era, Lovelace)]
+genesisFunds networkId g =
+    map (castAddr *** fromShelleyLovelace)
+     $ Map.toList
+     $ sgInitialFunds g
   where
-    getAddrCoin :: TxOut ByronEra -> (AddressInEra ByronEra, Lovelace)
-    getAddrCoin (TxOut addr (TxOutAdaOnly AdaOnlyInByronEra coin)) = (addr, coin)
-    getAddrCoin (TxOut _ (TxOutValue x _) ) = case x of {}
+    castAddr (Addr _ pcr stref)
+      = shelleyAddressInEra $ makeShelleyAddress networkId (fromShelleyPaymentCredential pcr) (fromShelleyStakeReference stref)
+    castAddr _ = error "castAddr:  unhandled Shelley.Addr case"
 
-extractGenesisFunds
-  :: forall mode era .
-     Mode mode era
-  -> SigningKeyOf era
-  -> (TxIn, TxOut era)
-extractGenesisFunds m k =
+
+genesisFundForKey :: forall era. IsShelleyBasedEra era
+  => NetworkId
+  -> ShelleyGenesis StandardShelley
+  -> SigningKey PaymentKey
+  -> (AddressInEra era, Lovelace)
+genesisFundForKey networkId genesis key =
     fromMaybe (error "No genesis funds for signing key.")
   . head
-  . filter (isTxOutForKey . snd)
-  . fmap genesisFundsEntryTxIO
-  . modeGenesisFunds
-  $ m
- where
-  genesisFundsEntryTxIO :: (AddressInEra era, Lovelace) -> (TxIn, TxOut era)
-  genesisFundsEntryTxIO (addr, coin) =
-    (genesisKeyPseudoTxIn m k addr, TxOut addr (mkTxOutValueAdaOnly (modeEra m) coin))
+  . filter (isTxOutForKey . fst)
+  $ genesisFunds networkId genesis
+  where
+    isTxOutForKey addr = keyAddress networkId key == addr
 
-  isTxOutForKey :: TxOut era -> Bool
-  isTxOutForKey (TxOut addr _) = keyAddress m modeNetworkId k == addr
 
-genesisExpenditure
-  :: Mode mode era
-  -> SigningKeyOf era
+genesisExpenditure ::
+     IsShelleyBasedEra era
+  => NetworkId
+  -> SigningKey PaymentKey
   -> AddressInEra era
   -> Lovelace
   -> Lovelace
   -> SlotNo
   -> (Tx era, TxIn, TxOut era)
-genesisExpenditure m key addr (Lovelace coin) (Lovelace fee) ttl =
-  (,,) tx txin txout
+genesisExpenditure networkId key addr coin fee ttl =  (tx, fundOut, txout )
  where
-   tx = mkTransaction m key 0 ttl (Lovelace fee)
-          [genesisKeyPseudoTxIn m key (keyAddress m modeNetworkId key)]
-          [txout]
-   txin = TxIn (getTxId $ getTxBody tx) (TxIx 0)
-   txout = TxOut addr (mkTxOutValueAdaOnly (modeEra m) (Lovelace (coin - fee)))
+   tx = mkGenTransaction (castKey key) 0 ttl fee [ pseudoTxIn ] [ txout ]
 
+   txout = TxOut addr $ mkTxOutValueAdaOnly $ coin - fee
+
+   pseudoTxIn = genesisUTxOPseudoTxIn networkId
+                  (verificationKeyHash $ getVerificationKey $ castKey key)
+
+   castKey :: SigningKey PaymentKey -> SigningKey GenesisUTxOKey
+   castKey(PaymentSigningKey skey) = GenesisUTxOSigningKey skey
+
+   fundOut = TxIn (getTxId $ getTxBody tx) (TxIx 0)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Genesis.hs
@@ -89,6 +89,15 @@ genesisKeyPseudoTxIn m@ModeShelley{} key _ =
      SigningKey PaymentKey -> SigningKey GenesisUTxOKey
    castSigningKeyRolePaymentKeyGenesisUTxOKey (PaymentSigningKey skey) =
      GenesisUTxOSigningKey skey
+genesisKeyPseudoTxIn m@ModeCardanoShelley{} key _ =
+  genesisUTxOPseudoTxIn
+    (modeNetworkId m)
+    (verificationKeyHash $ getVerificationKey $ castSigningKeyRolePaymentKeyGenesisUTxOKey key)
+ where
+   castSigningKeyRolePaymentKeyGenesisUTxOKey ::
+     SigningKey PaymentKey -> SigningKey GenesisUTxOKey
+   castSigningKeyRolePaymentKeyGenesisUTxOKey (PaymentSigningKey skey) =
+     GenesisUTxOSigningKey skey
 genesisKeyPseudoTxIn m@ModeByron{}
                      (getVerificationKey -> ByronVerificationKey key)
                      (AddressInEra _ (ByronAddress genAddr)) =
@@ -110,6 +119,11 @@ modeGenesisFunds = \case
     . Map.toList
     . Byron.unUTxO
     . Byron.genesisUtxo
+    $ modeGenesis m
+  m@ModeCardanoShelley{} ->
+    fmap (fromShelleyAddr m *** fromShelleyLovelace)
+    . Map.toList
+    . Consensus.sgInitialFunds
     $ modeGenesis m
   m -> error $ "modeGenesisFunds:  unsupported mode: " <> show m
   where

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -1,11 +1,4 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -25,14 +18,11 @@ import           Control.Monad.Class.MonadTimer (MonadTimer, threadDelay)
 import           Control.Monad.Class.MonadSTM.Strict (newTVar)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Map as Map
-import           Data.Maybe
 import           Data.Proxy (Proxy (..))
 import           Network.Socket (AddrInfo (..))
 import           System.Random (newStdGen)
 
 import           Control.Tracer (Tracer, nullTracer)
-import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Byron.Ledger.Mempool (GenTx)
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/NodeToNode.hs
@@ -107,7 +107,7 @@ benchmarkConnectTxSubmitC ioManager handshakeTracer submissionTracer codecConfig
     (addrAddress remoteAddr)
  where
   n2nVer :: NodeToNodeVersion
-  n2nVer = NodeToNodeV_3
+  n2nVer = NodeToNodeV_5
   blkN2nVer :: BlockNodeToNodeVersion blk
   blkN2nVer = supportedVers Map.! n2nVer
   supportedVers :: Map.Map NodeToNodeVersion (BlockNodeToNodeVersion blk)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -64,7 +64,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Mempool (mkShelleyTx)
 import qualified Ouroboros.Consensus.Shelley.Ledger.Mempool as Mempool (TxId(ShelleyTxId))
 
 import           Ouroboros.Consensus.Cardano.Block (GenTx (GenTxShelley, GenTxMary, GenTxAllegra))
-import qualified Ouroboros.Consensus.Cardano.Block (TxId(GenTxIdShelley))
+import qualified Ouroboros.Consensus.Cardano.Block as Block (TxId(GenTxIdShelley, GenTxIdAllegra, GenTxIdMary))
 
 import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle (..),
                                                                  ClientStTxIds (..),
@@ -363,7 +363,9 @@ txSubmissionClient tr bmtr sub threadIx =
      (ShelleyBasedEraMary, ShelleyTx _ tx') -> GenTxMary (mkShelleyTx tx')
 
    fromGenTxId :: gentxid -> txid
-   fromGenTxId (Ouroboros.Consensus.Cardano.Block.GenTxIdShelley (Mempool.ShelleyTxId (ShelleyLedger.TxId i))) = TxId $ Crypto.castHash i
+   fromGenTxId (Block.GenTxIdShelley (Mempool.ShelleyTxId (ShelleyLedger.TxId i))) = TxId $ Crypto.castHash i
+   fromGenTxId (Block.GenTxIdAllegra (Mempool.ShelleyTxId (ShelleyLedger.TxId i))) = TxId $ Crypto.castHash i
+   fromGenTxId (Block.GenTxIdMary    (Mempool.ShelleyTxId (ShelleyLedger.TxId i))) = TxId $ Crypto.castHash i
    fromGenTxId _ = error "submission.hs: fromGenTxId"
 
    tokIsBlocking :: TokBlockingStyle a -> Bool

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -15,8 +15,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
@@ -34,6 +34,7 @@ module Cardano.Benchmarking.GeneratorTx.Submission
   , tpsLimitedTxFeeder
   ) where
 
+import           Prelude (error)
 import           Cardano.Prelude hiding (ByteString, atomically, retry, threadDelay)
 import           Prelude (String, fail)
 
@@ -57,8 +58,13 @@ import           Cardano.Tracing.OrphanInstances.Consensus ()
 import           Cardano.Tracing.OrphanInstances.Network ()
 import           Cardano.Tracing.OrphanInstances.Shelley ()
 
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txInBlockSize)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx, GenTxId, txInBlockSize)
 import qualified Ouroboros.Consensus.Ledger.SupportsMempool as Mempool
+import           Ouroboros.Consensus.Shelley.Ledger.Mempool (mkShelleyTx)
+import qualified Ouroboros.Consensus.Shelley.Ledger.Mempool as Mempool (TxId(ShelleyTxId))
+
+import           Ouroboros.Consensus.Cardano.Block (GenTx (GenTxShelley, GenTxMary, GenTxAllegra))
+import qualified Ouroboros.Consensus.Cardano.Block (TxId(GenTxIdShelley))
 
 import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle (..),
                                                                  ClientStTxIds (..),
@@ -67,12 +73,13 @@ import           Ouroboros.Network.Protocol.TxSubmission.Client (ClientStIdle (.
 import           Ouroboros.Network.Protocol.TxSubmission.Type (BlockingReplyList (..),
                                                                TokBlockingStyle (..), TxSizeInBytes)
 
+import qualified Shelley.Spec.Ledger.TxBody as ShelleyLedger
+
 import           Cardano.Api.Typed
+import qualified Cardano.Crypto.Hash.Class as Crypto
 
 import           Cardano.Benchmarking.GeneratorTx.Era
 import           Cardano.Benchmarking.GeneratorTx.Benchmark
-import           Cardano.Benchmarking.GeneratorTx.Tx
-
 
 {-------------------------------------------------------------------------------
   Parametrisation & state
@@ -227,26 +234,22 @@ consumeTxs Submission{sTxSendQueue} blk req
        Just Nothing -> pure (True, UnReqd [])
        Just (Just tx) -> pure (False, UnReqd [tx])
 
-{-------------------------------------------------------------------------------
-  The submission client
--------------------------------------------------------------------------------}
 txSubmissionClient
-  :: forall m mode era tx txid gentx gentxid .
+  :: forall m era tx txid gentx gentxid .
      ( MonadIO m, MonadFail m
-     , ConfigSupportsTxGen mode era
+     , IsShelleyBasedEra era
      , tx      ~ Tx era
      , txid    ~ TxId
-     , gentx   ~ GenTxOf mode
-     , gentxid ~ GenTxIdOf mode
+     , gentx   ~ GenTx CardanoBlock
+     , gentxid ~ GenTxId CardanoBlock
      )
-  => Mode mode era
-  -> Tracer m NodeToNodeSubmissionTrace
+  => Tracer m NodeToNodeSubmissionTrace
   -> Tracer m (TraceBenchTxSubmit txid)
   -> Submission m era
   -> Natural
   -- This return type is forced by Ouroboros.Network.NodeToNode.connectTo
   -> TxSubmissionClient gentxid gentx m ()
-txSubmissionClient m tr bmtr sub threadIx =
+txSubmissionClient tr bmtr sub threadIx =
   TxSubmissionClient $
     pure $ client False (UnAcked []) (SubmissionThreadStats 0 0 0)
  where
@@ -269,8 +272,10 @@ txSubmissionClient m tr bmtr sub threadIx =
           -- The () return type is forced by Ouroboros.Network.NodeToNode.connectTo
           -> ClientStIdle gentxid gentx m ()
    client done unAcked (!stats) = ClientStIdle
-    { recvMsgRequestTxIds = \blocking (protoToAck -> ack) (protoToReq -> req)
+    { recvMsgRequestTxIds = \blocking ackNum reqNum
        -> do
+        let ack = Ack $ fromIntegral ackNum
+            req = Req $ fromIntegral reqNum
         traceWith tr $ reqIdsTrace ack req blocking
 
         (exhausted, unReqd) <-
@@ -315,19 +320,21 @@ txSubmissionClient m tr bmtr sub threadIx =
                      (NonBlockingReply $ txToIdSize <$> annNow)
                      (client exhausted newUnacked newStats)
 
-    , recvMsgRequestTxs = \(fmap (fromGenTxId m) -> reqTxids) -> do
-        traceWith tr $ ReqTxs (length reqTxids)
+    , recvMsgRequestTxs = \txIds -> do
+        let  reqTxIds :: [txid]
+             reqTxIds = fmap fromGenTxId txIds
+        traceWith tr $ ReqTxs (length reqTxIds)
         let UnAcked ua = unAcked
             uaIds = getTxId . getTxBody <$> ua
-            (toSend, _retained) = L.partition ((`L.elem` reqTxids) . getTxId . getTxBody) ua
-            missIds = reqTxids L.\\ uaIds
+            (toSend, _retained) = L.partition ((`L.elem` reqTxIds) . getTxId . getTxBody) ua
+            missIds = reqTxIds L.\\ uaIds
 
         traceWith tr $ TxList (length toSend)
-        traceWith bmtr $ TraceBenchTxSubServReq reqTxids
+        traceWith bmtr $ TraceBenchTxSubServReq reqTxIds
         traceWith bmtr $ TraceBenchTxSubServOuts (getTxId . getTxBody <$> ua)
         unless (L.null missIds) $
           traceWith bmtr $ TraceBenchTxSubServUnav missIds
-        pure $ SendMsgReplyTxs (toGenTx m <$> toSend)
+        pure $ SendMsgReplyTxs (toGenTx <$> toSend)
           (client done unAcked $
             stats { stsSent =
                     stsSent stats + Sent (length toSend)
@@ -347,13 +354,17 @@ txSubmissionClient m tr bmtr sub threadIx =
      pure report
 
    txToIdSize :: tx -> (gentxid, TxSizeInBytes)
-   txToIdSize = (Mempool.txId &&& txInBlockSize) . toGenTx m
+   txToIdSize = (Mempool.txId &&& txInBlockSize) . toGenTx
 
-   protoToAck :: Word16 -> Ack
-   protoToAck = Ack . fromIntegral
+   toGenTx :: tx -> gentx
+   toGenTx tx = case (shelleyBasedEra @ era , tx) of
+     (ShelleyBasedEraShelley, ShelleyTx _ tx') -> GenTxShelley (mkShelleyTx tx')
+     (ShelleyBasedEraAllegra, ShelleyTx _ tx') -> GenTxAllegra (mkShelleyTx tx')
+     (ShelleyBasedEraMary, ShelleyTx _ tx') -> GenTxMary (mkShelleyTx tx')
 
-   protoToReq :: Word16 -> Req
-   protoToReq = Req . fromIntegral
+   fromGenTxId :: gentxid -> txid
+   fromGenTxId (Ouroboros.Consensus.Cardano.Block.GenTxIdShelley (Mempool.ShelleyTxId (ShelleyLedger.TxId i))) = TxId $ Crypto.castHash i
+   fromGenTxId _ = error "submission.hs: fromGenTxId"
 
    tokIsBlocking :: TokBlockingStyle a -> Bool
    tokIsBlocking = \case
@@ -366,6 +377,6 @@ txSubmissionClient m tr bmtr sub threadIx =
       TokNonBlocking -> ReqIdsPrompt   ack req
 
    idListTrace :: ToAnnce tx -> TokBlockingStyle a -> NodeToNodeSubmissionTrace
-   idListTrace (ToAnnce (length -> toAnn)) = \case
-      TokBlocking    -> IdsListBlocking toAnn
-      TokNonBlocking -> IdsListPrompt   toAnn
+   idListTrace (ToAnnce toAnn) = \case
+      TokBlocking    -> IdsListBlocking $ length toAnn
+      TokNonBlocking -> IdsListPrompt   $ length toAnn

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -178,4 +178,3 @@ txOutValueToLovelace = \case
   TxOutValue _ v -> case valueToLovelace v of
     Just c -> c
     Nothing -> error "txOutValueLovelace  TxOut contains no ADA"
-  _ -> error "txOutValueLovelace unsupported case"

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -55,7 +55,7 @@ import qualified Shelley.Spec.Ledger.Address as Shelley
 import qualified Shelley.Spec.Ledger.API as Shelley
 import qualified Shelley.Spec.Ledger.TxBody as ShelleyLedger
 
-import           Cardano.API
+import           Cardano.Api
 import           Cardano.Api.Shelley hiding (fromShelleyAddr)
 import           Cardano.Api.TxSubmit
 import           Cardano.Api.Typed
@@ -124,7 +124,7 @@ fromByronTxOut (Byron.TxOut addr coin) =
   TxOut (AddressInEra ByronAddressInAnyEra $ ByronAddress addr)
         (TxOutAdaOnly AdaOnlyInByronEra . Lovelace $ Byron.lovelaceToInteger coin)
 
-fromShelleyAddr :: Mode mode ShelleyEra -> Shelley.Addr StandardShelley -> AddressInEra ShelleyEra
+fromShelleyAddr :: Mode mode ShelleyEra -> Shelley.Addr StandardCrypto -> AddressInEra ShelleyEra
 fromShelleyAddr m (Shelley.Addr _ pcr sref) =
   makeShelleyAddressInEra (modeNetworkId m) (fromShelleyPaymentCredential pcr) (fromShelleyStakeReference sref)
 fromShelleyAddr _ _ = error "fromShelleyAddr:  unhandled Shelley.Addr case"

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -7,247 +7,108 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Benchmarking.GeneratorTx.Tx
-  ( castTxMode
-  , fromByronTxId
-  , fromByronTxIn
-  , fromByronTxOut
-  , fromShelleyAddr
-  , fromShelleyLovelace
-  , fromGenTxId
-  , mkTransaction
+  (
+    mkGenTransaction -- ? needed ??
   , mkTransactionGen
   , mkTxOutValueAdaOnly
-  , txOutValueLovelace
-  , signTransaction
-  , toGenTx
+  , txOutValueToLovelace
   )
 where
 
-import           Cardano.Prelude hiding (TypeError)
-import           Prelude (error)
-import qualified Prelude
+import           Prelude
 
-import qualified Data.ByteString as SB
-import qualified Data.ByteString.Lazy as LB
 import qualified Data.List.NonEmpty as NonEmpty
+import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
+import           Data.Map.Strict (Map)
+import           Data.Maybe
 
--- Era-agnostic imports
-import           Cardano.Binary (Annotated (..), reAnnotate)
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Ouroboros.Consensus.HardFork.Combinator.Embed.Unary as HFC
-import           Ouroboros.Consensus.Ledger.SupportsMempool hiding (TxId)
-import           Ouroboros.Consensus.TypeFamilyWrappers
-
--- Cardano-specific imports
-import           Ouroboros.Consensus.Cardano.Block hiding (TxId, ShelleyEra)
-
--- Byron-specific imports
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Chain.UTxO as Byron
-import qualified Cardano.Crypto.Hashing as Byron
-import qualified Ouroboros.Consensus.Byron.Ledger as Byron hiding (TxId)
-
--- Shelley-specific imports
-import qualified Ouroboros.Consensus.Shelley.Ledger.Mempool as Shelley
-import qualified Shelley.Spec.Ledger.Address as Shelley
-import qualified Shelley.Spec.Ledger.API as Shelley
-import qualified Shelley.Spec.Ledger.TxBody as ShelleyLedger
+import           Cardano.Benchmarking.GeneratorTx.Era
 
 import           Cardano.Api
-import           Cardano.Api.Shelley hiding (fromShelleyAddr)
-import           Cardano.Api.TxSubmit
-import           Cardano.Api.Typed
-import           Cardano.Benchmarking.GeneratorTx.Era
-import           Cardano.Benchmarking.GeneratorTx.Tx.Byron
 
-
--- https://github.com/input-output-hk/cardano-node/issues/1858 is the proper solution.
-castTxMode :: Mode mode era -> Tx era -> TxForMode mode
-castTxMode ModeByron{}          tx@ByronTx{}   = TxForByronMode  tx
-castTxMode ModeShelley{}        tx@ShelleyTx{} = TxForShelleyMode tx
-castTxMode ModeCardanoByron{}   tx@ByronTx{}   = TxForCardanoMode $ InAnyCardanoEra ByronEra tx
-castTxMode ModeCardanoShelley{} tx@ShelleyTx{} = TxForCardanoMode $ InAnyCardanoEra ShelleyEra tx
-castTxMode _ _ = error "castTxMode unsupported case"
-
--- https://github.com/input-output-hk/cardano-node/issues/1853 would be the long-term solution.
-toGenTx :: Mode mode era -> Tx era -> GenTx (HFCBlockOf mode)
-toGenTx ModeShelley{}        (ShelleyTx _ tx) = inject $ Shelley.mkShelleyTx tx
-toGenTx ModeByron{}          (ByronTx tx)   = inject $ normalByronTxToGenTx tx
-toGenTx ModeCardanoShelley{} (ShelleyTx _ tx) = GenTxShelley $ Shelley.mkShelleyTx tx
-toGenTx ModeCardanoByron{}   (ByronTx tx)   = GenTxByron   $ normalByronTxToGenTx tx
-toGenTx _ _ = error "toGenTx unsupported case"
-
-shelleyTxId :: GenTxId (BlockOf ShelleyMode) -> TxId
-shelleyTxId (Shelley.ShelleyTxId (ShelleyLedger.TxId i)) = TxId (Crypto.castHash i)
-
-txOutAddress :: TxOut era -> AddressInEra era
-txOutAddress = \case
-  TxOut a@(AddressInEra ByronAddressInAnyEra{} _) _ -> a
-  TxOut a@(AddressInEra ShelleyAddressInEra{}  _) _ -> a
-
-mkTxOutValueAdaOnly :: Era era -> Lovelace -> TxOutValue era
-mkTxOutValueAdaOnly = \case
-  EraByron{}   -> TxOutAdaOnly AdaOnlyInByronEra
-  EraShelley{} -> TxOutAdaOnly AdaOnlyInShelleyEra
-
-txOutValueLovelace :: TxOutValue era -> Lovelace
-txOutValueLovelace = \case
-  TxOutAdaOnly AdaOnlyInByronEra   x -> x
-  TxOutAdaOnly AdaOnlyInShelleyEra x -> x
-  TxOutAdaOnly AdaOnlyInAllegraEra x -> x
-  _ -> error "txOutValueLovelace unsupported case"
- 
--- https://github.com/input-output-hk/cardano-node/issues/1859 is the proper solution.
-fromGenTxId :: Mode mode era -> GenTxId (HFCBlockOf mode) -> TxId
-fromGenTxId ModeShelley{}
-  (HFC.project' (Proxy @(WrapGenTxId ShelleyBlock)) -> x) = shelleyTxId x
-fromGenTxId ModeByron{}
-  (HFC.project' (Proxy @(WrapGenTxId Byron.ByronBlock)) -> (Byron.ByronTxId i)) = fromByronTxId i
-fromGenTxId ModeCardanoShelley{} (GenTxIdShelley x)  = shelleyTxId x
-fromGenTxId ModeCardanoByron{}   (GenTxIdByron   (Byron.ByronTxId i))                           = fromByronTxId i
-fromGenTxId _ _ =
-  error "fromGenTxId:  unsupported protocol"
-
-fromByronTxId :: Byron.TxId -> TxId
-fromByronTxId =
-  maybe (error "Failed to convert Byron txid.") TxId
-  . Crypto.hashFromBytes . Byron.hashToBytes
-
-fromByronTxIn :: Byron.TxIn -> TxIn
-fromByronTxIn (Byron.TxInUtxo txid txix) =
-  TxIn (fromByronTxId txid) (TxIx $ fromIntegral txix)
-
-fromByronTxOut :: Byron.TxOut -> TxOut ByronEra
-fromByronTxOut (Byron.TxOut addr coin) =
-  TxOut (AddressInEra ByronAddressInAnyEra $ ByronAddress addr)
-        (TxOutAdaOnly AdaOnlyInByronEra . Lovelace $ Byron.lovelaceToInteger coin)
-
-fromShelleyAddr :: Mode mode ShelleyEra -> Shelley.Addr StandardCrypto -> AddressInEra ShelleyEra
-fromShelleyAddr m (Shelley.Addr _ pcr sref) =
-  makeShelleyAddressInEra (modeNetworkId m) (fromShelleyPaymentCredential pcr) (fromShelleyStakeReference sref)
-fromShelleyAddr _ _ = error "fromShelleyAddr:  unhandled Shelley.Addr case"
-
-toByronTxId :: TxId -> Byron.TxId
-toByronTxId (TxId h) =
-  Byron.unsafeHashFromBytes (Crypto.hashToBytes h)
-
-toByronTxIn  :: TxIn -> Byron.TxIn
-toByronTxIn (TxIn txid (TxIx txix)) =
-  Byron.TxInUtxo (toByronTxId txid) (fromIntegral txix)
-
-toByronTxOut :: TxOut ByronEra -> Maybe Byron.TxOut
-toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress addr)) (TxOutAdaOnly AdaOnlyInByronEra value)) =
-  Byron.TxOut addr <$> toByronLovelace value
-toByronTxOut (TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _addr)) (TxOutValue e _ )) = case e of {}
-toByronTxOut (TxOut (AddressInEra (ShelleyAddressInEra e) _ ) _) = case e of {}
-
-toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
-toByronLovelace (Lovelace x) =
-  case Byron.integerToLovelace x of
-    Left  _  -> Nothing
-    Right x' -> Just x'
-
-signTransaction :: Mode mode era -> SigningKeyOf era -> TxBody era -> Tx era
-signTransaction p k body = case modeEra p of
-  EraByron   -> signByronTransaction (modeNetworkId p) body [k]
-  EraShelley -> signShelleyTransaction body [WitnessPaymentKey k]
-
-
-mkTransaction :: forall mode era
-  .  Mode mode era
-  -> SigningKeyOf era
+mkGenTransaction :: forall era .
+     IsShelleyBasedEra era
+  => SigningKey GenesisUTxOKey
   -> TxAdditionalSize
   -> SlotNo
   -> Lovelace
   -> [TxIn]
   -> [TxOut era]
   -> Tx era
-mkTransaction p key payloadSize ttl fee txins txouts =
-  signTransaction p key $ makeTransaction p
-  -- https://github.com/input-output-hk/cardano-node/issues/1854 would be the long-term solution.
- where
-   makeTransaction :: Mode mode era -> TxBody era
-   makeTransaction m = case modeEra m of
-     EraShelley -> case makeShelleyTransaction txins txouts ttl fee [] [] metaData Nothing of
-                      Right tx -> tx
-                      Left err -> error $ show err
-                   where metaData = if payloadSize == 0 then Nothing else Just $ payloadShelley payloadSize
-     EraByron ->
-       either (error . T.unpack) Prelude.id $
-         mkByronTransaction txins txouts
+mkGenTransaction key _payloadSize ttl fee txins txouts
+  = case makeTransactionBody txBodyContent of
+    Right b -> signShelleyTransaction b [WitnessGenesisUTxOKey key]
+    Left err -> error $ show err
+  where
+    txBodyContent = TxBodyContent {
+        txIns = txins
+      , txOuts = txouts
+      , txFee = fees
+      , txValidityRange = (TxValidityNoLowerBound, validityUpperBound)
+      , txMetadata = TxMetadataNone
+      , txAuxScripts = TxAuxScriptsNone
+      , txWithdrawals = TxWithdrawalsNone
+      , txCertificates = TxCertificatesNone
+      , txUpdateProposal = TxUpdateProposalNone
+      , txMintValue = TxMintNone
+      }
+    fees = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> TxFeeExplicit TxFeesExplicitInShelleyEra fee
+      ShelleyBasedEraAllegra -> TxFeeExplicit TxFeesExplicitInAllegraEra fee
+      ShelleyBasedEraMary    -> TxFeeExplicit TxFeesExplicitInMaryEra fee
 
-   payloadShelley :: TxAdditionalSize -> TxMetadata
-   payloadShelley = makeTransactionMetadata . Map.singleton 0 . TxMetaBytes . flip SB.replicate 42 . unTxAdditionalSize
+    validityUpperBound = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> TxValidityUpperBound ValidityUpperBoundInShelleyEra ttl
+      ShelleyBasedEraAllegra -> TxValidityUpperBound ValidityUpperBoundInAllegraEra ttl
+      ShelleyBasedEraMary    -> TxValidityUpperBound ValidityUpperBoundInMaryEra ttl
 
-   mkByronTransaction :: [TxIn]
-                        -> [TxOut ByronEra]
-                        -> Either Text (TxBody ByronEra)
-   mkByronTransaction ins outs = do
-     ins'  <- NonEmpty.nonEmpty ins        ?! error "makeByronTransaction: empty txIns"
-     let ins'' = NonEmpty.map toByronTxIn ins'
+mkTransaction :: forall era .
+     IsShelleyBasedEra era
+  => SigningKey PaymentKey
+  -> TxAdditionalSize
+  -> SlotNo
+  -> Lovelace
+  -> [TxIn]
+  -> [TxOut era]
+  -> Tx era
+mkTransaction key _payloadSize ttl fee txins txouts
+  = case makeTransactionBody txBodyContent of
+    Right b -> signShelleyTransaction b [WitnessPaymentKey key]
+    Left err -> error $ show err
+  where
+    txBodyContent = TxBodyContent {
+        txIns = txins
+      , txOuts = txouts
+      , txFee = fees
+      , txValidityRange = (TxValidityNoLowerBound, validityUpperBound)
+      , txMetadata = TxMetadataNone
+      , txAuxScripts = TxAuxScriptsNone
+      , txWithdrawals = TxWithdrawalsNone
+      , txCertificates = TxCertificatesNone
+      , txUpdateProposal = TxUpdateProposalNone
+      , txMintValue = TxMintNone
+      }
+    fees = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> TxFeeExplicit TxFeesExplicitInShelleyEra fee
+      ShelleyBasedEraAllegra -> TxFeeExplicit TxFeesExplicitInAllegraEra fee
+      ShelleyBasedEraMary    -> TxFeeExplicit TxFeesExplicitInMaryEra fee
 
-     outs'  <- NonEmpty.nonEmpty outs      ?! error "makeByronTransaction: empty txOuts"
-     outs'' <- traverse
-                 (\out -> toByronTxOut out ?! error "makeByronTransaction: ByronTxBodyLovelaceOverflow")
-                 outs'
-     return $
-       ByronTxBody $
-         reAnnotate $
-           Annotated
-             (Byron.UnsafeTx ins'' outs'' (createTxAttributes payloadSize))
-             ()
-    where
-     (?!) :: Maybe a -> e -> Either e a
-     Nothing ?! e = Left e
-     Just x  ?! _ = Right x
+    validityUpperBound = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> TxValidityUpperBound ValidityUpperBoundInShelleyEra ttl
+      ShelleyBasedEraAllegra -> TxValidityUpperBound ValidityUpperBoundInAllegraEra ttl
+      ShelleyBasedEraMary    -> TxValidityUpperBound ValidityUpperBoundInMaryEra ttl
 
-   -- | If this transaction should contain additional binary blob -
-   --   we have to create attributes of the corresponding size.
-   --   TxAttributes contains a map from 1-byte integer to arbitrary bytes which
-   --   will be used as a binary blob to increase the size of the transaction.
-   createTxAttributes
-     :: TxAdditionalSize
-     -> Byron.TxAttributes
-   createTxAttributes (TxAdditionalSize 0) = Byron.mkAttributes ()
-   createTxAttributes (TxAdditionalSize n) = blobAttributes n
-    where
-     blobAttributes :: Int -> Byron.TxAttributes
-     blobAttributes aSize =
-       (Byron.mkAttributes ()) {
-         Byron.attrRemain =
-           Byron.UnparsedFields $
-           Map.singleton k $ LB.replicate (finalSize aSize) byte
-       }
-
-     k :: Word8
-     k = 1 -- Arbitrary key.
-
-     -- Fill an attribute by the same arbitrary byte in each element.
-     byte :: Word8
-     byte = 0
-
-     sizeOfKey :: Int
-     sizeOfKey = 1
-
-     -- Please note that actual binary size of attributes will be a little bit
-     -- bigger than the size defined by user (via CLI argument), because size of
-     -- singleton 'Map k v' isn't equal to the size of ('k' + 'v').
-     finalSize :: Int -> Int64
-     finalSize userDefinedSize = fromIntegral (userDefinedSize - sizeOfKey)
-
-mkTransactionGen
-  :: (r ~ Int)
-  => Mode mode era
-  -> SigningKeyOf era
+mkTransactionGen :: forall era .
+     IsShelleyBasedEra era
+  => SigningKey PaymentKey
   -> NonEmpty (TxIn, TxOut era)
   -- ^ Non-empty list of (TxIn, TxOut) that will be used as
   -- inputs and the key to spend the associated value
   -> Maybe (AddressInEra era)
   -- ^ The address to associate with the 'change',
   -- if different from that of the first argument
-  -> [(r, TxOut era)]
+  -> [(Int, TxOut era)]
   -- ^ Each recipient and their payment details
   -> TxAdditionalSize
   -- ^ Optional size of additional binary blob in transaction (as 'txAttributes')
@@ -255,13 +116,13 @@ mkTransactionGen
   -- ^ Tx fee.
   -> ( Maybe (TxIx, Lovelace)   -- The 'change' index and value (if any)
      , Lovelace                 -- The associated fees
-     , Map r TxIx               -- The offset map in the transaction below
+     , Map Int TxIx               -- The offset map in the transaction below
      , Tx era
      )
-mkTransactionGen p signingKey inputs mChangeAddr payments payloadSize fee@(Lovelace fees) =
+mkTransactionGen signingKey inputs mChangeAddr payments payloadSize fee =
   (mChange, fee, offsetMap, tx)
  where
-  tx = mkTransaction p signingKey payloadSize (SlotNo 10000000)
+  tx = mkTransaction signingKey payloadSize (SlotNo 10000000)
          fee
          (NonEmpty.toList $ fst <$> inputs)
          (NonEmpty.toList txOutputs)
@@ -269,24 +130,22 @@ mkTransactionGen p signingKey inputs mChangeAddr payments payloadSize fee@(Lovel
   fundsTxOuts   = snd <$> NonEmpty.toList inputs
   payTxOuts     = map snd payments
 
-  Lovelace totalInpValue = txOutSum fundsTxOuts
-  Lovelace totalOutValue = txOutSum payTxOuts
-  changeValue@(Lovelace chgValRaw)
-                = Lovelace (totalInpValue - totalOutValue - fees)
-
+  totalInpValue = txOutSum fundsTxOuts
+  totalOutValue = txOutSum payTxOuts
+  changeValue = totalInpValue - totalOutValue - fee
       -- change the order of comparisons first check emptiness of txouts AND remove appendr after
 
   (txOutputs, mChange) =
-    if chgValRaw > 0
+    if changeValue > 0
     then
       let changeAddress = fromMaybe (txOutAddress . snd $ NonEmpty.head inputs) mChangeAddr
-          changeTxOut   = TxOut changeAddress $ mkTxOutValueAdaOnly (modeEra p) changeValue
+          changeTxOut   = TxOut changeAddress $ mkTxOutValueAdaOnly changeValue
           changeIndex   = TxIx $ fromIntegral $ length payTxOuts -- 0-based index
       in
           (appendr payTxOuts (changeTxOut :| []), Just (changeIndex, changeValue))
     else
       case payTxOuts of
-        []                 -> panic "change is zero and txouts is empty"
+        []                 -> error "change is zero and txouts is empty"
         txout0: txoutsRest -> (txout0 :| txoutsRest, Nothing)
 
   -- TxOuts of recipients are placed at the first positions
@@ -295,11 +154,28 @@ mkTransactionGen p signingKey inputs mChangeAddr payments payloadSize fee@(Lovel
                                      [0..]
   txOutSum :: [(TxOut era)] -> Lovelace
   txOutSum l = sum $ map toVal l
-  toVal :: forall era. TxOut era -> Lovelace
-  toVal (TxOut _ (TxOutAdaOnly _ val)) = val
-  toVal (TxOut (AddressInEra _ _) (TxOutValue _ _)) = error "unexpected multiAsset"
+
+  toVal (TxOut _ val) = txOutValueToLovelace val
+
+  txOutAddress (TxOut addr _) = addr
 
   -- | Append a non-empty list to a list.
   -- > appendr [1,2,3] (4 :| [5]) == 1 :| [2,3,4,5]
   appendr :: [a] -> NonEmpty a -> NonEmpty a
   appendr l nel = foldr NonEmpty.cons nel l
+
+mkTxOutValueAdaOnly :: forall era . IsShelleyBasedEra era => Lovelace -> TxOutValue era
+mkTxOutValueAdaOnly l = case shelleyBasedEra @ era of
+  ShelleyBasedEraShelley -> TxOutAdaOnly AdaOnlyInShelleyEra l
+  ShelleyBasedEraAllegra -> TxOutAdaOnly AdaOnlyInAllegraEra l
+  ShelleyBasedEraMary    -> TxOutValue MultiAssetInMaryEra $ lovelaceToValue l
+
+txOutValueToLovelace :: TxOutValue era -> Lovelace
+txOutValueToLovelace = \case
+  TxOutAdaOnly AdaOnlyInByronEra   x -> x
+  TxOutAdaOnly AdaOnlyInShelleyEra x -> x
+  TxOutAdaOnly AdaOnlyInAllegraEra x -> x
+  TxOutValue _ v -> case valueToLovelace v of
+    Just c -> c
+    Nothing -> error "txOutValueLovelace  TxOut contains no ADA"
+  _ -> error "txOutValueLovelace unsupported case"

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
@@ -45,7 +45,7 @@ import Cardano.Benchmarking.GeneratorTx.Benchmark
 import Cardano.Benchmarking.GeneratorTx.Genesis
 import Cardano.Benchmarking.GeneratorTx.CLI.Parsers
 import Cardano.Benchmarking.GeneratorTx.Era
-import Cardano.Benchmarking.GeneratorTx.Callback
+import Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition
 
 data ProtocolError =
     IncorrectProtocolSpecified  !Api.Protocol
@@ -157,7 +157,7 @@ runCommand (GenerateTxs logConfigFp
               myTracer msg = traceWith (btTxSubmit_ tracers) $ TraceBenchTxSubDebug msg
 
               runAll :: forall era. IsShelleyBasedEra era => Proxy era -> Benchmark -> GeneratorFunds -> ExceptT TxGenError IO ()
-              runAll = mkCallback ptcl nmagic_opt is_addr_mn iocp socketFp tracers
+              runAll = mangleLocalProtocolDefinition ptcl nmagic_opt is_addr_mn iocp socketFp tracers
           firstExceptT GenesisBenchmarkRunnerError $ case benchmarkEra of
             AnyCardanoEra ByronEra   -> error "ByronEra not supported"
             AnyCardanoEra ShelleyEra -> do

--- a/cardano-tx-generator/test/Main.hs
+++ b/cardano-tx-generator/test/Main.hs
@@ -43,11 +43,11 @@ cliArgs = testGroup "cli arguments"
                            $ words l
 
 pinnedHelpMessage = [here|ParserFailure(Usage: <program> --config FILEPATH --socket-path FILEPATH 
-                 [(--target-node (HOST,PORT))] [--init-cooldown INT] 
-                 [--initial-ttl INT] [--num-of-txs INT] [--tps DOUBLE] 
-                 [--inputs-per-tx INT] [--outputs-per-tx INT] [--tx-fee INT] 
-                 [--add-tx-size INT] [--fail-on-submission-errors] 
-                 [--byron | --shelley] [--n2n-magic-override NATURAL] 
+                 [--shelley | --mary | --allegra] [(--target-node (HOST,PORT))] 
+                 [--init-cooldown INT] [--initial-ttl INT] [--num-of-txs INT] 
+                 [--tps DOUBLE] [--inputs-per-tx INT] [--outputs-per-tx INT] 
+                 [--tx-fee INT] [--add-tx-size INT] 
+                 [--fail-on-submission-errors] [--n2n-magic-override NATURAL] 
                  [--addr-mainnet] 
                  (--genesis-funds-key FILEPATH | --utxo-funds-key FILEPATH
                    --tx-in TX-IN --tx-out TX-OUT |
@@ -56,6 +56,9 @@ pinnedHelpMessage = [here|ParserFailure(Usage: <program> --config FILEPATH --soc
 Available options:
   --config FILEPATH        Configuration file for the cardano-node
   --socket-path FILEPATH   Path to a cardano-node socket
+  --shelley                Initialise Cardano in shelley submode.
+  --mary                   Initialise Cardano in mary submode.
+  --allegra                Initialise Cardano in allegra submode.
   --target-node (HOST,PORT)
                            IP address and port of the node transactions will be
                            sent to.
@@ -70,8 +73,6 @@ Available options:
   --fail-on-submission-errors
                            Fail on submission thread errors, instead of logging
                            them.
-  --byron                  Initialise Cardano in Byron submode.
-  --shelley                Initialise Cardano in Shelley submode.
   --n2n-magic-override NATURAL
                            Override the network magic for the node-to-node
                            protocol.

--- a/locli/src/Cardano/Unlog/LogObject.hs
+++ b/locli/src/Cardano/Unlog/LogObject.hs
@@ -27,7 +27,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as Text
 import           Data.Time.Clock (UTCTime)
 import qualified Data.Map as Map
-import           Data.Map (Map)
 
 import           Cardano.BM.Stats.Resources
 
@@ -83,6 +82,10 @@ interpreters = Map.fromList
     \v -> LOTraceNodeIsLeader
             <$> v .: "slot"
 
+  , (,) "TraceNodeNotLeader" $
+    \v -> LOTraceNodeNotLeader
+            <$> v .: "slot"
+
   , (,) "TraceMempoolAddedTx" $
     \v -> do mps :: Object <- v .: "mempoolSize"
              LOMempoolTxs <$> mps .: "numTxs"
@@ -107,6 +110,7 @@ logObjectStreamInterpreterKeys = Map.keys interpreters
 data LOBody
   = LOTraceStartLeadershipCheck !Word64 !Word64 !Float
   | LOTraceNodeIsLeader !Word64
+  | LOTraceNodeNotLeader !Word64
   | LOResources !ResourceStats
   | LOMempoolTxs !Word64
   | LOMempoolRejectedTx

--- a/locli/src/Cardano/Unlog/SlotStats.hs
+++ b/locli/src/Cardano/Unlog/SlotStats.hs
@@ -33,6 +33,7 @@ data SlotStats
     , slChainDBSnap :: !Word64
     , slRejectedTx  :: !Word64
     , slBlockNo     :: !Word64
+    , slBlockless   :: !Word64
     , slOrderViol   :: !Word64
     , slEarliest    :: !UTCTime
     , slSpan        :: !NominalDiffTime
@@ -48,21 +49,22 @@ instance ToJSON SlotStats
 slotHeadE, slotFormatE :: Text
 slotHeadP, slotFormatP :: Text
 slotHeadP =
-  "abs.  slot    block lead  leader CDB rej check chain       %CPU      GCs   Produc-   Memory use, kB      Alloc rate  Mempool  UTxO" <>"\n"<>
-  "slot#   epoch  no. checks ships snap txs span  density all/ GC/mut maj/min tivity  Live   Alloc   RSS     / mut sec   txs  entries"
+  "abs.  slot    block block lead  leader CDB rej check chain       %CPU      GCs   Produc-   Memory use, kB      Alloc rate  Mempool  UTxO" <>"\n"<>
+  "slot#   epoch  no. -less checks ships snap txs span  density all/ GC/mut maj/min tivity  Live   Alloc   RSS     / mut sec   txs  entries"
 slotHeadE =
-  "abs.slot#,slot,epoch,block,leadChecks,leadShips,cdbSnap,rejTx,checkSpan,chainDens,%CPU,%GC,%MUT,Productiv,MemLiveKb,MemAllocKb,MemRSSKb,AllocRate/Mut,MempoolTxs,UTxO"
-slotFormatP = "%5d %4d:%2d %4d    %2d   %2d    %2d %2d %8s %0.3f  %3s %3s %3s %2s %3s   %4s %7s %7s %7s % 8s %4d %9d"
-slotFormatE = "%d,%d,%d,%d,%d,%d,%d,%d,%s,%0.3f,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d"
+  "abs.slot#,slot,epoch,block,blockless,leadChecks,leadShips,cdbSnap,rejTx,checkSpan,chainDens,%CPU,%GC,%MUT,Productiv,MemLiveKb,MemAllocKb,MemRSSKb,AllocRate/Mut,MempoolTxs,UTxO"
+slotFormatP = "%5d %4d:%2d %4d    %2d    %2d   %2d    %2d %2d %8s %0.3f  %3s %3s %3s %2s %3s   %4s %7s %7s %7s % 8s %4d %9d"
+slotFormatE = "%d,%d,%d,%d,%d,%d,%d,%d,%d,%s,%0.3f,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d"
 
 slotLine :: Bool -> Text -> SlotStats -> Text
 slotLine exportMode leadershipF SlotStats{..} = Text.pack $
   printf (Text.unpack leadershipF)
-         sl epsl epo blk chks  lds cdbsn rejtx span dens cpu gc mut majg ming   pro liv alc rss atm mpo utx
+         sl epsl epo blk blkl chks  lds cdbsn rejtx span dens cpu gc mut majg ming   pro liv alc rss atm mpo utx
  where sl    = slSlot
        epsl  = slEpochSlot
        epo   = slEpoch
        blk   = slBlockNo
+       blkl  = slBlockless
        chks  = slCountChecks
        lds   = slCountLeads
        cdbsn = slChainDBSnap
@@ -136,5 +138,6 @@ zeroSlotStats =
   , slChainDBSnap = 0
   , slRejectedTx = 0
   , slBlockNo = 0
+  , slBlockless = 0
   }
 

--- a/locli/src/Cardano/Unlog/SlotStats.hs
+++ b/locli/src/Cardano/Unlog/SlotStats.hs
@@ -36,7 +36,8 @@ data SlotStats
     , slBlockless   :: !Word64
     , slOrderViol   :: !Word64
     , slEarliest    :: !UTCTime
-    , slSpan        :: !NominalDiffTime
+    , slSpanCheck   :: !NominalDiffTime
+    , slSpanLead    :: !NominalDiffTime
     , slMempoolTxs  :: !Word64
     , slUtxoSize    :: !Word64
     , slDensity     :: !Float
@@ -49,17 +50,17 @@ instance ToJSON SlotStats
 slotHeadE, slotFormatE :: Text
 slotHeadP, slotFormatP :: Text
 slotHeadP =
-  "abs.  slot    block block lead  leader CDB rej check chain       %CPU      GCs   Produc-   Memory use, kB      Alloc rate  Mempool  UTxO" <>"\n"<>
-  "slot#   epoch  no. -less checks ships snap txs span  density all/ GC/mut maj/min tivity  Live   Alloc   RSS     / mut sec   txs  entries"
+  "abs.  slot    block block lead  leader CDB rej  check     lead  chain       %CPU      GCs   Produc-   Memory use, kB    Alloc rate  Mempool  UTxO" <>"\n"<>
+  "slot#   epoch  no. -less checks ships snap txs  span      span  density all/ GC/mut maj/min tivity  Live   Alloc   RSS   / mut sec   txs  entries"
 slotHeadE =
   "abs.slot#,slot,epoch,block,blockless,leadChecks,leadShips,cdbSnap,rejTx,checkSpan,chainDens,%CPU,%GC,%MUT,Productiv,MemLiveKb,MemAllocKb,MemRSSKb,AllocRate/Mut,MempoolTxs,UTxO"
-slotFormatP = "%5d %4d:%2d %4d    %2d    %2d   %2d    %2d %2d %8s %0.3f  %3s %3s %3s %2s %3s   %4s %7s %7s %7s % 8s %4d %9d"
-slotFormatE = "%d,%d,%d,%d,%d,%d,%d,%d,%d,%s,%0.3f,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d"
+slotFormatP = "%5d %4d:%2d %4d    %2d    %2d   %2d    %2d  %2d %8s %8s %0.3f  %3s %3s %3s %2s %3s   %4s %7s %7s %7s % 8s %4d %9d"
+slotFormatE = "%d,%d,%d,%d,%d,%d,%d,%d,%d,%s,%s,%0.3f,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d"
 
 slotLine :: Bool -> Text -> SlotStats -> Text
 slotLine exportMode leadershipF SlotStats{..} = Text.pack $
   printf (Text.unpack leadershipF)
-         sl epsl epo blk blkl chks  lds cdbsn rejtx span dens cpu gc mut majg ming   pro liv alc rss atm mpo utx
+         sl epsl epo blk blkl chks  lds cdbsn rejtx spanC spanL dens cpu gc mut majg ming   pro liv alc rss atm mpo utx
  where sl    = slSlot
        epsl  = slEpochSlot
        epo   = slEpoch
@@ -69,7 +70,8 @@ slotLine exportMode leadershipF SlotStats{..} = Text.pack $
        lds   = slCountLeads
        cdbsn = slChainDBSnap
        rejtx = slRejectedTx
-       span  = show slSpan :: Text
+       spanC = show slSpanCheck :: Text
+       spanL = show slSpanLead :: Text
        cpu   = d 3 $ rCentiCpu slResources
        dens  = slDensity
        gc    = d 2 $ rCentiGC  slResources
@@ -130,7 +132,8 @@ zeroSlotStats =
   , slCountLeads = 0
   , slOrderViol = 0
   , slEarliest = zeroUTCTime
-  , slSpan = realToFrac (0 :: Int)
+  , slSpanCheck = realToFrac (0 :: Int)
+  , slSpanLead = realToFrac (0 :: Int)
   , slMempoolTxs = 0
   , slUtxoSize = 0
   , slDensity = 0

--- a/locli/src/Cardano/Unlog/Summary.hs
+++ b/locli/src/Cardano/Unlog/Summary.hs
@@ -125,7 +125,7 @@ runLeadershipCheckCmd cp mLeadershipsDumpFile mPrettyDumpFile mExportTimelineFil
        hPutStrLn hnd . Text.pack $
          printf "--- input: %s" (intercalate " " $ unJsonLogfile <$> srcs)
        renderStats   statsHeadP statsFormatP s hnd
-       renderTimeline leadershipHeadP leadershipFormatP False xs hnd
+       renderSlotTimeline slotHeadP slotFormatP False xs hnd
    renderExportStats :: Summary -> TextOutputFile -> IO ()
    renderExportStats s o =
      withFile (unTextOutputFile o) WriteMode $
@@ -133,20 +133,13 @@ runLeadershipCheckCmd cp mLeadershipsDumpFile mPrettyDumpFile mExportTimelineFil
    renderExportTimeline :: Seq SlotStats -> TextOutputFile -> IO ()
    renderExportTimeline xs o =
      withFile (unTextOutputFile o) WriteMode $
-       renderTimeline leadershipHeadE leadershipFormatE True xs
+       renderSlotTimeline slotHeadE slotFormatE True xs
 
    renderStats :: Text -> Text -> Summary -> Handle -> IO ()
    renderStats statHead statFmt summary hnd = do
        hPutStrLn hnd statHead
        forM_ (toDistribLines statFmt summary) $
          hPutStrLn hnd
-
-   renderTimeline :: Text -> Text -> Bool -> Seq SlotStats -> Handle -> IO ()
-   renderTimeline leadHead leadFmt exportMode slotStats hnd = do
-       forM_ (zip (toList slotStats) [(0 :: Int)..]) $ \(l, i) -> do
-         when (i `mod` 33 == 0 && (i == 0 || not exportMode)) $
-           hPutStrLn hnd leadHead
-         hPutStrLn hnd $ toLeadershipLine exportMode leadFmt l
 
 data Summary
   = Summary
@@ -281,8 +274,8 @@ toDistribLines statsF Summary{..} =
     (renderPercSpec 6 ps) count miss chkdt dens cpu gc mut majg ming     liv alc rss cpu85Sp cpu85SpIdx cpu85SpPrev
     where chkdt = show chkdt' :: Text
 
-statsHeadE, statsFormatE, leadershipHeadE, leadershipFormatE :: Text
-statsHeadP, statsFormatP, leadershipHeadP, leadershipFormatP :: Text
+statsHeadE, statsFormatE :: Text
+statsHeadP, statsFormatP :: Text
 statsHeadP =
   "%tile Count MissR  CheckΔt   Dens  CPU  GC MUT Maj Min         Live   Alloc   RSS    CPU85%-SpanLengths/Idx/Prev"
 statsHeadE =
@@ -291,10 +284,3 @@ statsFormatP =
   "%6s %5d %0.2f   %6s  %0.3f  %3d %3d %3d %2d %3d      %8d %8d %7d %4d %4d %4d"
 statsFormatE =
   "%s,%d,%0.2f,%s,%0.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d"
-leadershipHeadP =
-  "abs.  slot    block lead  leader CDB rej check chain       %CPU      GCs   Produc-   Memory use, kB      Alloc rate  Mempool  UTxO" <>"\n"<>
-  "slot#   epoch  no. checks ships snap txs span  density all/ GC/mut maj/min tivity  Live   Alloc   RSS     / mut sec   txs  entries"
-leadershipHeadE =
-  "abs.slot#,slot,epoch,block,leadChecks,leadShips,cdbSnap,rejTx,checkSpan,chainDens,%CPU,%GC,%MUT,Productiv,MemLiveKb,MemAllocKb,MemRSSKb,AllocRate/Mut,MempoolTxs,UTxO"
-leadershipFormatP = "%5d %4d:%2d %4d    %2d   %2d    %2d %2d %8s %0.3f  %3s %3s %3s %2s %3s   %4s %7s %7s %7s % 8s %4d %9d"
-leadershipFormatE = "%d,%d,%d,%d,%d,%d,%d,%d,%s,%0.3f,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "c997529667d68821e430c82a8cc1165b4ee53308",
-        "sha256": "17hzw8gv6nhd6vfhszkh24cd4p420g96cmpwzjlzwpaad5mnvfp2",
+        "rev": "67eedea16bc9674c9b0dc52c72d330697c6b882a",
+        "sha256": "1cfr3njicpcs44w209c95skldd6xl3jwnvpvmhn8vh89m7byicgh",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/c997529667d68821e430c82a8cc1165b4ee53308.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/67eedea16bc9674c9b0dc52c72d330697c6b882a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "400d18092ce604352cf36fe5f105b0d7c78be074",
-        "sha256": "19r4mamm9bxc1hz32qgsrfnrfxwp4pgnb4d28fzai3izznil03vi",
+        "rev": "f97de0bbf51c9bdc7b0eecb830cec8472b786555",
+        "sha256": "14iy7483hjqsvvw48ql65y54q8giaphgg531l2fwqg70hypwn75k",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/400d18092ce604352cf36fe5f105b0d7c78be074.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/f97de0bbf51c9bdc7b0eecb830cec8472b786555.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "93f833b3390b22287d50dda70f06be5fc419f334",
-        "sha256": "0r1zj1bw67wnis2lp7fifqw5qjr260g4hg11jvyyn1kwc0bq3cs7",
+        "rev": "22de1b849a7c4137401acc81376fc722d97aafa8",
+        "sha256": "1qm7lki0xq5n5w4dcxxawzwkkww5lr9sv45kp2f1zh9rdc1jmf68",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/93f833b3390b22287d50dda70f06be5fc419f334.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/22de1b849a7c4137401acc81376fc722d97aafa8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "3230d3a0547c734b4dcea856aaec89b9adc373bf",
-        "sha256": "1p35gkp7icx3shkh4kgzghjgj4wg646bqbkns104nqzqcnqx68sz",
+        "rev": "5b86d63a0b59b7666d19901b654d8fbde27d9500",
+        "sha256": "1mfb93nnw0x4gyq93v6lh6h7imliw4j0wp5l9gpdafy3rw621xzb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/3230d3a0547c734b4dcea856aaec89b9adc373bf.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/5b86d63a0b59b7666d19901b654d8fbde27d9500.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "f97de0bbf51c9bdc7b0eecb830cec8472b786555",
-        "sha256": "14iy7483hjqsvvw48ql65y54q8giaphgg531l2fwqg70hypwn75k",
+        "rev": "c997529667d68821e430c82a8cc1165b4ee53308",
+        "sha256": "17hzw8gv6nhd6vfhszkh24cd4p420g96cmpwzjlzwpaad5mnvfp2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/f97de0bbf51c9bdc7b0eecb830cec8472b786555.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/c997529667d68821e430c82a8cc1165b4ee53308.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/scripts/runs-fetch.sh
+++ b/scripts/runs-fetch.sh
@@ -9,7 +9,7 @@ unpack_run() {
         mkdir -p "$rundir"/analysis
         (
                 cd "$rundir"/analysis
-                tar xaf ../logs-nodes.tar.xz logs-node-{0,1,3,10,20}
+                tar xaf ../logs-nodes.tar.xz logs-node-{0,1,10}
         )
 }
 

--- a/scripts/runs-sheets-merge.sh
+++ b/scripts/runs-sheets-merge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2046,SC2206,SC2207
+
+basedir=$(realpath "$(dirname "$0")")
+. "$basedir"/common.sh
+
+set -e
+
+mach=node-1
+
+if test -z "$*"
+then runs=($(ls runs))
+else runs=("$@")
+fi
+
+spreadsheets_mach() {
+        local mach=$1
+        shift
+        local runs=($*)
+
+        for r in ${runs[*]}
+        do echo runs/$r/analysis/stats-"$mach".ods
+        done
+}
+
+ssconvert --merge-to runs/stats-$mach.ods $(spreadsheets_mach $mach ${runs[*]})


### PR DESCRIPTION
* Update the tx-generator to support Mary-Mode.
* Remove special Shelley-only and Byron-only modes
* Update cardano-tx-generator to 1.24.2
* Update run-tx-generator script
* Remove Mode-type
* Todo fix funding CLI options
* Todo fix network-magic CLI options