### PR TITLE
CAD-2860 locli:  rHeap in the node

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -84,17 +84,22 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: d1f52161a736e0e0cf42bfc23ad5d94a5a530942
-  --sha256: 19diqm96v4cj2lsa92wgsdiyzk74jwkkd5y3sajdgxm85khk8lnk
+  tag: e5910dbb1023798ec96b00ccc93ce1f5122ac1cd
+  --sha256: 0180jga2m4yjg5k1421kf94l5pm4wzlnnvidi0kw5c1wfz7pfalm
   subdir:
     cardano-api
     cardano-api/test
     cardano-cli
     cardano-config
     cardano-node
-    hedgehog-extras
 
 ---------- >8 -----------
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/hedgehog-extras
+  tag: 8bcd3c9dc22cc44f9fcfe161f4638a384fc7a187
+  --sha256: 12viwpahjdfvlqpnzdgjp40nw31rvyznnab1hml9afpaxd6ixh70
 
 source-repository-package
   type: git
@@ -152,8 +157,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 60b13d80afa266f02f363672950e896ed735e807
-  --sha256: 0gci6r4c6ldrgracbr4fni4hbrl62lmm5p70cafkwk21a0kqs8cz
+  tag: bf3b4336dfd202fe0b5e765cdaa97788674e456c
+  --sha256: 1ilq7yq8a3mpy21fiqharx7vs2b555n78gf7m48kkd0pl58vq759
   subdir:
     contra-tracer
     iohk-monitoring
@@ -166,9 +171,15 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/Win32-network
+  tag: 94153b676617f8f33abe8d8182c37377d2784bd1
+  --sha256: 0pb7bg0936fldaa5r08nqbxvi2g8pcy4w3c7kdcg7pdgmimr30ss
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1ab4ded9eb5a6e7dec9bdd1869506f6a6eb73f42
-  --sha256: 1h1hwpww6b8c8hggr9x70417bs432glzhdfzdd7bvzhlc32lb30m
+  tag: 7f90c8c59ffc7d61a4e161e886d8962a9c26787a
+  --sha256: 0hnw6hvbyny3wniaqw8d37l4ysgp8xrq5d84fapxfm525a4hfs0x
   subdir:
     io-sim
     io-sim-classes
@@ -181,7 +192,6 @@ source-repository-package
     ouroboros-network-framework
     typed-protocols
     typed-protocols-examples
-    Win32-network
 
 constraints:
     hedgehog >= 1.0

--- a/locli/src/Cardano/Unlog/Resources.hs
+++ b/locli/src/Cardano/Unlog/Resources.hs
@@ -34,9 +34,10 @@ mkResAccums =
   , rCentiMut    = mkAccumTicksShare
   , rGcsMajor    = mkAccumDelta
   , rGcsMinor    = mkAccumDelta
-  , rAlloc       = mkAccumDelta `divAccum` 1024
-  , rLive        = mkAccumNew   `divAccum` 1024
-  , rRSS         = mkAccumNew   `divAccum` 1024
+  , rRSS         = mkAccumNew   `divAccum` 1048576
+  , rHeap        = mkAccumNew   `divAccum` 1048576
+  , rLive        = mkAccumNew   `divAccum` 1048576
+  , rAlloc       = mkAccumDelta `divAccum` 1048576
   , rCentiBlkIO  = mkAccumTicksShare
   , rThreads     = mkAccumNew
   }
@@ -74,9 +75,10 @@ discardObsoleteValues =
   , rCentiMut    = Just
   , rGcsMajor    = const Nothing
   , rGcsMinor    = const Nothing
-  , rAlloc       = const Nothing
-  , rLive        = Just
   , rRSS         = Just
+  , rHeap        = Just
+  , rLive        = Just
+  , rAlloc       = const Nothing
   , rCentiBlkIO  = Just
   , rThreads     = Just
   }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,42 +1,38 @@
 { system ? builtins.currentSystem
 , crossSystem ? null
 , config ? {}
-, sourcesOverride ? {}
-, gitrev ? null
-}:
-let
-  sources = import ./sources.nix { inherit pkgs; }
-    // sourcesOverride;
-  iohkNixMain = import sources.iohk-nix {};
-  haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
-  nixpkgs = if (sources ? nixpkgs)
+, nixpkgs ? if (sources ? nixpkgs)
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
-    else iohkNixMain.nixpkgs;
-
+    else iohkNix.nixpkgs
+, sourcesOverride ? {}
+, sources ? import ./sources.nix { pkgs = import nixpkgs { inherit system; }; } // sourcesOverride
+, gitrev ? null
+, iohkNix ? import sources.iohk-nix { inherit system; }
+, haskellNix ? (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs
+}:
+let
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohkNixMain.overlays.haskell-nix-extra
-    ++ iohkNixMain.overlays.crypto
+    ++ iohkNix.overlays.haskell-nix-extra
+    ++ iohkNix.overlays.crypto
     # iohkNix: nix utilities and niv:
-    ++ iohkNixMain.overlays.iohkNix
+    ++ iohkNix.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {
         inherit gitrev;
 
         # commonLib: mix pkgs.lib with iohk-nix utils and our own:
-        commonLib = lib // iohkNix // iohkNix.cardanoLib
+        commonLib = lib // pkgs.iohkNix // pkgs.iohkNix.cardanoLib
           // import ./util.nix { inherit haskell-nix; }
           # also expose our sources, nixpkgs and overlays
-        // { inherit overlays sources nixpkgs; };
-
-        svcLib = import ./svclib.nix { inherit pkgs; };
+          // { inherit overlays sources nixpkgs; };
       })
       # And, of course, our haskell-nix-ified cabal project:
       (import ./pkgs.nix)

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,7 @@
 # our packages overlay
 pkgs: _: with pkgs;
   let
-    compiler = config.haskellNix.compiler or "ghc8102";
+    compiler = config.haskellNix.compiler or "ghc8104";
   in {
   cardanoBenchmarkingHaskellPackages = import ./haskell.nix {
     inherit compiler

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "d1f52161a736e0e0cf42bfc23ad5d94a5a530942",
-        "sha256": "19diqm96v4cj2lsa92wgsdiyzk74jwkkd5y3sajdgxm85khk8lnk",
+        "rev": "e5910dbb1023798ec96b00ccc93ce1f5122ac1cd",
+        "sha256": "0180jga2m4yjg5k1421kf94l5pm4wzlnnvidi0kw5c1wfz7pfalm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/d1f52161a736e0e0cf42bfc23ad5d94a5a530942.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/e5910dbb1023798ec96b00ccc93ce1f5122ac1cd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {


### PR DESCRIPTION
1. bump the node and `iohk-monitoring` for the new `rHeap` resource metric
2. `rHeap` processing in `locli`
3. rescale the memory usage to MiB, instead of KiB