### PR TITLE
CAD-2529 generator: prototype benchmarking era transitions

### DIFF
--- a/cardano-tx-generator/app/cardano-tx-generator.hs
+++ b/cardano-tx-generator/app/cardano-tx-generator.hs
@@ -1,18 +1,5 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-
-import           Cardano.Prelude hiding (option)
-
-import qualified Options.Applicative as Opt
-
-import           Cardano.Benchmarking.Run
+import           Cardano.Benchmarking.Run (plainOldCliScript)
+import           Cardano.Benchmarking.Run (eraTransitionTest)
 
 main :: IO ()
-main = do
-  cmd <- Opt.customExecParser
-         (Opt.prefs Opt.showHelpOnEmpty)
-         (parserInfo
-           "cardano-tx-generator - load Cardano clusters with parametrised transaction flow")
-  runExceptT (runCommand cmd) >>= \case
-    Right _  -> pure ()
-    Left err -> print err >> exitFailure
+main = plainOldCliScript

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -34,6 +34,8 @@ library
                        Cardano.Benchmarking.GeneratorTx.Tx.Byron
                        Cardano.Benchmarking.GeneratorTx.Submission
                        Cardano.Benchmarking.GeneratorTx.CLI.Parsers
+                       Cardano.Benchmarking.DSL
+                       Cardano.Benchmarking.Script
                        Cardano.Benchmarking.Run
 
   other-modules:       Paths_cardano_tx_generator
@@ -104,12 +106,7 @@ executable cardano-tx-generator
                        "-with-rtsopts=-T"
 
   build-depends:       base >=4.12 && <5
-                     , cardano-prelude
                      , cardano-tx-generator
-                     , optparse-applicative
-                     , transformers-except
-
-  default-extensions:  NoImplicitPrelude
 
 test-suite cardano-tx-generator-test
   hs-source-dirs:       test

--- a/cardano-tx-generator/src/Cardano/Benchmarking/DSL.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/DSL.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Cardano.Benchmarking.DSL
+{-
+(
+  BenchmarkScript
+, ScriptM
+, DSL(..)
+, getDSL
+, MonoDSLs
+)
+-}
+
+where
+
+import           Prelude (error)
+import           Cardano.Prelude
+
+import           Cardano.Api
+import Cardano.Benchmarking.GeneratorTx.Benchmark -- (Benchmark, GeneratorFunds)
+import Cardano.Benchmarking.GeneratorTx.Era
+import Cardano.Benchmarking.GeneratorTx
+import Cardano.Benchmarking.GeneratorTx.Tx
+
+type ScriptM a = ExceptT TxGenError IO a
+type BenchmarkScript a = (BenchTracers IO CardanoBlock, MonoDSLs) ->  ScriptM a
+
+-- Look at hardfork combinator for more elegant abstraction.
+type MonoDSLs = (DSL ShelleyEra, DSL AllegraEra, DSL MaryEra)
+
+getDSL :: MonoDSLs -> CardanoEra era -> DSL era
+getDSL _         ByronEra = error "ByronEra not supported"
+getDSL (x, _, _) ShelleyEra = x
+getDSL (_, x, _) AllegraEra = x
+getDSL (_, _, x) MaryEra    = x
+
+type Fee = Lovelace
+type TTL = SlotNo
+
+type SecureGenesisFund era =
+     Fee
+  -> TTL
+  -> SigningKey PaymentKey
+  -> AddressInEra era
+  -> ScriptM Fund
+
+type SplitFunds era =
+     Lovelace
+  -> NumberOfTxs
+  -> NumberOfInputsPerTx
+  -> SigningKey PaymentKey
+  -> AddressInEra era
+  -> Fund
+  -> ScriptM [Fund]
+
+-- txGenerator is basically pure except for logging
+type TxGenerator era =
+     Benchmark
+  -> AddressInEra era
+  -> SigningKey PaymentKey
+  -> Int
+  -> [Fund]
+  -> ScriptM [Tx era]
+
+type RunBenchmark era =
+     NonEmpty NodeIPv4Address
+  -> TPSRate
+  -> SubmissionErrorPolicy
+  -> [Tx era]
+  -> ScriptM ()
+
+type KeyAddress era = SigningKey PaymentKey -> AddressInEra era
+
+data DSL era = DSL {
+--    networkId :: NetworkId
+    keyAddress :: KeyAddress era
+  , secureGenesisFund :: SecureGenesisFund era
+  , splitFunds :: SplitFunds era
+  , txGenerator :: TxGenerator era
+  , runBenchmark :: RunBenchmark era
+  }
+
+coolDown :: InitCooldown -> ScriptM ()
+coolDown (InitCooldown t) = liftIO $ threadDelay $ 1000 * 1000 * t

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Era.hs
@@ -24,7 +24,6 @@ module Cardano.Benchmarking.GeneratorTx.Era
   , NumberOfInputsPerTx(..)
   , NumberOfOutputsPerTx(..)
   , NumberOfTxs(..)
-  , TxAdditionalSize(..)
   , TPSRate(..)
 
   , Ack(..)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Error.hs
@@ -2,7 +2,8 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Benchmarking.GeneratorTx.Error
-  ( TxGenError (..)
+  (
+    TxGenError (..)
   ) where
 
 import           Cardano.Api.Typed
@@ -14,7 +15,6 @@ data TxGenError =
   --   UTxO entry.  The first value is the largest single UTxO available.
   | TxFileError !(FileError TextEnvelopeError)
   | SplittingSubmissionError !Text
-  | UtxoReadFailure !Text
   | SuppliedUtxoTooSmall !Int !Int
   | BadPayloadSize !Text
   -- ^ The supplied UTxO size (second value) was less than the requested

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
@@ -1,16 +1,35 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition
   (
-    mangleLocalProtocolDefinition
+    CliError (..)
+--  , mangleLocalProtocolDefinition
+  , runBenchmarkScriptWith
   ) where
 
-import           Prelude (error)
+import           Prelude (error, show)
+import Paths_cardano_tx_generator (version)
+
+import Data.Version (showVersion)
+import Data.Text (pack)
+
 import           Cardano.Prelude hiding (TypeError, show)
+import Control.Monad.Trans.Except.Extra (firstExceptT)
+import Control.Tracer (traceWith)
+
+import           Ouroboros.Consensus.Block.Abstract (BlockProtocol)
 
 import qualified Ouroboros.Consensus.Cardano as Consensus
+import           Ouroboros.Consensus.Cardano (Protocol, ProtocolCardano)
+
 import           Ouroboros.Consensus.Config
                    ( configBlock, configCodec)
 import           Ouroboros.Consensus.Config.SupportsNode
@@ -18,54 +37,40 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Node.ProtocolInfo
                    (ProtocolInfo (..))
 import           Ouroboros.Network.NodeToClient (IOManager)
+import           Ouroboros.Network.Block (MaxSlotNo(..))
 
-import           Cardano.Chain.Slotting
 import           Cardano.Api
 import           Cardano.Api.Typed
 import qualified Cardano.Api.Typed as Api
+import           Cardano.Chain.Slotting
+import qualified Cardano.Chain.Genesis as Genesis
 
--- Node imports
-import           Cardano.Node.Types (SocketPath(..))
-import           Cardano.Tracing.OrphanInstances.Byron()
-import           Cardano.Tracing.OrphanInstances.Common()
-import           Cardano.Tracing.OrphanInstances.Consensus()
-import           Cardano.Tracing.OrphanInstances.Network()
-import           Cardano.Tracing.OrphanInstances.Shelley()
+import           Cardano.Node.Configuration.Logging
+import           Cardano.Node.Configuration.POM
+import           Cardano.Node.Protocol.Cardano
+import           Cardano.Node.Types
 
-import Cardano.Benchmarking.GeneratorTx.Benchmark
+import Cardano.Benchmarking.DSL -- (BenchmarkScript, DSL(..))
 import Cardano.Benchmarking.GeneratorTx.Era
 import Cardano.Benchmarking.GeneratorTx.NodeToNode
-import Cardano.Benchmarking.GeneratorTx
-import Cardano.Benchmarking.GeneratorTx.Genesis (GeneratorFunds)
+import qualified Cardano.Benchmarking.GeneratorTx as GeneratorTx
+import qualified Cardano.Benchmarking.GeneratorTx.Tx as GeneratorTx
 
-type Funding era = Benchmark -> GeneratorFunds -> ExceptT TxGenError IO (SigningKey PaymentKey, [(TxIn, TxOut era)])
-type BenchmarkAction era
-      = Benchmark -> (SigningKey PaymentKey, [(TxIn, TxOut era)]) -> ExceptT TxGenError IO ()
-
-type Action era = Proxy era -> Benchmark -> GeneratorFunds -> ExceptT TxGenError IO ()
-
-mangleLocalProtocolDefinition
-  :: forall blok ptcl era.
-     (
-       IsShelleyBasedEra era
-     , ConfigSupportsTxGen CardanoMode era
-     )
-  =>  Consensus.Protocol IO blok ptcl
+mangleLocalProtocolDefinition ::
+     Consensus.Protocol IO blok ptcl
   -> Maybe NetworkMagic
   -> Bool
   -> IOManager
   -> SocketPath
   -> BenchTracers IO CardanoBlock
-  -> Action era
+  -> MonoDSLs
 mangleLocalProtocolDefinition ptcl@(Consensus.ProtocolCardano
              _
              Consensus.ProtocolParamsShelleyBased{Consensus.shelleyBasedGenesis}
               _ _ _ _ _ _)
             nmagic_opt is_addr_mn iom (SocketPath sock) tracers
-    = action
+    = (DSL {..}, DSL {..}, DSL {..})
   where
-    action _proxy benchmark fundOptions
-      =  funding benchmark fundOptions >>= benchmarkAction benchmark
 
     ProtocolInfo{pInfoConfig} = Consensus.protocolInfo ptcl
     localConnectInfo = LocalNodeConnectInfo
@@ -81,18 +86,93 @@ mangleLocalProtocolDefinition ptcl@(Consensus.ProtocolCardano
                        (configCodec pInfoConfig)
                        (getNetworkMagic $ configBlock pInfoConfig)
 
-    funding :: Funding era
-    funding = secureFunds
+    keyAddress :: IsShelleyBasedEra era => KeyAddress era
+    keyAddress = GeneratorTx.keyAddress networkId
+
+    secureGenesisFund :: IsShelleyBasedEra era => SecureGenesisFund era
+    secureGenesisFund = GeneratorTx.secureGenesisFund
                 (btTxSubmit_ tracers)
                 localConnectInfo
                 networkId
                 shelleyBasedGenesis
 
-    benchmarkAction :: BenchmarkAction era
-    benchmarkAction = runBenchmark (btTxSubmit_ tracers) (btN2N_ tracers) networkId connectClient
+    splitFunds :: IsShelleyBasedEra era => SplitFunds era
+    splitFunds = GeneratorTx.splitFunds
+                (btTxSubmit_ tracers)
+                localConnectInfo
+
+    txGenerator :: IsShelleyBasedEra era => TxGenerator era
+    txGenerator = GeneratorTx.txGenerator (btTxSubmit_ tracers)
+
+    runBenchmark :: IsShelleyBasedEra era => RunBenchmark era
+    runBenchmark = GeneratorTx.runBenchmark (btTxSubmit_ tracers) (btN2N_ tracers) connectClient
 
     networkId = if is_addr_mn
       then Mainnet
       else Testnet $ getNetworkMagic $ configBlock pInfoConfig
 
 mangleLocalProtocolDefinition _ _ _ _ _ _ = error "mkCallbacks"
+
+runBenchmarkScriptWith ::
+     IOManager
+  -> FilePath
+  -> SocketPath
+  -> Maybe NetworkMagic
+  -> Bool
+  -> BenchmarkScript a
+  -> ExceptT CliError IO a
+runBenchmarkScriptWith iocp logConfigFile socketFile nmagic_opt is_addr_mn script = do
+  nc <- liftIO $ mkNodeConfig logConfigFile
+  case ncProtocolConfig nc of
+    NodeProtocolConfigurationByron _    -> error "NodeProtocolConfigurationByron not supported"
+    NodeProtocolConfigurationShelley _  -> error "NodeProtocolConfigurationShelley not supported"
+    NodeProtocolConfigurationCardano byC shC hfC -> do
+        ptcl :: Protocol IO CardanoBlock ProtocolCardano <- firstExceptT (ProtocolInstantiationError . pack . show) $
+                  mkConsensusProtocolCardano byC shC hfC Nothing
+        loggingLayer <- mkLoggingLayer nc ptcl
+        let tracers :: BenchTracers IO CardanoBlock
+            tracers = createTracers loggingLayer
+            dslSet :: MonoDSLs
+            dslSet = mangleLocalProtocolDefinition ptcl nmagic_opt is_addr_mn iocp socketFile tracers
+        res <- firstExceptT BenchmarkRunnerError $ script (tracers, dslSet)
+        liftIO $ do
+          threadDelay (200*1000) -- Let the logging layer print out everything.
+          shutdownLoggingLayer loggingLayer
+        return res
+
+  where
+    mkLoggingLayer :: NodeConfiguration -> Protocol IO blk (BlockProtocol blk) -> ExceptT CliError IO LoggingLayer
+    mkLoggingLayer nc ptcl =
+      firstExceptT (\(ConfigErrorFileNotFound fp) -> ConfigNotFoundError fp) $
+        createLoggingLayer (pack $ showVersion version) nc ptcl
+
+    mkNodeConfig :: FilePath -> IO NodeConfiguration
+    mkNodeConfig logConfig = do
+     let configFp = ConfigYamlFilePath logConfig
+         filesPc = defaultPartialNodeConfiguration
+                   { pncProtocolFiles = Last . Just $
+                     ProtocolFilepaths
+                     { byronCertFile = Just ""
+                     , byronKeyFile = Just ""
+                     , shelleyKESFile = Just ""
+                     , shelleyVRFFile = Just ""
+                     , shelleyCertFile = Just ""
+                     , shelleyBulkCredsFile = Just ""
+                     }
+                   , pncValidateDB = Last $ Just False
+                   , pncShutdownIPC = Last $ Just Nothing
+                   , pncShutdownOnSlotSynced = Last $ Just NoMaxSlotNo
+                   , pncConfigFile = Last $ Just configFp
+                   }
+     configYamlPc <- parseNodeConfigurationFP . Just $ configFp
+     case makeNodeConfiguration $ configYamlPc <> filesPc of
+        Left err -> panic $ "Error in creating the NodeConfiguration: " <> pack err
+        Right nc' -> return nc'
+
+data CliError  =
+    GenesisReadError !FilePath !Genesis.GenesisDataError
+  | FileNotFoundError !FilePath
+  | ConfigNotFoundError         !FilePath
+  | ProtocolInstantiationError  !Text
+  | BenchmarkRunnerError !GeneratorTx.TxGenError
+  deriving stock Show

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
@@ -7,185 +6,60 @@
 {-# OPTIONS_GHC -Wno-all-missed-specialisations -Wno-orphans #-}
 
 module Cardano.Benchmarking.Run
-  ( parseCommand
-  , parserInfo
-  , runCommand
+  (
+    plainOldCliScript
+  , eraTransitionTest
   ) where
 
-import Prelude (String, error)
-import Prelude qualified
-import Data.Version (showVersion)
-import Data.Text (pack, unpack)
 import Cardano.Prelude hiding (option)
-import Control.Monad (fail)
-import Control.Monad.Trans.Except.Extra (firstExceptT)
-import Control.Tracer (traceWith)
-import Options.Applicative qualified as Opt
-import Options.Applicative
-import Paths_cardano_tx_generator (version)
+--import System.Exit (exitFailure)
 
-import Cardano.Chain.Genesis qualified as Genesis
-
-import Ouroboros.Network.Block (MaxSlotNo(..))
 import Ouroboros.Network.NodeToClient (IOManager, withIOManager)
 
-import Ouroboros.Consensus.Block.Abstract (BlockProtocol)
-import Ouroboros.Consensus.Cardano (Protocol, ProtocolCardano)
+import Cardano.Benchmarking.GeneratorTx.Benchmark (GeneratorCmd (..), runParser)
+import Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition (CliError(..), runBenchmarkScriptWith)
+import qualified Cardano.Benchmarking.Script as Script (plainOldCliScript, eraTransitionTest)
 
-import Cardano.Api.Protocol qualified as Api
-import Cardano.Api.Typed
-import Cardano.Api.TxSubmit
-import Cardano.Node.Configuration.Logging
-import Cardano.Node.Configuration.POM
-import Cardano.Node.Protocol.Cardano
-import Cardano.Node.Types
+plainOldCliScript :: IO ()
+plainOldCliScript = withIOManager $ \iocp -> do
+  cmd <- runParser "cardano-tx-generator - load Cardano clusters with parametrised transaction flow"
+  runPlainOldCliScript iocp cmd >>= \case
+    Right _  -> pure ()
+    Left err -> print err >> exitFailure
 
-import Cardano.Benchmarking.GeneratorTx
-import Cardano.Benchmarking.GeneratorTx.Benchmark
-import Cardano.Benchmarking.GeneratorTx.Genesis
-import Cardano.Benchmarking.GeneratorTx.CLI.Parsers
-import Cardano.Benchmarking.GeneratorTx.Era
-import Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition
+runPlainOldCliScript :: IOManager -> GeneratorCmd -> IO (Either CliError ())
+runPlainOldCliScript
+  iocp
+  (GenerateTxs
+     logConfigFile
+     socketFile
+     benchmarkEra
+     cliPartialBenchmark
+     nmagic_opt
+     is_addr_mn
+     fundOptions
+  )
+  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile nmagic_opt is_addr_mn
+      $ Script.plainOldCliScript cliPartialBenchmark benchmarkEra fundOptions
 
-data ProtocolError =
-    IncorrectProtocolSpecified  !Api.Protocol
-  | ProtocolInstantiationError  !Text
-  | GenesisBenchmarkRunnerError !TxGenError
-  | ConfigNotFoundError         !FilePath
-  deriving stock Show
+eraTransitionTest :: IO ()
+eraTransitionTest = withIOManager $ \iocp -> do
+  cmd <- runParser "cardano-tx-generator - test era transitioning benchmarks"
+  runEraTransitionTest iocp cmd >>= \case
+    Right _  -> pure ()
+    Left err -> print err >> exitFailure
 
-data CliError =
-    GenesisReadError !FilePath !Genesis.GenesisDataError
-  | GenerateTxsError !ProtocolError
-  | FileNotFoundError !FilePath
-  deriving stock Show
-
-data GeneratorCmd =
-  GenerateTxs FilePath
-              SocketPath
-              AnyCardanoEra
-              PartialBenchmark
-              (Maybe NetworkMagic)
-              Bool
-              GeneratorFunds
-
-parserInfo :: String -> Opt.ParserInfo GeneratorCmd
-parserInfo t =
-  Opt.info
-  (parseCommand Opt.<**> Opt.helper)
-  (Opt.fullDesc <> Opt.header t)
-
-defaultEra :: AnyCardanoEra
-defaultEra = AnyCardanoEra ShelleyEra
-
-parseCommand :: Opt.Parser GeneratorCmd
-parseCommand =
-  GenerateTxs
-    <$> parseConfigFile
-          "config"
-          "Configuration file for the cardano-node"
-    <*> parseSocketPath
-          "socket-path"
-          "Path to a cardano-node socket"
-   <*> ( fromMaybe defaultEra <$>
-         (
-             eraFlag "shelley" ShelleyEra
-         <|> eraFlag "mary"    MaryEra
-         <|> eraFlag "allegra" AllegraEra
-         )
-       )
-    <*> parsePartialBenchmark
-    <*> optional pMagicOverride
-    <*> ( flag False True
-          (long "addr-mainnet" <> help "Override address discriminator to mainnet.")
-        )
-    <*> parseGeneratorFunds
- where
-   pMagicOverride :: Opt.Parser NetworkMagic
-   pMagicOverride =
-     NetworkMagic <$>
-     Opt.option Opt.auto
-     (  Opt.long "n2n-magic-override"
-       <> Opt.metavar "NATURAL"
-       <> Opt.help "Override the network magic for the node-to-node protocol."
-     )
-   eraFlag name tag = flag Nothing (Just $ AnyCardanoEra tag)
-                         (long name <> help ("Initialise Cardano in " ++ name ++" submode."))
-
-runCommand :: GeneratorCmd -> ExceptT CliError IO ()
-runCommand (GenerateTxs logConfigFp
-                        socketFp
-                        benchmarkEra
-                        cliPartialBenchmark
-                        nmagic_opt
-                        is_addr_mn
-                        fundOptions) =
-  withIOManagerE $ \iocp -> do
-    benchmark <- case mkBenchmark (defaultBenchmark <> cliPartialBenchmark) of
-       Left e -> fail $ "Incomplete benchmark spec (is defaultBenchmark complete?):  " <> unpack e
-       Right b -> return b
-    let configFp = ConfigYamlFilePath logConfigFp
-        filesPc = defaultPartialNodeConfiguration
-                  { pncProtocolFiles = Last . Just $
-                    ProtocolFilepaths
-                    { byronCertFile = Just ""
-                    , byronKeyFile = Just ""
-                    , shelleyKESFile = Just ""
-                    , shelleyVRFFile = Just ""
-                    , shelleyCertFile = Just ""
-                    , shelleyBulkCredsFile = Just ""
-                    }
-                  , pncValidateDB = Last $ Just False
-                  , pncShutdownIPC = Last $ Just Nothing
-                  , pncShutdownOnSlotSynced = Last $ Just NoMaxSlotNo
-                  , pncConfigFile = Last $ Just configFp
-                  }
-    configYamlPc <- liftIO . parseNodeConfigurationFP . Just $ configFp
-    nc <- case makeNodeConfiguration $ configYamlPc <> filesPc of
-            Left err -> panic $ "Error in creating the NodeConfiguration: " <> pack err
-            Right nc' -> return nc'
-
-    case ncProtocolConfig nc of
-      NodeProtocolConfigurationByron _    -> error "NodeProtocolConfigurationByron not supported"
-      NodeProtocolConfigurationShelley _  -> error "NodeProtocolConfigurationShelley not supported"
-      NodeProtocolConfigurationCardano byC shC hfC -> firstExceptT GenerateTxsError $ do
-          ptcl :: Protocol IO CardanoBlock ProtocolCardano <- firstExceptT (ProtocolInstantiationError . pack . show) $
-                    mkConsensusProtocolCardano byC shC hfC Nothing
-          loggingLayer <- mkLoggingLayer nc ptcl
-          let tracers :: BenchTracers IO CardanoBlock
-              tracers = createTracers loggingLayer
-              myTracer msg = traceWith (btTxSubmit_ tracers) $ TraceBenchTxSubDebug msg
-
-              runAll :: forall era. IsShelleyBasedEra era => Proxy era -> Benchmark -> GeneratorFunds -> ExceptT TxGenError IO ()
-              runAll = mangleLocalProtocolDefinition ptcl nmagic_opt is_addr_mn iocp socketFp tracers
-          firstExceptT GenesisBenchmarkRunnerError $ case benchmarkEra of
-            AnyCardanoEra ByronEra   -> error "ByronEra not supported"
-            AnyCardanoEra ShelleyEra -> do
-              liftIO $ myTracer "runBenchmark :: ShelleyEra"
-              runAll (Proxy @ ShelleyEra) benchmark fundOptions
-            AnyCardanoEra AllegraEra -> do
-              liftIO $ myTracer "runBenchmark :: AllegraEra"
-              runAll (Proxy @ AllegraEra) benchmark fundOptions
-            AnyCardanoEra MaryEra    -> do
-              liftIO $ myTracer "runBenchmark :: MaryEra"
-              runAll (Proxy @ MaryEra) benchmark fundOptions
-            _ -> return () -- ???? redundant but type error if left out ??
-          liftIO $ do
-            threadDelay (200*1000) -- Let the logging layer print out everything.
-            shutdownLoggingLayer loggingLayer
- where
-   mkLoggingLayer :: NodeConfiguration -> Protocol IO blk (BlockProtocol blk) -> ExceptT ProtocolError IO LoggingLayer
-   mkLoggingLayer nc ptcl =
-     firstExceptT (\(ConfigErrorFileNotFound fp) -> ConfigNotFoundError fp) $
-       createLoggingLayer (pack $ showVersion version) nc ptcl
-
-----------------------------------------------------------------------------
-
-withIOManagerE :: (IOManager -> ExceptT e IO a) -> ExceptT e IO a
-withIOManagerE k = ExceptT $ withIOManager (runExceptT . k)
-
-instance Prelude.Show (TxForMode a) where
-  show = \case
-    TxForByronMode          tx  -> Prelude.show tx
-    TxForShelleyMode        tx  -> Prelude.show tx
-    TxForCardanoMode (InAnyCardanoEra _ tx)  -> Prelude.show tx
+runEraTransitionTest :: IOManager -> GeneratorCmd -> IO (Either CliError ())
+runEraTransitionTest
+  iocp
+  (GenerateTxs
+     logConfigFile
+     socketFile
+     _benchmarkEra
+     cliPartialBenchmark
+     nmagic_opt
+     is_addr_mn
+     fundOptions
+  )
+  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile nmagic_opt is_addr_mn
+      $ Script.eraTransitionTest cliPartialBenchmark fundOptions

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Cardano.Benchmarking.Script
+  (
+    plainOldCliScript
+  , eraTransitionTest
+  ) where
+
+import Prelude (error)
+import Cardano.Prelude hiding (option)
+import Data.Text (unpack)
+import qualified Data.List.NonEmpty as NE
+
+import Control.Tracer (traceWith)
+
+import Cardano.Api.Typed
+
+import Cardano.Benchmarking.GeneratorTx.Benchmark
+import Cardano.Benchmarking.GeneratorTx (readSigningKey)
+import Cardano.Benchmarking.DSL
+import Cardano.Benchmarking.GeneratorTx.Era
+import Cardano.Benchmarking.GeneratorTx.Error (TxGenError(..))
+
+plainOldCliScript :: PartialBenchmark -> AnyCardanoEra -> GeneratorFunds -> BenchmarkScript ()
+plainOldCliScript cliPartialBenchmark benchmarkEra (FundsGenesis keyFile) (tracers, dslSet) = do
+  case benchmarkEra of
+      AnyCardanoEra ByronEra   -> error "ByronEra not supported"
+      AnyCardanoEra ShelleyEra -> do
+        myTracer "POScript :: ShelleyEra"
+        genericScript $ getDSL dslSet ShelleyEra
+      AnyCardanoEra AllegraEra -> do
+        myTracer "POScript  :: AllegraEra"
+        genericScript $ getDSL dslSet AllegraEra
+      AnyCardanoEra MaryEra    -> do
+        myTracer "POScript  :: MaryEra"
+        genericScript $ getDSL dslSet MaryEra
+  where
+    myTracer msg = liftIO $ traceWith (btTxSubmit_ tracers) $ TraceBenchTxSubDebug msg
+    genericScript :: forall era. DSL era -> ExceptT TxGenError IO ()
+    genericScript (DSL{..}) = do
+      b <- case mkBenchmark (defaultBenchmark <> cliPartialBenchmark) of
+         Left e -> error $ "Incomplete benchmark spec (is defaultBenchmark complete?):  " <> unpack e
+         Right b -> return b
+      let
+        fees = bTxFee b
+        coolDownDelay = bInitCooldown b
+
+      key <- readSigningKey keyFile
+      let
+        globalOutAddr = keyAddress key    -- A globalOutAddr is used for all TXs in the generator.
+
+      myTracer "POScript: securing funds"
+      firstUTxO <- secureGenesisFund fees (bInitialTTL b) key globalOutAddr
+
+      myTracer $ "******* Tx generator: waiting for first UTxO" ++ show coolDownDelay ++ "s *******"
+      coolDown coolDownDelay
+      funds <- splitFunds fees (bTxCount b) (bTxFanIn b) key globalOutAddr firstUTxO
+      myTracer $ "******* Tx generator: waiting for funds split" ++ show coolDownDelay ++ "s *******"
+      coolDown coolDownDelay
+
+      myTracer "POScript: pre-computing transactions"
+      finalTransactions <- txGenerator b globalOutAddr key (fromIntegral $ NE.length $ bTargets b) funds
+
+      myTracer "POScript: sending transactions"
+      runBenchmark (bTargets b) (bTps b) (bErrorPolicy b) finalTransactions
+
+eraTransitionTest :: PartialBenchmark -> GeneratorFunds -> BenchmarkScript ()
+eraTransitionTest cliPartialBenchmark (FundsGenesis keyFile) (tracers, dslSet) = do
+      b <- case mkBenchmark (defaultBenchmark <> cliPartialBenchmark) of
+         Left e -> error $ "Incomplete benchmark spec (is defaultBenchmark complete?):  " <> unpack e
+         Right b -> return b
+      let
+        fees = bTxFee b
+        coolDownDelay = bInitCooldown b
+
+      key <- readSigningKey keyFile
+      let
+        addr_shelley :: AddressInEra ShelleyEra
+        addr_shelley = keyAddress key
+
+        addr_mary :: AddressInEra MaryEra
+        addr_mary = keyAddress_mary key
+
+      myTracer "POScript: securing funds"
+
+      firstUTxO <- secureGenesisFund fees (bInitialTTL b) key addr_shelley
+
+      myTracer $ "******* Tx generator: waiting for first UTxO" ++ show coolDownDelay ++ "s *******"
+      coolDown coolDownDelay
+      [fund1,fund2] <- splitFunds fees 2 (bTxFanIn b) key addr_shelley firstUTxO
+      funds_shelley <- splitFunds fees (bTxCount b) (bTxFanIn b) key addr_shelley fund1
+      funds_mary   <- splitFunds fees (bTxCount b) (bTxFanIn b) key addr_shelley fund2
+
+      myTracer $ "******* Tx generator: waiting for funds split" ++ show coolDownDelay ++ "s *******"
+      coolDown coolDownDelay
+
+      myTracer "POScript: pre-computing transactions Shelley"
+      tx1 <- txGenerator b addr_shelley key (fromIntegral $ NE.length $ bTargets b) funds_shelley
+      myTracer "POScript: sending transactions Shelley"
+      runBenchmark (bTargets b) (bTps b) (bErrorPolicy b) tx1
+
+      myTracer "POScript: pre-computing transactions Mary"
+      (tx2 :: [Tx MaryEra]) <- txGenerator_mary b addr_mary key (fromIntegral $ NE.length $ bTargets b) funds_mary
+      myTracer "POScript: sending transactions Mary"
+      runBenchmark_mary (bTargets b) (bTps b) (bErrorPolicy b) tx2
+  where
+    DSL {..} = getDSL dslSet ShelleyEra
+    DSL {
+      runBenchmark = runBenchmark_mary
+     , txGenerator  = txGenerator_mary
+     , keyAddress   = keyAddress_mary
+--     , secureGenesisFund = secureGenesisFund_mary
+--     , splitFunds        = splitFunds_mary
+     } =getDSL dslSet MaryEra
+
+    myTracer msg = liftIO $ traceWith (btTxSubmit_ tracers) $ TraceBenchTxSubDebug msg

--- a/cardano-tx-generator/test/Main.hs
+++ b/cardano-tx-generator/test/Main.hs
@@ -8,7 +8,7 @@ import           Test.Tasty.HUnit
 import           Text.Heredoc
 import           Options.Applicative
   
-import           Cardano.Benchmarking.Run (parseCommand)
+import           Cardano.Benchmarking.GeneratorTx.Benchmark (parseCommand)
 import           Cardano.Benchmarking.GeneratorTx.SizedMetadata
 
 


### PR DESCRIPTION
This PR adds a proof of concept for running benchmarks across era transitions.
Also this adds:
* Small self-contained benchmark scripts (see `Script.hs`).
* Better reusable building blocks for benchmark scripts.
* Reusable `with` -style wrapper for initialization/ running scripts.
* Demotion of the big `Benchmark` type (which used to be passed to many functions.)
  (Now functions only have those arguments that are needed, which makes them easier to call) 