### PR TITLE
CAD-2672 CLI cleanup

### DIFF
--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
@@ -283,8 +283,6 @@ data GeneratorCmd =
               SocketPath
               AnyCardanoEra
               PartialBenchmark
-              (Maybe NetworkMagic)
-              Bool
               GeneratorFunds
 
 parserInfo :: String -> Opt.ParserInfo GeneratorCmd
@@ -313,20 +311,8 @@ parseCommand =
          )
        )
     <*> parsePartialBenchmark
-    <*> optional pMagicOverride
-    <*> ( flag False True
-          (long "addr-mainnet" <> help "Override address discriminator to mainnet.")
-        )
     <*> parseGeneratorFunds
  where
-   pMagicOverride :: Opt.Parser NetworkMagic
-   pMagicOverride =
-     NetworkMagic <$>
-     Opt.option Opt.auto
-     (  Opt.long "n2n-magic-override"
-       <> Opt.metavar "NATURAL"
-       <> Opt.help "Override the network magic for the node-to-node protocol."
-     )
    eraFlag name tag = flag Nothing (Just $ AnyCardanoEra tag)
                          (long name <> help ("Initialise Cardano in " ++ name ++" submode."))
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Run.hs
@@ -35,11 +35,9 @@ runPlainOldCliScript
      socketFile
      benchmarkEra
      cliPartialBenchmark
-     nmagic_opt
-     is_addr_mn
      fundOptions
   )
-  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile nmagic_opt is_addr_mn
+  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile
       $ Script.plainOldCliScript cliPartialBenchmark benchmarkEra fundOptions
 
 eraTransitionTest :: IO ()
@@ -57,9 +55,7 @@ runEraTransitionTest
      socketFile
      _benchmarkEra
      cliPartialBenchmark
-     nmagic_opt
-     is_addr_mn
      fundOptions
   )
-  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile nmagic_opt is_addr_mn
+  = runExceptT $ runBenchmarkScriptWith iocp logConfigFile socketFile
       $ Script.eraTransitionTest cliPartialBenchmark fundOptions

--- a/cardano-tx-generator/test/Main.hs
+++ b/cardano-tx-generator/test/Main.hs
@@ -60,8 +60,7 @@ pinnedHelpMessage = [here|ParserFailure(Usage: <program> --config FILEPATH --soc
                  [--init-cooldown INT] [--initial-ttl INT] [--num-of-txs INT] 
                  [--tps DOUBLE] [--inputs-per-tx INT] [--outputs-per-tx INT] 
                  [--tx-fee INT] [--add-tx-size INT] 
-                 [--fail-on-submission-errors] [--n2n-magic-override NATURAL] 
-                 [--addr-mainnet] 
+                 [--fail-on-submission-errors] 
                  (--genesis-funds-key FILEPATH | --utxo-funds-key FILEPATH
                    --tx-in TX-IN --tx-out TX-OUT |
                    --split-utxo-funds-key FILEPATH --split-utxo FILEPATH)
@@ -86,10 +85,6 @@ Available options:
   --fail-on-submission-errors
                            Fail on submission thread errors, instead of logging
                            them.
-  --n2n-magic-override NATURAL
-                           Override the network magic for the node-to-node
-                           protocol.
-  --addr-mainnet           Override address discriminator to mainnet.
   --genesis-funds-key FILEPATH
                            Genesis UTxO funds signing key.
   --utxo-funds-key FILEPATH


### PR DESCRIPTION
Remove the following CLI arguments:
`(long "addr-mainnet" <> help "Override address discriminator to mainnet.")`
```
(  Opt.long "n2n-magic-override"
￼       <> Opt.metavar "NATURAL"
￼       <> Opt.help "Override the network magic for the node-to-node protocol."
￼     )
```
These arguments are no longer needed.