### PR TITLE
Cleanup script language

### DIFF
--- a/benchmarks/shelley3pools/tx-generator-script.json
+++ b/benchmarks/shelley3pools/tx-generator-script.json
@@ -1,9 +1,7 @@
 [
-    { "setInitCooldown": 10 },
     { "setNumberOfInputsPerTx": 1 },
     { "setNumberOfOutputsPerTx": 1 },
     { "setNumberOfTxs": 3000 },
-    { "setTPSRate": 10 },
     { "setTxAdditionalSize": 0 },
     { "setFee": 0 },
     { "setTTL": 1000000 },
@@ -12,9 +10,9 @@
     { "setLocalSocket": "logs/sockets/1" },
     { "readSigningKey": "pass-partout", "filePath": "configuration/genesis-shelley/utxo-keys/utxo1.skey" },
     { "secureGenesisFund": "genFund", "genesisKey": "pass-partout", "fundKey": "pass-partout" },
-    { "delay": null },
+    { "delay": 10 },
     { "splitFund": [ "fund1", "fund2", "fund3","fund4" ], "sourceFund": "genFund", "newKey": "pass-partout" },
-    { "delay": null },
+    { "delay": 10 },
     { "splitFundToList": "allegraFunds", "sourceFund": "fund1", "newKey": "pass-partout" },
     { "prepareTxList": "allegraTxs", "newKey": "pass-partout", "fundList": "allegraFunds" },
     { "splitFundToList": "maryFunds", "sourceFund": "fund2", "newKey": "pass-partout" },
@@ -24,11 +22,11 @@
             { "addr": "127.0.0.1", "port": 3001 },
             { "addr": "127.0.0.1", "port": 3002 }
         ] },
-    { "asyncBenchmark": "allegraThread", "txList": "allegraTxs" },
+    { "asyncBenchmark": "allegraThread", "txList": "allegraTxs", "tps": 10 },
     { "waitForEra": "Mary" },
     { "setEra": "Mary" },
     { "prepareTxList": "maryTxs", "newKey": "pass-partout", "fundList": "maryFunds" },
     { "cancelBenchmark": "allegraThread" },
-    { "asyncBenchmark": "maryThread", "txList": "maryTxs" },
+    { "asyncBenchmark": "maryThread", "txList": "maryTxs", "tps": 10 },
     { "waitBenchmark": "maryThread" }
 ]

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -27,7 +27,7 @@ data Action where
   Set                :: !SetKeyVal -> Action
 --  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
   StartProtocol      :: !FilePath -> Action
-  Delay              :: Action
+  Delay              :: !Double ->Action
   ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
   SecureGenesisFund  :: !FundName -> !KeyName -> !KeyName -> Action
   SplitFund          :: [FundName] -> !KeyName -> !FundName -> Action
@@ -51,7 +51,7 @@ action a = case a of
   SecureGenesisFund fundName fundKey genesisKey -> secureGenesisFund fundName fundKey genesisKey
   SplitFund newFunds newKey sourceFund -> splitFund  newFunds newKey sourceFund
   SplitFundToList fundList destKey sourceFund -> splitFundToList fundList destKey sourceFund
-  Delay -> delay
+  Delay t -> delay t
   PrepareTxList name key fund -> prepareTxList name key fund
   RunBenchmark txs -> runBenchmark txs -- Obsolete. Use AsyncBenchmark.
   AsyncBenchmark thread txs -> asyncBenchmark thread txs

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Action.hs
@@ -22,19 +22,19 @@ import           Cardano.Api (AnyCardanoEra)
 import           Cardano.Benchmarking.Script.Env
 import           Cardano.Benchmarking.Script.Store
 import           Cardano.Benchmarking.Script.Core
+import           Cardano.Benchmarking.Types (TPSRate)
 
 data Action where
   Set                :: !SetKeyVal -> Action
 --  Declare            :: SetKeyVal   -> Action --declare (once): error if key was set before
   StartProtocol      :: !FilePath -> Action
-  Delay              :: !Double ->Action
+  Delay              :: !Double -> Action
   ReadSigningKey     :: !KeyName -> !SigningKeyFile -> Action
   SecureGenesisFund  :: !FundName -> !KeyName -> !KeyName -> Action
   SplitFund          :: [FundName] -> !KeyName -> !FundName -> Action
   SplitFundToList    :: !FundListName -> !KeyName -> !FundName -> Action
   PrepareTxList      :: !TxListName -> !KeyName -> !FundListName -> Action
-  RunBenchmark       :: !TxListName -> Action --Obsolete
-  AsyncBenchmark     :: !ThreadName -> !TxListName -> Action
+  AsyncBenchmark     :: !ThreadName -> !TxListName -> TPSRate -> Action
   WaitBenchmark      :: !ThreadName -> Action
   CancelBenchmark    :: !ThreadName -> Action
   Reserved           :: [String] -> Action
@@ -53,8 +53,7 @@ action a = case a of
   SplitFundToList fundList destKey sourceFund -> splitFundToList fundList destKey sourceFund
   Delay t -> delay t
   PrepareTxList name key fund -> prepareTxList name key fund
-  RunBenchmark txs -> runBenchmark txs -- Obsolete. Use AsyncBenchmark.
-  AsyncBenchmark thread txs -> asyncBenchmark thread txs
+  AsyncBenchmark thread txs tps -> asyncBenchmark thread txs tps
   WaitBenchmark thread -> waitBenchmark thread
   CancelBenchmark thread -> cancelBenchmark thread
   WaitForEra era -> waitForEra era

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Aeson.hs
@@ -78,7 +78,7 @@ actionToJSON a = case a of
     where names = [n | FundName n <- newFunds]
   SplitFundToList (FundListName fundList) (KeyName destKey) (FundName sourceFund)
     -> object ["splitFundToList" .= fundList, "newKey" .= destKey, "sourceFund" .= sourceFund ]
-  Delay -> singleton "delay" Null
+  Delay t -> object ["delay" .= t ]
   PrepareTxList (TxListName name) (KeyName key) (FundListName fund)
     -> object ["prepareTxList" .= name, "newKey" .= key, "fundList" .= fund ]
   RunBenchmark (TxListName txs) -> singleton "runBenchmark" txs
@@ -116,9 +116,7 @@ objectToAction obj = case obj of
   (HashMap.lookup "secureGenesisFund" -> Just v) -> parseSecureGenesisFund v
   (HashMap.lookup "splitFund"         -> Just v) -> parseSplitFund v
   (HashMap.lookup "splitFundToList"   -> Just v) -> parseSplitFundToList v
-  (HashMap.lookup "delay"             -> Just v) -> case v of
-    Null -> return Delay
-    _ -> typeMismatch "Delay" v
+  (HashMap.lookup "delay"             -> Just v) -> Delay <$> parseJSON v
   (HashMap.lookup "prepareTxList"     -> Just v) -> parsePrepareTxList v
   (HashMap.lookup "runBenchmark"      -> Just v)
     -> (withText "Error parsing runBenchmark" $ \t -> return $ RunBenchmark $ TxListName $ Text.unpack t) v

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Core.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Core.hs
@@ -28,7 +28,7 @@ import           Cardano.Api ( AsType(..), CardanoEra(..), InAnyCardanoEra(..), 
                              , chainTipToChainPoint )
 import           Cardano.Benchmarking.GeneratorTx as Core
                    (AsyncBenchmarkControl, asyncBenchmark, waitBenchmark, readSigningKey, secureGenesisFund, splitFunds, txGenerator, TxGenError)
-import           Cardano.Benchmarking.Types as Core (NumberOfTxs(..), InitCooldown(..), SubmissionErrorPolicy(..))
+import           Cardano.Benchmarking.Types as Core (NumberOfTxs(..), SubmissionErrorPolicy(..))
 import           Cardano.Benchmarking.GeneratorTx.Tx as Core (keyAddress)
 import           Cardano.Benchmarking.GeneratorTx.LocalProtocolDefinition as Core (startProtocol)
 import           Cardano.Benchmarking.GeneratorTx.NodeToNode (ConnectClient, benchmarkConnectTxSubmit)
@@ -139,10 +139,8 @@ splitFundToList newFunds destKey sourceFund = do
   funds <- splitFundN count destKey sourceFund
   setName newFunds funds
 
-delay :: ActionM ()
-delay = do
-  (InitCooldown t) <- getUser TInitCooldown
-  liftIO $ threadDelay $ 1000000 * t
+delay :: Double -> ActionM ()
+delay t = liftIO $ threadDelay $ floor $ 1000000 * t
 
 prepareTxList
    :: TxListName

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -27,8 +27,7 @@ printJSON = BSL.putStrLn $ prettyPrint testScript
 
 txConfig :: [Action]
 txConfig = map Set [
-    TInitCooldown         ==> InitCooldown 10
-  , TNumberOfInputsPerTx  ==> NumberOfInputsPerTx 1
+    TNumberOfInputsPerTx  ==> NumberOfInputsPerTx 1
   , TNumberOfOutputsPerTx ==> NumberOfOutputsPerTx 1
   , TNumberOfTxs          ==> NumberOfTxs 500
   , TTPSRate              ==> TPSRate 10
@@ -47,9 +46,9 @@ testScript =
   , Set $ TLocalSocket ==> "logs/sockets/1"
   , ReadSigningKey passPartout "configuration/genesis-shelley/utxo-keys/utxo1.skey"
   , SecureGenesisFund genFund passPartout passPartout
-  , Delay
+  , Delay 10
   , SplitFund outputFunds passPartout genFund
-  , Delay
+  , Delay 10
   , SplitFundToList fundList passPartout f1
   , PrepareTxList txList passPartout fundList
   , Set $ TTargets ==> makeTargets [ 3000, 3001, 3002]

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Example.hs
@@ -30,7 +30,6 @@ txConfig = map Set [
     TNumberOfInputsPerTx  ==> NumberOfInputsPerTx 1
   , TNumberOfOutputsPerTx ==> NumberOfOutputsPerTx 1
   , TNumberOfTxs          ==> NumberOfTxs 500
-  , TTPSRate              ==> TPSRate 10
   , TTxAdditionalSize     ==> TxAdditionalSize 0
   , TFee                  ==> quantityToLovelace (Quantity 0)
   , TTTL                  ==> SlotNo 1000000
@@ -52,7 +51,7 @@ testScript =
   , SplitFundToList fundList passPartout f1
   , PrepareTxList txList passPartout fundList
   , Set $ TTargets ==> makeTargets [ 3000, 3001, 3002]
-  , AsyncBenchmark threadName txList
+  , AsyncBenchmark threadName txList (TPSRate 10)
   , WaitForEra $ AnyCardanoEra ByronEra
   , CancelBenchmark threadName
   , Reserved []

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -25,7 +25,6 @@ import           Cardano.Benchmarking.Types
 
 -- Some boiler plate; ToDo may generate this.
 data Tag v where
-  TInitCooldown         :: Tag InitCooldown
   TNumberOfInputsPerTx  :: Tag NumberOfInputsPerTx
   TNumberOfOutputsPerTx :: Tag NumberOfOutputsPerTx
   TNumberOfTxs          :: Tag NumberOfTxs
@@ -46,7 +45,6 @@ deriving instance Show (Tag v)
 deriving instance Eq (Tag v)
 
 data Sum where
-  SInitCooldown         :: !InitCooldown         -> Sum
   SNumberOfInputsPerTx  :: !NumberOfInputsPerTx  -> Sum
   SNumberOfOutputsPerTx :: !NumberOfOutputsPerTx -> Sum
   SNumberOfTxs          :: !NumberOfTxs          -> Sum
@@ -61,7 +59,6 @@ data Sum where
 
 taggedToSum :: Applicative f => DSum Tag f -> f Sum
 taggedToSum x = case x of
-  (TInitCooldown         :=> v) -> SInitCooldown         <$> v
   (TNumberOfInputsPerTx  :=> v) -> SNumberOfInputsPerTx  <$> v
   (TNumberOfOutputsPerTx :=> v) -> SNumberOfOutputsPerTx <$> v
   (TNumberOfTxs          :=> v) -> SNumberOfTxs          <$> v
@@ -75,7 +72,6 @@ taggedToSum x = case x of
 
 sumToTaggged :: Applicative f => Sum -> DSum Tag f
 sumToTaggged x = case x of
-  SInitCooldown         v -> TInitCooldown         ==> v
   SNumberOfInputsPerTx  v -> TNumberOfInputsPerTx  ==> v
   SNumberOfOutputsPerTx v -> TNumberOfOutputsPerTx ==> v
   SNumberOfTxs          v -> TNumberOfTxs          ==> v

--- a/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
+++ b/cardano-tx-generator/src/Cardano/Benchmarking/Script/Setters.hs
@@ -28,7 +28,6 @@ data Tag v where
   TNumberOfInputsPerTx  :: Tag NumberOfInputsPerTx
   TNumberOfOutputsPerTx :: Tag NumberOfOutputsPerTx
   TNumberOfTxs          :: Tag NumberOfTxs
-  TTPSRate              :: Tag TPSRate
   TFee                  :: Tag Lovelace
   TTTL                  :: Tag SlotNo
   TTxAdditionalSize     :: Tag TxAdditionalSize
@@ -48,7 +47,6 @@ data Sum where
   SNumberOfInputsPerTx  :: !NumberOfInputsPerTx  -> Sum
   SNumberOfOutputsPerTx :: !NumberOfOutputsPerTx -> Sum
   SNumberOfTxs          :: !NumberOfTxs          -> Sum
-  STPSRate              :: !TPSRate              -> Sum
   SFee                  :: !Lovelace             -> Sum
   STTL                  :: !SlotNo               -> Sum
   STxAdditionalSize     :: !TxAdditionalSize     -> Sum
@@ -62,7 +60,6 @@ taggedToSum x = case x of
   (TNumberOfInputsPerTx  :=> v) -> SNumberOfInputsPerTx  <$> v
   (TNumberOfOutputsPerTx :=> v) -> SNumberOfOutputsPerTx <$> v
   (TNumberOfTxs          :=> v) -> SNumberOfTxs          <$> v
-  (TTPSRate              :=> v) -> STPSRate              <$> v
   (TFee                  :=> v) -> SFee                  <$> v
   (TTTL                  :=> v) -> STTL                  <$> v
   (TTxAdditionalSize     :=> v) -> STxAdditionalSize     <$> v
@@ -75,7 +72,6 @@ sumToTaggged x = case x of
   SNumberOfInputsPerTx  v -> TNumberOfInputsPerTx  ==> v
   SNumberOfOutputsPerTx v -> TNumberOfOutputsPerTx ==> v
   SNumberOfTxs          v -> TNumberOfTxs          ==> v
-  STPSRate              v -> TTPSRate              ==> v
   SFee                  v -> TFee                  ==> v
   STTL                  v -> TTTL                  ==> v
   STxAdditionalSize     v -> TTxAdditionalSize     ==> v

--- a/cardano-tx-generator/test/script.json
+++ b/cardano-tx-generator/test/script.json
@@ -1,8 +1,5 @@
 [
     {
-        "setInitCooldown": 10
-    },
-    {
         "setNumberOfInputsPerTx": 1
     },
     {
@@ -42,7 +39,7 @@
         "fundKey": "pass-partout"
     },
     {
-        "delay": null
+        "delay": 10
     },
     {
         "splitFund": [
@@ -55,7 +52,7 @@
         "newKey": "pass-partout"
     },
     {
-        "delay": null
+        "delay": 10
     },
     {
         "splitFundToList": "fundList",
@@ -93,4 +90,7 @@
     {
         "cancelBenchmark": "thread1"
     },
+    {
+        "reserved": []
+    }
 ]

--- a/cardano-tx-generator/test/script.json
+++ b/cardano-tx-generator/test/script.json
@@ -9,9 +9,6 @@
         "setNumberOfTxs": 500
     },
     {
-        "setTPSRate": 10
-    },
-    {
         "setTxAdditionalSize": 0
     },
     {
@@ -82,7 +79,8 @@
     },
     {
         "asyncBenchmark": "thread1",
-        "txList": "txlist"
+        "txList": "txlist",
+        "tps": 10
     },
     {
         "waitForEra": "Byron"


### PR DESCRIPTION
* Remove `InitCoolDown` global config. Instead pass timeout explicitly in `delay` command.
* Remove `runBenchmark` (in favor of `asyncBenchmark).
* Remove global config `TPSRate`.