### PR TITLE
CAD-2414 sized Tx-payloads

### DIFF
--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -30,6 +30,7 @@ library
                        Cardano.Benchmarking.GeneratorTx.Genesis
                        Cardano.Benchmarking.GeneratorTx.NodeToNode
                        Cardano.Benchmarking.GeneratorTx.Tx
+                       Cardano.Benchmarking.GeneratorTx.SizedMetadata
                        Cardano.Benchmarking.GeneratorTx.Tx.Byron
                        Cardano.Benchmarking.GeneratorTx.Submission
                        Cardano.Benchmarking.GeneratorTx.CLI.Parsers

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -16,6 +16,7 @@ data TxGenError =
   | SplittingSubmissionError !Text
   | UtxoReadFailure !Text
   | SuppliedUtxoTooSmall !Int !Int
+  | BadPayloadSize !Text
   -- ^ The supplied UTxO size (second value) was less than the requested
   --   number of transactions to send (first value).
   deriving stock Show

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+module Cardano.Benchmarking.GeneratorTx.SizedMetadata
+where
+
+import           Prelude
+
+import qualified Data.Map.Strict as Map
+import qualified Data.ByteString as BS
+import           Cardano.Benchmarking.GeneratorTx.Tx
+import           Cardano.Api
+
+maxMapSize :: Int
+maxMapSize = 1000
+maxBSSize :: Int
+maxBSSize = 64
+
+-- Properties of the underlying/opaque CBOR encoding.
+assume_cbor_properties :: Bool
+assume_cbor_properties
+  =    prop_mapCostsShelley
+    && prop_mapCostsAllegra
+    && prop_mapCostsMary
+    && prop_bsCostsSelley
+    && prop_bsCostsAllegra
+    && prop_bsCostsMary
+
+-- The cost of map entries in metadata follows a step function.
+-- This assums the map indecies are [0..n].
+prop_mapCostsShelley :: Bool
+prop_mapCostsAllegra :: Bool
+prop_mapCostsMary    :: Bool
+prop_mapCostsShelley = measureMapCosts AsShelleyEra == assumeMapCosts AsShelleyEra
+prop_mapCostsAllegra = measureMapCosts AsAllegraEra == assumeMapCosts AsAllegraEra
+prop_mapCostsMary    = measureMapCosts AsMaryEra    == assumeMapCosts AsMaryEra
+
+assumeMapCosts :: forall era . IsShelleyBasedEra era => AsType era -> [Int]
+assumeMapCosts _proxy = stepFunction [
+      (   1 , 0)          -- An empty map of metadata has the same cost as TxMetadataNone.
+    , (   1 , firstEntry) -- Using Metadata costs 37 or 39 bytes  (first map entry).
+    , (  22 , 2)          -- The next 22 entries cost 2 bytes each.
+    , ( 233 , 3)          -- 233 entries at 3 bytes.
+    , ( 744 , 4)          -- 744 entries at 4 bytes.
+    ]
+  where
+    firstEntry = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> 37
+      ShelleyBasedEraAllegra -> 39
+      ShelleyBasedEraMary    -> 39
+
+-- Bytestring costs are not LINEAR !!
+-- Costs are piecewise linear for payload sizes [0..24] and [25..64].
+prop_bsCostsSelley  :: Bool
+prop_bsCostsAllegra :: Bool
+prop_bsCostsMary    :: Bool
+prop_bsCostsSelley  = measureBSCosts AsShelleyEra == [37..60] ++ [62..102]
+prop_bsCostsAllegra = measureBSCosts AsAllegraEra == [39..62] ++ [64..104]
+prop_bsCostsMary    = measureBSCosts AsMaryEra    == [39..62] ++ [64..104]
+
+stepFunction :: [(Int, Int)] -> [Int]
+stepFunction f = scanl1 (+) steps
+  where
+    steps = concatMap (\(count,step) -> replicate count step) f
+
+-- Measure the cost of metadata map entries.
+-- This is the cost of the index with an empty BS as payload.
+measureMapCosts :: forall era . IsShelleyBasedEra era => AsType era -> [Int]
+measureMapCosts era = map (metadataSize era . Just . replicateEmptyBS) [0..maxMapSize]
+  where
+    replicateEmptyBS :: Int -> TxMetadata
+    replicateEmptyBS n = listMetadata $ replicate n $ TxMetaBytes $ BS.empty
+
+listMetadata :: [TxMetadataValue] -> TxMetadata
+listMetadata l = makeTransactionMetadata $ Map.fromList $ zip [0..] l
+
+-- Cost of metadata with a single BS of size [0..maxBSSize].
+measureBSCosts :: forall era . IsShelleyBasedEra era => AsType era -> [Int]
+measureBSCosts era = map (metadataSize era . Just . bsMetadata) [0..maxBSSize]
+  where bsMetadata s = listMetadata [TxMetaBytes $ BS.replicate s 0]
+
+metadataSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMetadata -> Int
+metadataSize p m = dummyTxSize p m - dummyTxSize p Nothing
+
+dummyTxSize :: forall era . IsShelleyBasedEra era => AsType era -> Maybe TxMetadata -> Int
+dummyTxSize _p metadata = case makeTransactionBody dummyTx of
+    Right b -> BS.length $ serialiseToCBOR b
+    Left err -> error $ "metaDataSize " ++ show err
+  where
+    dataInEra :: Maybe TxMetadata -> TxMetadataInEra era
+    dataInEra Nothing = TxMetadataNone
+    dataInEra (Just m) = case shelleyBasedEra @ era of
+      ShelleyBasedEraShelley -> TxMetadataInEra TxMetadataInShelleyEra m
+      ShelleyBasedEraAllegra -> TxMetadataInEra TxMetadataInAllegraEra m
+      ShelleyBasedEraMary    -> TxMetadataInEra TxMetadataInMaryEra m
+
+    dummyTx = TxBodyContent {
+        txIns = [ TxIn "dbaff4e270cfb55612d9e2ac4658a27c79da4a5271c6f90853042d1403733810" (TxIx 0) ]
+      , txOuts = []
+      , txFee = mkFee $ fromInteger 0
+      , txValidityRange = (TxValidityNoLowerBound, mkValidityUpperBound $ fromInteger 0)
+      , txMetadata = dataInEra metadata
+      , txAuxScripts = TxAuxScriptsNone
+      , txWithdrawals = TxWithdrawalsNone
+      , txCertificates = TxCertificatesNone
+      , txUpdateProposal = TxUpdateProposalNone
+      , txMintValue = TxMintNone
+      }

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -70,13 +70,13 @@ mkGenTransaction key _payloadSize ttl fee txins txouts
 mkTransaction :: forall era .
      IsShelleyBasedEra era
   => SigningKey PaymentKey
-  -> TxAdditionalSize
+  -> TxMetadataInEra era
   -> SlotNo
   -> Lovelace
   -> [TxIn]
   -> [TxOut era]
   -> Tx era
-mkTransaction key _payloadSize ttl fee txins txouts
+mkTransaction key metadata ttl fee txins txouts
   = case makeTransactionBody txBodyContent of
     Right b -> signShelleyTransaction b [WitnessPaymentKey key]
     Left err -> error $ show err
@@ -86,7 +86,7 @@ mkTransaction key _payloadSize ttl fee txins txouts
       , txOuts = txouts
       , txFee = mkFee fee
       , txValidityRange = (TxValidityNoLowerBound, mkValidityUpperBound ttl)
-      , txMetadata = TxMetadataNone
+      , txMetadata = metadata
       , txAuxScripts = TxAuxScriptsNone
       , txWithdrawals = TxWithdrawalsNone
       , txCertificates = TxCertificatesNone
@@ -123,7 +123,7 @@ mkTransactionGen :: forall era .
   -- if different from that of the first argument
   -> [(Int, TxOut era)]
   -- ^ Each recipient and their payment details
-  -> TxAdditionalSize
+  -> TxMetadataInEra era
   -- ^ Optional size of additional binary blob in transaction (as 'txAttributes')
   -> Lovelace
   -- ^ Tx fee.
@@ -132,10 +132,10 @@ mkTransactionGen :: forall era .
      , Map Int TxIx               -- The offset map in the transaction below
      , Tx era
      )
-mkTransactionGen signingKey inputs mChangeAddr payments payloadSize fee =
+mkTransactionGen signingKey inputs mChangeAddr payments metadata fee =
   (mChange, fee, offsetMap, tx)
  where
-  tx = mkTransaction signingKey payloadSize (SlotNo 10000000)
+  tx = mkTransaction signingKey metadata (SlotNo 10000000)
          fee
          (NonEmpty.toList $ fst <$> inputs)
          (NonEmpty.toList txOutputs)

--- a/cardano-tx-generator/test/Main.hs
+++ b/cardano-tx-generator/test/Main.hs
@@ -9,6 +9,7 @@ import           Text.Heredoc
 import           Options.Applicative
   
 import           Cardano.Benchmarking.Run (parseCommand)
+import           Cardano.Benchmarking.GeneratorTx.SizedMetadata
 
 
 --import           Cardano.Benchmarking.MockServer as MockServer
@@ -19,13 +20,25 @@ main = defaultMain tests
 tests :: TestTree
 tests =  testGroup "cardano-tx-generator"
   [
-    cliArgs    
+    cliArgs
+  , sizedMetadata
   , mockServer
   ]
   
 mockServer = testGroup "direct/pure client-server connect"
   [ testCase "tx-send == tx-received" $ assertBool "tx-send == tx-received" True -- TODO !
   ]
+
+sizedMetadata = testGroup "properties of the CBOR encoding relevant for generating sized metadat"
+  [ testCase "Shelley metadata map costs" $ assertBool "metadata map costs" prop_mapCostsShelley
+  , testCase "Shelley metadata ByteString costs" $ assertBool "metadata ByteString costs" prop_bsCostsShelley
+  , testCase "Allegra metadata map costs" $ assertBool "metadata map costs" prop_mapCostsAllegra
+  , testCase "Allegra metadata ByteString costs" $ assertBool "metadata ByteString costs" prop_bsCostsAllegra
+  , testCase "Mary metadata map costs"    $ assertBool "metadata map costs" prop_mapCostsMary
+  , testCase "Marymetadata ByteString costs"    $ assertBool "metadata ByteString costs" prop_bsCostsMary
+  , testCase "Test mkMetadata" $ assertBool "" True --WIP
+  ]
+
 
 cliArgs = testGroup "cli arguments"
   [


### PR DESCRIPTION
This feature adds metadata to the transactions that are used for benchmarking.
`--add-tx-size` set the size of the metadata in bytes.
This size refers to the size of the CBOR encoded Transaction that is transmitted via the network,