### PR TITLE
CAD-2772 making tx-generator node-ready

### DIFF
--- a/benchmarks/shelley3pools/tx-generator-script.json
+++ b/benchmarks/shelley3pools/tx-generator-script.json
@@ -25,8 +25,8 @@
             { "addr": "127.0.0.1", "port": 3002 }
         ] },
     { "asyncBenchmark": "allegraThread", "txList": "allegraTxs" },
-    { "waitForEra": "MaryEra" },
-    { "setEra": "MaryEra" },
+    { "waitForEra": "Mary" },
+    { "setEra": "Mary" },
     { "prepareTxList": "maryTxs", "newKey": "pass-partout", "fundList": "maryFunds" },
     { "cancelBenchmark": "allegraThread" },
     { "asyncBenchmark": "maryThread", "txList": "maryTxs" },

--- a/cardano-tx-generator/cardano-tx-generator.cabal
+++ b/cardano-tx-generator/cardano-tx-generator.cabal
@@ -21,7 +21,7 @@ library
                         -Wno-unticked-promoted-constructors
                         -Wpartial-fields
                         -Wredundant-constraints
-                        -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+                        -Wwarn=deprecations
 
   exposed-modules:
                        Cardano.Benchmarking.CliArgsScript

--- a/cardano-tx-generator/src/Cardano/Benchmarking/CliArgsScript.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/CliArgsScript.hs
@@ -1,3 +1,6 @@
+{- HLINT ignore "Use record patterns" -}
+{- HLINT ignore "Redundant bracket" -}
+{- HLINT ignore "Reduce duplication" -}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Command.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Command.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations -Wno-orphans #-}
 
 module Cardano.Benchmarking.Command

--- a/cardano-tx-generator/src/Cardano/Benchmarking/DSL.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/DSL.hs
@@ -1,11 +1,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Benchmarking.DSL
 where

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -48,7 +46,7 @@ import           Cardano.Node.Types
 
 import           Ouroboros.Consensus.Shelley.Eras (StandardShelley)
 
-import           Cardano.Api
+import           Cardano.Api hiding (txFee)
 
 import           Cardano.Benchmarking.Types
 import           Cardano.Benchmarking.GeneratorTx.Error
@@ -112,7 +110,7 @@ splitFunds  :: forall era. IsShelleyBasedEra era
   -> Lovelace
   -> NumberOfTxs
   -> NumberOfInputsPerTx
-  -> (SigningKey PaymentKey)
+  -> SigningKey PaymentKey
   -> AddressInEra era
   -> Fund
   -> ExceptT TxGenError IO [Fund]
@@ -220,7 +218,7 @@ splitFunds
 -----------------------------------------------------------------------------------------
 
 -- This is the entry point for the CLI args tx-generator
-{-# DEPRECATED runBenchmark "to be removed: use asyncBenchmark instead" #-}
+-- {-# DEPRECATED runBenchmark "to be removed: use asyncBenchmark instead" #-}
 runBenchmark :: forall era. IsShelleyBasedEra era
   => Tracer IO (TraceBenchTxSubmit TxId)
   -> Tracer IO NodeToNodeSubmissionTrace

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Benchmark.hs
@@ -1,8 +1,7 @@
+{- HLINT ignore "Move brackets to avoid $" -}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/LocalProtocolDefinition.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition
   ( CliError (..)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/SizedMetadata.hs
@@ -1,3 +1,5 @@
+{- HLINT ignore "Use camelCase" -}
+{- HLINT ignore "Use uncurry" -}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
@@ -69,7 +71,7 @@ measureMapCosts :: forall era . IsShelleyBasedEra era => AsType era -> [Int]
 measureMapCosts era = map (metadataSize era . Just . replicateEmptyBS) [0..maxMapSize]
  where
   replicateEmptyBS :: Int -> TxMetadata
-  replicateEmptyBS n = listMetadata $ replicate n $ TxMetaBytes $ BS.empty
+  replicateEmptyBS n = listMetadata $ replicate n $ TxMetaBytes BS.empty
 
 listMetadata :: [TxMetadataValue] -> TxMetadata
 listMetadata l = makeTransactionMetadata $ Map.fromList $ zip [0..] l
@@ -91,8 +93,8 @@ dummyTxSizeInEra metadata = case makeTransactionBody dummyTx of
   dummyTx = TxBodyContent {
       txIns = [ TxIn "dbaff4e270cfb55612d9e2ac4658a27c79da4a5271c6f90853042d1403733810" (TxIx 0) ]
     , txOuts = []
-    , txFee = mkFee $ fromInteger 0
-    , txValidityRange = (TxValidityNoLowerBound, mkValidityUpperBound $ fromInteger 0)
+    , txFee = mkFee 0
+    , txValidityRange = (TxValidityNoLowerBound, mkValidityUpperBound 0)
     , txMetadata = metadata
     , txAuxScripts = TxAuxScriptsNone
     , txWithdrawals = TxWithdrawalsNone

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Submission.hs
@@ -4,13 +4,11 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -35,9 +33,8 @@ module Cardano.Benchmarking.GeneratorTx.Submission
   , tpsLimitedTxFeederShutdown
   ) where
 
-import           Prelude (error)
+import           Prelude (String, error, fail)
 import           Cardano.Prelude hiding (ByteString, atomically, retry, threadDelay)
-import           Prelude (String, fail)
 
 import           Control.Arrow ((&&&))
 import           Control.Concurrent (threadDelay)

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx.hs
@@ -1,10 +1,8 @@
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 
 module Cardano.Benchmarking.GeneratorTx.Tx
@@ -52,7 +50,7 @@ keyAddress networkId k
       (PaymentCredentialByKey $ verificationKeyHash $ getVerificationKey k)
       NoStakeAddress
 
-{-# DEPRECATED mkGenesisTransaction "to be removed" #-}
+--{-# DEPRECATED mkGenesisTransaction "to be removed" #-}
 mkGenesisTransaction :: forall era .
      IsShelleyBasedEra era
   => SigningKey GenesisUTxOKey
@@ -182,7 +180,7 @@ mkTransactionGen signingKey inputs address payments metadata fee =
   offsetMap = Map.fromList $ zipWith (\payment index -> (fst payment, TxIx index))
                                      payments
                                      [0..]
-  txOutSum :: [(TxOut era)] -> Lovelace
+  txOutSum :: [ TxOut era ] -> Lovelace
   txOutSum l = sum $ map toVal l
 
   toVal (TxOut _ val) = txOutValueToLovelace val

--- a/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx/Byron.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/GeneratorTx/Tx/Byron.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations -Wextra #-}

--- a/cardano-tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/OuroborosImports.hs
@@ -1,3 +1,4 @@
+{- HLINT ignore "Eta reduce" -}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -1,14 +1,13 @@
-{-# LANGUAGE DeriveGeneric #-}
+{- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use uncurry" -}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-} --
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -56,7 +55,7 @@ withEra action = do
 
 startProtocol :: FilePath -> ActionM ()
 startProtocol filePath = do
-  (liftIO $ runExceptT $ Core.startProtocol filePath) >>= \case
+  liftIO (runExceptT $ Core.startProtocol filePath) >>= \case
     Left err -> throwE $ CliError err
     Right (loggingLayer, protocol) -> do
       set LoggingLayer loggingLayer
@@ -67,7 +66,7 @@ startProtocol filePath = do
 
 readSigningKey :: KeyName -> SigningKeyFile -> ActionM ()
 readSigningKey name filePath =
-  (liftIO $ runExceptT $ Core.readSigningKey filePath) >>= \case
+  liftIO ( runExceptT $ Core.readSigningKey filePath) >>= \case
     Left err -> liftTxGenError err
     Right key -> setName name key
 
@@ -207,7 +206,7 @@ asyncBenchmarkCore (ThreadName threadName) transactions = do
     Right ctl -> return ctl
 
 
-{-# DEPRECATED runBenchmark "to be removed: use asynBenchmark" #-}
+--{-# DEPRECATED runBenchmark "to be removed: use asynBenchmark" #-}
 runBenchmark :: TxListName -> ActionM ()
 runBenchmark transactions = asyncBenchmarkCore (ThreadName "UnlabeledThread") transactions >>= waitBenchmarkCore
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Env.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Env.hs
@@ -1,10 +1,8 @@
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -64,7 +62,7 @@ liftTxGenError :: TxGenError -> ActionM a
 liftTxGenError = throwE . TxGenError
 
 askIOManager :: ActionM IOManager
-askIOManager = lift $ RWS.ask
+askIOManager = lift RWS.ask
 
 set :: Store v -> v -> ActionM ()
 set key val = lift $ RWS.modify $ DMap.insert key (pure val)
@@ -77,7 +75,7 @@ setName = set . Named
 
 get :: Store v -> ActionM v
 get key = do
-  (lift $ RWS.gets $ DMap.lookup key) >>= \case
+  lift (RWS.gets $ DMap.lookup key) >>= \case
     Just (Identity v) -> return v
     Nothing -> throwE $ LookupError key
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 module Cardano.Benchmarking.Script.Example
 where
 
@@ -34,7 +33,7 @@ txConfig = map Set [
   , TNumberOfTxs          ==> NumberOfTxs 500
   , TTPSRate              ==> TPSRate 10
   , TTxAdditionalSize     ==> TxAdditionalSize 0
-  , TFee                  ==> (quantityToLovelace $ Quantity 0)
+  , TFee                  ==> quantityToLovelace (Quantity 0)
   , TTTL                  ==> SlotNo 1000000
   ]
 

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -75,14 +75,14 @@ taggedToSum x = case x of
 
 sumToTaggged :: Applicative f => Sum -> DSum Tag f
 sumToTaggged x = case x of
-  SInitCooldown         v -> (TInitCooldown         ==> v)
-  SNumberOfInputsPerTx  v -> (TNumberOfInputsPerTx  ==> v)
-  SNumberOfOutputsPerTx v -> (TNumberOfOutputsPerTx ==> v)
-  SNumberOfTxs          v -> (TNumberOfTxs          ==> v)
-  STPSRate              v -> (TTPSRate              ==> v)
-  SFee                  v -> (TFee                  ==> v)
-  STTL                  v -> (TTTL                  ==> v)
-  STxAdditionalSize     v -> (TTxAdditionalSize     ==> v)
-  SLocalSocket          v -> (TLocalSocket          ==> v)
-  SEra                  v -> (TEra                  ==> v)
-  STargets              v -> (TTargets              ==> v)
+  SInitCooldown         v -> TInitCooldown         ==> v
+  SNumberOfInputsPerTx  v -> TNumberOfInputsPerTx  ==> v
+  SNumberOfOutputsPerTx v -> TNumberOfOutputsPerTx ==> v
+  SNumberOfTxs          v -> TNumberOfTxs          ==> v
+  STPSRate              v -> TTPSRate              ==> v
+  SFee                  v -> TFee                  ==> v
+  STTL                  v -> TTTL                  ==> v
+  STxAdditionalSize     v -> TTxAdditionalSize     ==> v
+  SLocalSocket          v -> TLocalSocket          ==> v
+  SEra                  v -> TEra                  ==> v
+  STargets              v -> TTargets              ==> v

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Tracer.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Tracer.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -25,7 +24,6 @@ module Cardano.Benchmarking.Tracer
   ) where
 
 import           Prelude (Show(..), String)
-import           Data.Time.Clock (NominalDiffTime)
 
 import           Cardano.Prelude hiding (TypeError, show)
 
@@ -35,7 +33,7 @@ import           Data.Aeson (ToJSON (..), (.=))
 import qualified Data.Aeson as A
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
-import           Data.Time.Clock (DiffTime, getCurrentTime)
+import           Data.Time.Clock (DiffTime, NominalDiffTime, getCurrentTime)
 
 -- Mode-agnostic imports.
 import           Cardano.BM.Data.Tracer

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Types.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-all-missed-specialisations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}

--- a/cardano-tx-generator/test/Main.hs
+++ b/cardano-tx-generator/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE Trustworthy #-}
 module Main (main) where
 
 import           Prelude


### PR DESCRIPTION
Updates for the `tx-generator` to make it read for `cardano-node`.
Fixes suggested by hlint.